### PR TITLE
Fixes bug in visitColor for compressed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.6
+
+* Fix a bug where some colors would crash `compressed` mode.
+
 ## 1.0.0-beta.5
 
 * Add a `compressed` output style.

--- a/lib/src/visitor/serialize.dart
+++ b/lib/src/visitor/serialize.dart
@@ -440,7 +440,7 @@ class _SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisitor {
     if (_isCompressed && fuzzyEquals(value.alpha, 1)) {
       var name = namesByColor[value];
       var hexLength = _canUseShortHex(value) ? 4 : 7;
-      if (name.length <= hexLength) {
+      if (name != null && name.length <= hexLength) {
         _buffer.write(name);
       } else if (_canUseShortHex(value)) {
         _buffer.writeCharCode($hash);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.0.0-beta.5.1
+version: 1.0.0-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/test/compressed_test.dart
+++ b/test/compressed_test.dart
@@ -120,6 +120,10 @@ void main() {
         expect(_compile("a {b: rgba(255, 0, 0, 0.5)}"),
             equals("a{b:rgba(255,0,0,.5)}"));
       });
+
+      test("don't error when there's no name", () {
+        expect(_compile("a {b: #cc3232}"), equals("a{b:#cc3232}"));
+      });
     });
   });
 


### PR DESCRIPTION
If `value` is not a named color, `name.length` will error.
This checks that `name` is not null before checking the length.