### PR TITLE
Parse declaration children before building its span

### DIFF
--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -178,10 +178,10 @@ abstract class StylesheetParser extends Parser {
   ///   parsing it as a declaration value. If this fails, backtrack and parse
   ///   it as a selector.
   ///
-  /// * If the declaration value value valid but is followed by "{", backtrack
-  ///   and parse it as a selector anyway. This ensures that ".foo:bar {" is
-  ///   always parsed as a selector and never as a property with nested
-  ///   properties beneath it.
+  /// * If the declaration value is valid but is followed by "{", backtrack and
+  ///   parse it as a selector anyway. This ensures that ".foo:bar {" is always
+  ///   parsed as a selector and never as a property with nested properties
+  ///   beneath it.
   Statement _declarationOrStyleRule() {
     var start = scanner.state;
     var declarationOrBuffer = _declarationOrBuffer();
@@ -262,8 +262,8 @@ abstract class StylesheetParser extends Parser {
 
     var postColonWhitespace = rawText(whitespace);
     if (lookingAtChildren()) {
-      return new Declaration(name, scanner.spanFrom(start),
-          children: this.children(_declarationChild));
+      var children = this.children(_declarationChild);
+      return new Declaration(name, scanner.spanFrom(start), children: children);
     }
 
     midBuffer.write(postColonWhitespace);


### PR DESCRIPTION
Declarations with children have an incorrect source span. Take the following SCSS and simple visitor:

```scss
a {
  padding: {
    left: 2px;
    top: 2px;
  }
  width: 2px;

  pre {
    color: red;
  }
}
```

```dart
import 'dart:io';

import 'lib/src/ast/sass.dart';
import 'lib/src/value.dart';
import 'lib/src/visitor/interface/statement.dart';

void main(List<String> args) {
  var file = args.first;
  var contents = new File(file).readAsStringSync();
  var sassTree = new Stylesheet.parseScss(contents);
  sassTree.accept(new LittleVisitor());
}

class LittleVisitor implements StatementVisitor<Value> {
  LittleVisitor() {}

  // ## Statements

  void visitStylesheet(Stylesheet node) {
    for (var child in node.children) {
      child.accept(this);
    }
  }

  void visitStyleRule(StyleRule node) {
    stdout.write(node.selector);
    stdout.write('{\n');
    for (var child in node.children) {
      child.accept(this);
    }
    stdout.write('}\n');
  }

  void visitDeclaration(Declaration node) {
    stdout.write(node.span.text);
  }
}
```

This prints:

```
// BEFORE THIS PATCH
a {
padding: width: 2pxpre {
color: red}
}

// AFTER THIS PATCH
a {
padding: {
    left: 2px;
    top: 2px;
  }
  width: 2pxpre {
color: red}
}
```
