### PR TITLE
Run specs against Dart's dev channel by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,19 @@
 language: ruby
 env:
 # Language specs, defined in sass/sass-spec
-- TASK=specs   DART_VERSION=latest
-- TASK=specs   DART_VERSION=1.24.2
+- TASK=specs   DART_CHANNEL=dev    DART_VERSION=latest
+- TASK=specs   DART_CHANNEL=stable DART_VERSION=latest
 
 # Unit tests, defined in test/.
-- TASK=tests   DART_VERSION=latest
-- TASK=tests   DART_VERSION=1.24.2
-- TASK=tests   DART_VERSION=latest NODE_VERSION=stable
-- TASK=tests   DART_VERSION=latest NODE_VERSION=v6.9.1
-- TASK=tests   DART_VERSION=latest NODE_VERSION=v4.6.2
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest
+- TASK=tests   DART_CHANNEL=stable DART_VERSION=latest
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest NODE_VERSION=stable
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest NODE_VERSION=v6.9.1
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest NODE_VERSION=v4.6.2
 
 # Miscellaneous checks.
-- TASK=analyze DART_VERSION=latest
-- TASK=format  DART_VERSION=latest
+- TASK=analyze DART_CHANNEL=dev    DART_VERSION=latest
+- TASK=format  DART_CHANNEL=dev    DART_VERSION=latest
 
 rvm:
 - 2.3.1
@@ -32,7 +32,7 @@ install:
 - none=$(tput sgr0)
 
 # Install the Dart SDK.
-- curl -o dart.zip "https://storage.googleapis.com/dart-archive/channels/stable/release/$DART_VERSION/sdk/dartsdk-linux-x64-release.zip"
+- curl -o dart.zip "https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/release/$DART_VERSION/sdk/dartsdk-linux-x64-release.zip"
 - unzip dart.zip
 - export PATH="$PATH:`pwd`/dart-sdk/bin"
 - pub get


### PR DESCRIPTION
All new Dart releases for the near future will be in the 2.0.0 dev
branch, so we should test against that.