### PR TITLE
Represent DynamicImport.url as a String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 * Add support for importing an `_index.scss` or `_index.sass` file when
   importing a directory.
 
+### Node JS API
+
+* Import URLs passed to importers are no longer normalized. For example, if a
+  stylesheet contains `@import "./foo.scss"`, importers will now receive
+  `"./foo.scss"` rather than `"foo.scss"`.
+
 ## 1.0.0-beta.5.3
 
 * Support hard tabs in the indented syntax.

--- a/lib/src/ast/sass/import/dynamic.dart
+++ b/lib/src/ast/sass/import/dynamic.dart
@@ -9,14 +9,16 @@ import '../import.dart';
 
 /// An import that will load a Sass file at runtime.
 class DynamicImport implements Import {
+  // TODO(nweiz): Make this a [Url] when dart-lang/sdk#32490 is fixed, or when
+  // Node Sass imports no longer expose a leading `./`.
   /// The URI of the file to import.
   ///
   /// If this is relative, it's relative to the containing file.
-  final Uri url;
+  final String url;
 
   final FileSpan span;
 
   DynamicImport(this.url, this.span);
 
-  String toString() => StringExpression.quoteText(url.toString());
+  String toString() => StringExpression.quoteText(url);
 }

--- a/lib/src/importer/node/interface.dart
+++ b/lib/src/importer/node/interface.dart
@@ -12,7 +12,7 @@ class NodeImporter {
   NodeImporter(Object context, Iterable<String> includePaths,
       Iterable<_Importer> importers);
 
-  Tuple2<String, Uri> load(Uri url, Uri previous) => null;
+  Tuple2<String, String> load(String url, Uri previous) => null;
 
-  Future<Tuple2<String, Uri>> loadAsync(Uri url, Uri previous) => null;
+  Future<Tuple2<String, String>> loadAsync(String url, Uri previous) => null;
 }

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -762,12 +762,14 @@ abstract class StylesheetParser extends Parser {
 
   /// Parses [url] as an import URL.
   @protected
-  Uri parseImportUrl(String url) {
+  String parseImportUrl(String url) {
     // Backwards-compatibility for implementations that allow absolute Windows
     // paths in imports.
-    if (p.windows.isAbsolute(url)) return p.windows.toUri(url);
+    if (p.windows.isAbsolute(url)) return p.windows.toUri(url).toString();
 
-    return Uri.parse(url);
+    // Throw a [FormatException] if [url] is invalid.
+    Uri.parse(url);
+    return url;
   }
 
   /// Returns whether [url] indicates that an `@import` is a plain CSS import.

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -696,21 +696,23 @@ class _EvaluateVisitor
         var stylesheet = await _importLikeNode(import);
         if (stylesheet != null) return new Tuple2(null, stylesheet);
       } else {
+        var url = Uri.parse(import.url);
+
         // Try to resolve [import.url] relative to the current URL with the
         // current importer.
-        if (import.url.scheme.isEmpty && _importer != null) {
+        if (url.scheme.isEmpty && _importer != null) {
           var stylesheet =
-              await _tryImport(_importer, _baseUrl.resolveUri(import.url));
+              await _tryImport(_importer, _baseUrl.resolveUri(url));
           if (stylesheet != null) return new Tuple2(_importer, stylesheet);
         }
 
         for (var importer in _importers) {
-          var stylesheet = await _tryImport(importer, import.url);
+          var stylesheet = await _tryImport(importer, url);
           if (stylesheet != null) return new Tuple2(importer, stylesheet);
         }
       }
 
-      if (import.url.scheme == 'package') {
+      if (import.url.startsWith('package:')) {
         // Special-case this error message, since it's tripped people up in the
         // past.
         throw "\"package:\" URLs aren't supported on this platform.";
@@ -744,13 +746,13 @@ class _EvaluateVisitor
     var contents = result.item1;
     var url = result.item2;
 
-    if (url.scheme == 'file') {
+    if (url.startsWith('file:')) {
       _includedFiles.add(p.fromUri(url));
     } else {
-      _includedFiles.add(url.toString());
+      _includedFiles.add(url);
     }
 
-    return url.scheme == 'file' && pUrl.extension(url.path) == '.sass'
+    return url.startsWith('file') && pUrl.extension(url) == '.sass'
         ? new Stylesheet.parseSass(contents, url: url, color: _color)
         : new Stylesheet.parseScss(contents, url: url, color: _color);
   }

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 199b3bd52a5c5c147444ee45c2f3d46ef8af2d28
+// Checksum: 53f8eb4f4e6ed2cad3fe359490a50e12911a278a
 
 import 'dart:math' as math;
 
@@ -690,21 +690,22 @@ class _EvaluateVisitor
         var stylesheet = _importLikeNode(import);
         if (stylesheet != null) return new Tuple2(null, stylesheet);
       } else {
+        var url = Uri.parse(import.url);
+
         // Try to resolve [import.url] relative to the current URL with the
         // current importer.
-        if (import.url.scheme.isEmpty && _importer != null) {
-          var stylesheet =
-              _tryImport(_importer, _baseUrl.resolveUri(import.url));
+        if (url.scheme.isEmpty && _importer != null) {
+          var stylesheet = _tryImport(_importer, _baseUrl.resolveUri(url));
           if (stylesheet != null) return new Tuple2(_importer, stylesheet);
         }
 
         for (var importer in _importers) {
-          var stylesheet = _tryImport(importer, import.url);
+          var stylesheet = _tryImport(importer, url);
           if (stylesheet != null) return new Tuple2(importer, stylesheet);
         }
       }
 
-      if (import.url.scheme == 'package') {
+      if (import.url.startsWith('package:')) {
         // Special-case this error message, since it's tripped people up in the
         // past.
         throw "\"package:\" URLs aren't supported on this platform.";
@@ -738,13 +739,13 @@ class _EvaluateVisitor
     var contents = result.item1;
     var url = result.item2;
 
-    if (url.scheme == 'file') {
+    if (url.startsWith('file:')) {
       _includedFiles.add(p.fromUri(url));
     } else {
-      _includedFiles.add(url.toString());
+      _includedFiles.add(url);
     }
 
-    return url.scheme == 'file' && pUrl.extension(url.path) == '.sass'
+    return url.startsWith('file') && pUrl.extension(url) == '.sass'
         ? new Stylesheet.parseSass(contents, url: url, color: _color)
         : new Stylesheet.parseScss(contents, url: url, color: _color);
   }

--- a/test/node_api/importer_test.dart
+++ b/test/node_api/importer_test.dart
@@ -266,6 +266,16 @@ void main() {
           }))));
     });
 
+    // Regression test for #246.
+    test("doesn't remove ./", () {
+      renderSync(new RenderOptions(
+          data: "@import './foo'",
+          importer: allowInterop(expectAsync2((url, _) {
+            expect(url, equals('./foo'));
+            return new NodeImporterResult(contents: '');
+          }))));
+    });
+
     test("isn't resolved relative to the current file", () {
       renderSync(new RenderOptions(
           data: "@import 'foo/bar'",


### PR DESCRIPTION
This works around dart-lang/sdk#32490. We need to preserve the leading
"./" to match Node Sass's behavior.

Closes #246