### PR TITLE
Fix an expression-parsing bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-alpha.4
+
+* Fix a bug where `1 + - 2` and similar constructs would crash the parser.
+
 ## 1.0.0-alpha.3
 
 * Fix a bug where color equality didn't take the alpha channel into account.

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -966,7 +966,7 @@ abstract class StylesheetParser extends Parser {
     /// slash-separated numbers.
     var allowSlash = lookingAtNumber();
 
-    /// The leftmost expression that's been fully-parsed.
+    /// The leftmost expression that's been fully-parsed. Never `null`.
     var singleExpression = _singleExpression();
 
     // Resets the scanner state to the state it was at at the beginning of the
@@ -982,7 +982,6 @@ abstract class StylesheetParser extends Parser {
     }
 
     resolveOneOperation() {
-      assert(singleExpression != null);
       var operator = operators.removeLast();
       if (operator != BinaryOperator.dividedBy) allowSlash = false;
       if (allowSlash && !_inParentheses) {
@@ -1037,13 +1036,16 @@ abstract class StylesheetParser extends Parser {
 
       assert(singleExpression != null);
       operands.add(singleExpression);
-      singleExpression = null;
+      whitespace();
+      allowSlash = allowSlash && lookingAtNumber();
+      singleExpression = _singleExpression();
+      allowSlash = allowSlash && singleExpression is NumberExpression;
     }
 
     resolveSpaceExpressions() {
-      if (singleExpression != null) resolveOperations();
+      resolveOperations();
       if (spaceExpressions == null) return;
-      if (singleExpression != null) spaceExpressions.add(singleExpression);
+      spaceExpressions.add(singleExpression);
       singleExpression =
           new ListExpression(spaceExpressions, ListSeparator.space);
       spaceExpressions = null;

--- a/lib/src/visitor/perform.dart
+++ b/lib/src/visitor/perform.dart
@@ -841,10 +841,14 @@ class _PerformVisitor
           return left.times(right);
         case BinaryOperator.dividedBy:
           var result = left.dividedBy(right);
-          if (!node.allowsSlash) return result;
-          var leftSlash = (left as SassNumber).asSlash ?? left.toCssString();
-          var rightSlash = (right as SassNumber).asSlash ?? right.toCssString();
-          return (result as SassNumber).withSlash("$leftSlash/$rightSlash");
+          if (node.allowsSlash && left is SassNumber && right is SassNumber) {
+            var leftSlash = left.asSlash ?? left.toCssString();
+            var rightSlash = right.asSlash ?? right.toCssString();
+            return (result as SassNumber).withSlash("$leftSlash/$rightSlash");
+          } else {
+            return result;
+          }
+          break;
         case BinaryOperator.modulo:
           return left.modulo(right);
         default:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.0.0-alpha.3
+version: 1.0.0-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
A binary operator followed by a unary operator (for example, `1 + - 2`)
would crash the parser.

See sass/sass-spec#967