### PR TITLE
Fix *-exists().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.0.0-alpha.7
 
+* Fix `function-exists()`, `variable-exists()`, and `mixin-exists()` to use the
+  lexical scope rather than always using the global scope.
+
 * `str-index()` now correctly inserts at negative indices.
 
 * Properly parse `url()`s that contain comment-like text.

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -870,24 +870,9 @@ void defineCoreFunctions(Environment environment) {
     return new SassBoolean(_features.contains(feature.text));
   });
 
-  environment.defineFunction("variable-exists", r"$name", (arguments) {
-    var variable = arguments[0].assertString("name");
-    return new SassBoolean(environment.variableExists(variable.text));
-  });
-
   environment.defineFunction("global-variable-exists", r"$name", (arguments) {
     var variable = arguments[0].assertString("name");
     return new SassBoolean(environment.globalVariableExists(variable.text));
-  });
-
-  environment.defineFunction("function-exists", r"$name", (arguments) {
-    var variable = arguments[0].assertString("name");
-    return new SassBoolean(environment.functionExists(variable.text));
-  });
-
-  environment.defineFunction("mixin-exists", r"$name", (arguments) {
-    var variable = arguments[0].assertString("name");
-    return new SassBoolean(environment.mixinExists(variable.text));
   });
 
   environment.defineFunction("inspect", r"$value",

--- a/lib/src/visitor/perform.dart
+++ b/lib/src/visitor/perform.dart
@@ -128,6 +128,21 @@ class _PerformVisitor
       : _loadPaths = loadPaths == null ? const [] : new List.from(loadPaths),
         _environment = environment ?? new Environment(),
         _color = color {
+    _environment.defineFunction("variable-exists", r"$name", (arguments) {
+      var variable = arguments[0].assertString("name");
+      return new SassBoolean(_environment.variableExists(variable.text));
+    });
+
+    _environment.defineFunction("function-exists", r"$name", (arguments) {
+      var variable = arguments[0].assertString("name");
+      return new SassBoolean(_environment.functionExists(variable.text));
+    });
+
+    _environment.defineFunction("mixin-exists", r"$name", (arguments) {
+      var variable = arguments[0].assertString("name");
+      return new SassBoolean(_environment.mixinExists(variable.text));
+    });
+
     _environment.defineFunction("call", r"$function, $args...", (arguments) {
       var function = arguments[0];
       var args = arguments[1] as SassArgumentList;


### PR DESCRIPTION
These were always using the global scope rather than the lexical scope.
They've been moved into the perform visitor so that they have access to
the lexical environment instead.

See sass/sass-spec#1037