### PR TITLE
Preserve whitespace after `and` in media queries in compressed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * Preserve empty lines in `/*` comments in the indented syntax.
 
+* Preserve whitespace after `and` in media queries in compressed mode.
+
 ## 1.0.0-beta.5.2
 
 * Fix a bug where some colors would crash `compressed` mode.

--- a/lib/src/visitor/serialize.dart
+++ b/lib/src/visitor/serialize.dart
@@ -248,13 +248,12 @@ class _SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisitor {
     if (query.type != null) {
       _buffer.write(query.type);
       if (query.features.isNotEmpty) {
-        _buffer.write(" and");
-        _writeOptionalSpace();
+        _buffer.write(" and ");
       }
     }
 
     _writeBetween(
-        query.features, _isCompressed ? "and" : " and ", _buffer.write);
+        query.features, _isCompressed ? "and " : " and ", _buffer.write);
   }
 
   void visitStyleRule(CssStyleRule node) {

--- a/test/compressed_test.dart
+++ b/test/compressed_test.dart
@@ -165,14 +165,16 @@ void main() {
           equals("@media screen{a{b:c}}"));
     });
 
-    test('removes whitespace around "and"', () {
+    // Removing whitespace after "and", "or", or "not" is forbidden because it
+    // would cause it to parse as a function token.
+    test('removes whitespace before "and" when possible', () {
       expect(
           _compile("""
         @media screen and (min-width: 900px) and (max-width: 100px) {
           a {b: c}
         }
       """),
-          equals("@media screen and(min-width: 900px)and(max-width: 100px)"
+          equals("@media screen and (min-width: 900px)and (max-width: 100px)"
               "{a{b:c}}"));
     });
 


### PR DESCRIPTION
Closes #239