### PR TITLE
Use the latest Dart's mechanism for imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,20 @@ language: ruby
 # support configuration-specific imports with the new front-end.
 env:
 # Language specs, defined in sass/sass-spec
-- TASK=specs   DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0
-- TASK=specs   DART_CHANNEL=stable DART_VERSION=latest
-- TASK=specs   DART_CHANNEL=stable DART_VERSION=latest ASYNC=true
+- TASK=specs   DART_CHANNEL=dev    DART_VERSION=latest
+#- TASK=specs   DART_CHANNEL=stable DART_VERSION=latest
+#- TASK=specs   DART_CHANNEL=stable DART_VERSION=latest ASYNC=true
 
 # Unit tests, defined in test/.
-- TASK=tests   DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0
-- TASK=tests   DART_CHANNEL=stable DART_VERSION=latest
-- TASK=tests   DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0 NODE_VERSION=stable
-- TASK=tests   DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0 NODE_VERSION=v6.9.1
-- TASK=tests   DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0 NODE_VERSION=v4.6.2
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest
+#- TASK=tests   DART_CHANNEL=stable DART_VERSION=latest
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest NODE_VERSION=stable
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest NODE_VERSION=v6.9.1
+- TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest NODE_VERSION=v4.6.2
 
 # Miscellaneous checks.
-- TASK=analyze DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0
-- TASK=format  DART_CHANNEL=dev    DART_VERSION=2.0.0-dev.36.0
+- TASK=analyze DART_CHANNEL=dev    DART_VERSION=latest
+- TASK=format  DART_CHANNEL=dev    DART_VERSION=latest
 
 rvm:
 - 2.3.1
@@ -95,7 +95,7 @@ jobs:
   include:
   - stage: deploy
     if: (type IN (push, api)) AND (repo = sass/dart-sass) AND tag =~ ^\d+\.\d+\.\d+([+-].*)?$
-    env: DART_CHANNEL=dev DART_VERSION=2.0.0-dev.36.0
+    env: DART_CHANNEL=dev DART_VERSION=latest
     script: skip # Don't run tests
 
     deploy:

--- a/bin/sass.dart
+++ b/bin/sass.dart
@@ -3,4 +3,4 @@
 // https://opensource.org/licenses/MIT.
 
 export 'package:sass/src/executable.dart'
-    if (node) 'package:sass/src/node.dart';
+    if (dart.library.js) 'package:sass/src/node.dart';

--- a/lib/src/importer/node.dart
+++ b/lib/src/importer/node.dart
@@ -2,4 +2,4 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-export 'node/interface.dart' if (node) 'node/implementation.dart';
+export 'node/interface.dart' if (dart.library.js) 'node/implementation.dart';

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -4,4 +4,4 @@
 
 export 'io/interface.dart'
     if (dart.library.io) 'io/vm.dart'
-    if (node) 'io/node.dart';
+    if (dart.library.js) 'io/node.dart';

--- a/lib/src/sync_package_resolver.dart
+++ b/lib/src/sync_package_resolver.dart
@@ -1,2 +1,2 @@
 export 'package:package_resolver/package_resolver.dart'
-    if (node) 'sync_package_resolver/node.dart';
+    if (dart.library.js) 'sync_package_resolver/node.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ executables:
   dart-sass: sass
 
 environment:
-  sdk: '>=1.22.0 <2.0.0'
+  sdk: '>=2.0.0-dev.42.0 <2.0.0'
 
 dependencies:
   args: ">=0.13.0 <2.0.0"

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -102,6 +102,7 @@ void _js({@required bool release}) {
   var destination = new File('build/sass.dart.js');
 
   var args = [
+    '--categories=Server',
     '-Dnode=true',
     '-Dversion=$_version',
     '-Ddart-version=$_dartVersion',


### PR DESCRIPTION
This allows us to continue using configuration-specific imports to
target Node in particular without breaking sass/dart-sass#25.