### PR TITLE
Fix ArgumentDeclaration.toString() when no args except rest

### DIFF
--- a/lib/src/ast/sass/argument_declaration.dart
+++ b/lib/src/ast/sass/argument_declaration.dart
@@ -38,11 +38,8 @@ class ArgumentDeclaration implements SassNode {
       new ScssParser("($contents)", url: url).parseArgumentDeclaration();
 
   String toString() {
-    var components =
-        new List<String>.from(arguments.map((arg) => arg.toString()));
-    if (restArgument != null) {
-      components.add('$restArgument...');
-    }
+    var components = new List.from(arguments.map((arg) => arg.toString()));
+    if (restArgument != null) components.add('$restArgument...');
     return components.join(', ');
   }
 }

--- a/lib/src/ast/sass/argument_declaration.dart
+++ b/lib/src/ast/sass/argument_declaration.dart
@@ -37,6 +37,12 @@ class ArgumentDeclaration implements SassNode {
   factory ArgumentDeclaration.parse(String contents, {url}) =>
       new ScssParser("($contents)", url: url).parseArgumentDeclaration();
 
-  String toString() =>
-      arguments.join(', ') + (restArgument == null ? '' : ", $restArgument...");
+  String toString() {
+    var components =
+        new List<String>.from(arguments.map((arg) => arg.toString()));
+    if (restArgument != null) {
+      components.add('$restArgument...');
+    }
+    return components.join(', ');
+  }
 }


### PR DESCRIPTION
`ArgumentDeclaration.toString()` unconditionally puts a comma before the rest argument, even if it is the only argument. For example, with the input:

```scss
@mixin box-shadow1($shadows...) {
  -webkit-box-shadow: $shadows;
  box-shadow: $shadows;
}

@mixin box-shadow2($arg1, $shadows...) {
  color: $arg1;
  -webkit-box-shadow: $shadows;
  box-shadow: $shadows;
}

@mixin box-shadow2($arg1, $arg2) {
  color: $arg1;
  -webkit-box-shadow: $arg2;
  box-shadow: $arg2;
}
```

Given this simple visitor and `main`:

```dart
import 'dart:io';

import 'lib/src/ast/sass.dart';
import 'lib/src/value.dart';
import 'lib/src/visitor/interface/statement.dart';

void main(List<String> args) {
  var file = args.first;
  var contents = new File(file).readAsStringSync();
  var sassTree = new Stylesheet.parseScss(contents);
  sassTree.accept(new LittleVisitor());
}

class LittleVisitor implements StatementVisitor<Value> {
  LittleVisitor() {}

  void visitStylesheet(Stylesheet node) {
    for (var child in node.children) {
      child.accept(this);
    }
  }

  void visitIncludeRule(IncludeRule node) {
    stdout.write('  @include ${node.name}');
    stdout.write(node.arguments);
    stdout.write(';\n');
  }

  void visitMixinRule(MixinRule node) {
    stdout.write('@mixin ${node.name}(');
    stdout.write(node.arguments);
    stdout.write(') {\n  ...\n}\n');
  }

  void visitStyleRule(StyleRule node) {
    stdout.write(node.selector);
    stdout.write('{\n');
    for (var child in node.children) {
      child.accept(this);
    }
    stdout.write('}\n');
  }
}
```

We output the following:

```
$ dart argument_declaration.dart f.scss
@mixin box-shadow1(, shadows...) {
  ...
}
@mixin box-shadow2(arg1, shadows...) {
  ...
}
@mixin box-shadow2(arg1, arg2) {
  ...
}
```

This PR fixes the output to look like:

```
$ dart argument_declaration.dart f.scss
@mixin box-shadow1(shadows...) {
  ...
}
@mixin box-shadow2(arg1, shadows...) {
  ...
}
@mixin box-shadow2(arg1, arg2) {
  ...
}
```

(the variables do not include `$`, but that's another issue, if it's an issue at all.)