### PR TITLE
Make function in package script more portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * Fix a bug where dividing by a compatible unit would produce an invalid
   result.
 
+* Remove a non-`sh`-compatible idiom from the standalone shell script.
+
 ### Dart API
 
 * Add a `functions` parameter to `compile()`, `compleString()`,

--- a/package/dart-sass.sh
+++ b/package/dart-sass.sh
@@ -7,7 +7,7 @@
 # executable and a snapshot of Sass. It can be created with `pub run grinder
 # package`.
 
-function follow_links() {
+follow_links() {
   file="$1"
   while [ -h "$file" ]; do
     # On Mac OS, readlink -f doesn't work.


### PR DESCRIPTION
The script in the standalone package currently fails on OSes like Ubuntu where /bin/sh does not support functions declared with the function keyword.

This removes the function keyword from `follow_links`.