### PR TITLE
Node API: generate a source map even when outFile isn't set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   `sass templates/stylesheets:public/css` compiles all non-partial Sass files
   in `templates/stylesheets` to CSS files in `public/css`.
 
+### Node API
+
+* Generate source maps when the `sourceMaps` option is set to a string and the
+  `outFile` option is not set.
+
 ## 1.3.2
 
 * Add support for `@elseif` as an alias of `@else if`. This is not an

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -342,8 +342,10 @@ RenderResult _newRenderResult(
     var sourceMapDir = p.dirname(sourceMapPath);
 
     result.sourceMap.sourceRoot = options.sourceMapRoot;
-    result.sourceMap.targetUrl =
-        p.toUri(p.relative(options.outFile, from: sourceMapDir)).toString();
+    if (options.outFile != null) {
+      result.sourceMap.targetUrl =
+          p.toUri(p.relative(options.outFile, from: sourceMapDir)).toString();
+    }
 
     var sourceMapDirUrl = p.toUri(sourceMapDir).toString();
     for (var i = 0; i < result.sourceMap.urls.length; i++) {
@@ -359,8 +361,9 @@ RenderResult _newRenderResult(
     if (!isTruthy(options.omitSourceMapUrl)) {
       var url = options.sourceMapEmbed
           ? new Uri.dataFromBytes(sourceMapBytes, mimeType: "application/json")
-          : p.toUri(
-              p.relative(sourceMapPath, from: p.dirname(options.outFile)));
+          : p.toUri(options.outFile == null
+              ? sourceMapPath
+              : p.relative(sourceMapPath, from: p.dirname(options.outFile)));
       css += "\n\n/*# sourceMappingURL=$url */";
     }
   }
@@ -378,7 +381,8 @@ RenderResult _newRenderResult(
 
 /// Returns whether source maps are enabled by [options].
 bool _enableSourceMaps(RenderOptions options) =>
-    isTruthy(options.sourceMap) && options.outFile != null;
+    options.sourceMap is String ||
+    (isTruthy(options.sourceMap) && options.outFile != null);
 
 /// Creates a [JSError] with the given fields added to it so it acts like a Node
 /// Sass error.

--- a/test/node_api/source_map_test.dart
+++ b/test/node_api/source_map_test.dart
@@ -154,6 +154,14 @@ void main() {
     });
   });
 
+  test("emits a source map with a string sourceMap and no outFile", () {
+    var result = sass.renderSync(
+        new RenderOptions(data: "a {b: c}", sourceMap: "out.css.map"));
+    var map = _jsonUtf8.decode(result.map) as Map<String, Object>;
+    expect(map, containsPair("sources", ["stdin"]));
+    expect(map, isNot(contains("targetUrl")));
+  });
+
   test("with omitSourceMapUrl, doesn't include a source map comment", () {
     var result = sass.renderSync(new RenderOptions(
         data: "a {b: c}",


### PR DESCRIPTION
Contrary to documentation, Node Sass generates a source map when
outFile is unset as long as sourceMap is a string.