### PR TITLE
Don't duplicate line/column info in error output.

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -51,7 +51,27 @@ main(List<String> args) async {
     var css = render(options.rest.first, color: color);
     if (css.isNotEmpty) print(css);
   } on SassException catch (error, stackTrace) {
-    stderr.writeln(error.toString(color: color));
+    stderr.writeln("Error: ${error.message}");
+    stderr.writeln(error.span.highlight(color: color));
+
+    var start = error.span.start;
+    if (error is SassRuntimeException) {
+      var firstFrame = error.trace.frames.first;
+      if (start.sourceUrl != firstFrame.uri ||
+          start.line + 1 != firstFrame.line ||
+          start.column + 1 != firstFrame.column) {
+        stderr.writeln(
+            "  ${start.sourceUrl} ${start.line + 1}:${start.column + 1}");
+      }
+
+      for (var frame in error.trace.toString().split("\n")) {
+        if (frame.isEmpty) continue;
+        stderr.writeln("  $frame");
+      }
+    } else {
+      stderr.writeln(
+          "  ${start.sourceUrl} ${start.line + 1}:${start.column + 1}");
+    }
 
     if (options['trace'] as bool) {
       stderr.writeln();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   charcode: "^1.1.0"
   collection: "^1.1.0"
   path: "^1.0.0"
-  source_span: "^1.0.0"
+  source_span: "^1.3.0"
   string_scanner: ">=0.1.5 <2.0.0"
   stack_trace: ">=0.9.0 <2.0.0"
   tuple: "^1.0.0"


### PR DESCRIPTION
All span information is now presented as a stack frame, and elided if
it's redundant with the existing stack.