### PR TITLE
Pin Dart to 2.0.0-dev.36.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,25 @@
 
 # Set the language to Ruby so that we can run sass-spec tests.
 language: ruby
+
+# Note: we're currently pinned to Dart 2.0.0-dev.36.0 because dart2js doesn't
+# support configuration-specific imports with the new front-end.
 env:
 # Language specs, defined in sass/sass-spec
-- TASK=specs   DART_CHANNEL=dev    DART_VERSION=latest
+- TASK=specs   DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0
 - TASK=specs   DART_CHANNEL=stable DART_VERSION=latest
 - TASK=specs   DART_CHANNEL=stable DART_VERSION=latest ASYNC=true
 
 # Unit tests, defined in test/.
-- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0
 - TASK=tests   DART_CHANNEL=stable DART_VERSION=latest
-- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest NODE_VERSION=stable
-- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest NODE_VERSION=v6.9.1
-- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest NODE_VERSION=v4.6.2
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0 NODE_VERSION=stable
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0 NODE_VERSION=v6.9.1
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0 NODE_VERSION=v4.6.2
 
 # Miscellaneous checks.
-- TASK=analyze DART_CHANNEL=dev    DART_VERSION=latest
-- TASK=format  DART_CHANNEL=dev    DART_VERSION=latest
+- TASK=analyze DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0
+- TASK=format  DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0
 
 rvm:
 - 2.3.1
@@ -92,7 +95,7 @@ jobs:
   include:
   - stage: deploy
     if: (type IN (push, api)) AND (repo = sass/dart-sass) AND tag =~ ^\d+\.\d+\.\d+([+-].*)?$
-    env: DART_CHANNEL=dev DART_VERSION=latest
+    env: DART_CHANNEL=dev DART_VERSION=2.0.0-dev.36.0
     script: skip # Don't run tests
 
     deploy:


### PR DESCRIPTION
2.0.0-dev.37.0 uses the new common front-end for dart2js, which
doesn't support configuration-specific imports and thus breaks Dart
Sass.