### PR TITLE
Disallow all top-level declarations and extend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 * Fix a crash when inspecting a string expression that ended in "\a".
 
+* Fix a bug where declarations and `@extend` were allowed outside of a style
+  rule in certain circumstances.
+
 * Fix `not` in parentheses in `@supports` conditions.
 
 * Allow `url` as an identifier name.


### PR DESCRIPTION
We were previously allowing declarations and extend in control
directives at the top level of documents, as long as those documents
were only ever imported in a nested context.

See sass/sass-spec#1111