### PR TITLE
Properly parse URLs containing "//" and "/*".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.0.0-alpha.7
 
+* Properly parse `url()`s that contain comment-like text.
+
 * Fix a few more small `@extend` bugs.
 
 ## 1.0.0-alpha.6

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -1919,7 +1919,7 @@ abstract class StylesheetParser extends Parser {
 
     var start = scanner.state;
     if (!scanner.scanChar($lparen)) return null;
-    whitespace();
+    whitespaceWithoutComments();
 
     // Match Ruby Sass's behavior: parse a raw URL() if possible, and if not
     // backtrack and re-parse as a function expression.
@@ -1942,7 +1942,7 @@ abstract class StylesheetParser extends Parser {
           buffer.writeCharCode(scanner.readChar());
         }
       } else if (isWhitespace(next)) {
-        whitespace();
+        whitespaceWithoutComments();
         if (scanner.peekChar() != $rparen) break;
       } else if (next == $rparen) {
         buffer.writeCharCode(scanner.readChar());


### PR DESCRIPTION
See sass/sass-spec#1034