### PR TITLE
Improve handling of invalid semicolons in the indented syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.4.0
 
+* Improve the error message for invalid semicolons in the indented syntax.
+
+* Properly disallow semicolons after declarations in the indented syntax.
+
 ### Command-Line Interface
 
 * Add support for compiling multiple files at once by writing

--- a/lib/src/parse/sass.dart
+++ b/lib/src/parse/sass.dart
@@ -54,15 +54,11 @@ class SassParser extends StylesheetParser {
   }
 
   void expectStatementSeparator([String name]) {
-    if (!atEndOfStatement()) scanner.expectChar($lf);
+    if (!atEndOfStatement()) _expectNewline();
     if (_peekIndentation() <= currentIndentation) return;
     scanner.error(
         "Nothing may be indented ${name == null ? 'here' : 'beneath a $name'}.",
         position: _nextIndentationEnd.position);
-  }
-
-  void expectSemicolon(String name) {
-    if (!atEndOfStatement()) scanner.expectChar($lf);
   }
 
   bool atEndOfStatement() {
@@ -292,6 +288,20 @@ class SassParser extends StylesheetParser {
 
     if (scanner.peekChar() == $slash && scanner.peekChar(1) == $slash) {
       silentComment();
+    }
+  }
+
+  /// Expect and consume a single newline character.
+  void _expectNewline() {
+    switch (scanner.peekChar()) {
+      case $semicolon:
+        scanner.error("semicolons aren't allowed in the indented syntax.");
+        return;
+      case $lf:
+        scanner.readChar();
+        return;
+      default:
+        scanner.error("expected newline.");
     }
   }
 

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -304,12 +304,12 @@ abstract class StylesheetParser extends Parser {
         // Properties that are ambiguous with selectors can't have additional
         // properties nested beneath them, so we force an error. This will be
         // caught below and cause the text to be reparsed as a selector.
-        if (couldBeSelector) scanner.expectChar($semicolon);
+        if (couldBeSelector) expectStatementSeparator();
       } else if (!atEndOfStatement()) {
         // Force an exception if there isn't a valid end-of-property character
         // but don't consume that character. This will also cause the text to be
         // reparsed.
-        scanner.expectChar($semicolon);
+        expectStatementSeparator();
       }
     } on FormatException catch (_) {
       if (!couldBeSelector) rethrow;


### PR DESCRIPTION
This improves the error message and fixes a bug where semicolons were
allowed after declarations.

See sass/sass-spec#1254