### PR TITLE
Fix handling of **/.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 * Fix a bug with `@extend` superselector calculations.
 
+* Fix a bug where `**/` would fail to close a loud comment.
+
 ## 1.0.0-alpha.4
 
 * Add support for bracketed lists.

--- a/lib/src/parse/scss.dart
+++ b/lib/src/parse/scss.dart
@@ -147,7 +147,7 @@ class ScssParser extends StylesheetParser {
     scanner.expect("/*");
     do {
       while (scanner.readChar() != $asterisk) {}
-    } while (scanner.readChar() != $slash);
+    } while (!scanner.scanChar($slash));
 
     return new Comment(
         scanner.substring(start.position), scanner.spanFrom(start),


### PR DESCRIPTION
We had been failing to close comments because we'd consume the second
asterisk and fail to register that it might be the one to end the
comment.

See sass/sass-spec#986
Closes #58