### PR TITLE
Preserve escapes in non-script identifiers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 * Don't crash when passing only `$hue` or no keyword arguments to
   `adjust-color()`, `scale-color()`, or `change-color()`.
 
+* Preserve escapes in identifiers. This used to only work for identifiers in
+  SassScript.
+
 ## 1.0.0-alpha.5
 
 * Fix bounds-checking for `opacify()`, `fade-in()`, `transparentize()`, and

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -1797,7 +1797,7 @@ abstract class StylesheetParser extends Parser {
           scanner.readChar();
           scanner.readChar();
         } else {
-          buffer.writeCharCode(escape());
+          buffer.writeCharCode(escapeCharacter());
         }
       } else if (next == $hash) {
         if (scanner.peekChar(1) == $lbrace) {
@@ -1934,7 +1934,7 @@ abstract class StylesheetParser extends Parser {
           next >= 0x0080) {
         buffer.writeCharCode(scanner.readChar());
       } else if (next == $backslash) {
-        buffer.writeCharCode(escape());
+        buffer.write(escape());
       } else if (next == $hash) {
         if (scanner.peekChar(1) == $lbrace) {
           buffer.add(singleInterpolation());
@@ -2084,7 +2084,7 @@ abstract class StylesheetParser extends Parser {
       var next = scanner.peekChar();
       switch (next) {
         case $backslash:
-          buffer.writeCharCode(escape());
+          buffer.write(escape());
           wroteNewline = false;
           break;
 
@@ -2203,7 +2203,7 @@ abstract class StylesheetParser extends Parser {
     } else if (isNameStart(first)) {
       buffer.writeCharCode(scanner.readChar());
     } else if (first == $backslash) {
-      _scanEscapeText(buffer);
+      buffer.write(escape());
     } else if (first == $hash && scanner.peekChar(1) == $lbrace) {
       buffer.add(singleInterpolation());
     }
@@ -2218,7 +2218,7 @@ abstract class StylesheetParser extends Parser {
           next >= 0x0080) {
         buffer.writeCharCode(scanner.readChar());
       } else if (next == $backslash) {
-        _scanEscapeText(buffer);
+        buffer.write(escape());
       } else if (next == $hash && scanner.peekChar(1) == $lbrace) {
         buffer.add(singleInterpolation());
       } else {
@@ -2227,31 +2227,6 @@ abstract class StylesheetParser extends Parser {
     }
 
     return buffer.interpolation(scanner.spanFrom(start));
-  }
-
-  /// Consumes an escape sequence and writes the characters that compose it to
-  /// [buffer].
-  void _scanEscapeText(StringSink buffer) {
-    scanner.expectChar($backslash);
-    buffer.writeCharCode($backslash);
-
-    var first = scanner.peekChar();
-    if (first == null) {
-      return;
-    } else if (isNewline(first)) {
-      scanner.error("Expected escape sequence.");
-    } else if (isHex(first)) {
-      for (var i = 0; i < 6; i++) {
-        var next = scanner.peekChar();
-        if (next == null || !isHex(next)) break;
-        buffer.writeCharCode(scanner.readChar());
-      }
-      if (isWhitespace(scanner.peekChar())) {
-        buffer.writeCharCode(scanner.readChar());
-      }
-    } else {
-      buffer.writeCharCode(scanner.readChar());
-    }
   }
 
   /// Consumes interpolation.


### PR DESCRIPTION
See sass/sass-spec#1015