### PR TITLE
Update usage to show the accurate command

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -40,7 +40,7 @@ void main(List<String> args) {
 
   if (options['help'] as bool || options.rest.isEmpty) {
     print("Compile Sass to CSS.\n");
-    print("Usage: sass <input>\n");
+    print("Usage: dart-sass <input>\n");
     print(argParser.usage);
     exit(64);
   }


### PR DESCRIPTION
When installing Dart Sass with `npm i dart-sass -g`, the executable is `dart-sass`. Unless I'm missing something?