### PR TITLE
Match Node Sass's logic around source map file names

### DIFF
--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -342,7 +342,14 @@ RenderResult _newRenderResult(
     var sourceMapDir = p.dirname(sourceMapPath);
 
     result.sourceMap.sourceRoot = options.sourceMapRoot;
-    if (options.outFile != null) {
+    if (options.outFile == null) {
+      if (options.file == null) {
+        result.sourceMap.targetUrl = 'stdin.css';
+      } else {
+        result.sourceMap.targetUrl =
+            p.toUri(p.setExtension(options.file, '.css')).toString();
+      }
+    } else {
       result.sourceMap.targetUrl =
           p.toUri(p.relative(options.outFile, from: sourceMapDir)).toString();
     }

--- a/test/node_api/source_map_test.dart
+++ b/test/node_api/source_map_test.dart
@@ -154,12 +154,47 @@ void main() {
     });
   });
 
-  test("emits a source map with a string sourceMap and no outFile", () {
-    var result = sass.renderSync(
-        new RenderOptions(data: "a {b: c}", sourceMap: "out.css.map"));
-    var map = _jsonUtf8.decode(result.map) as Map<String, Object>;
-    expect(map, containsPair("sources", ["stdin"]));
-    expect(map, isNot(contains("targetUrl")));
+  group("with a string sourceMap and no outFile", () {
+    test("emits a source map", () {
+      var result = sass.renderSync(
+          new RenderOptions(data: "a {b: c}", sourceMap: "out.css.map"));
+      var map = _jsonUtf8.decode(result.map) as Map<String, Object>;
+      expect(map, containsPair("sources", ["stdin"]));
+    });
+
+    test("derives the target URL from the input file", () async {
+      var path = p.join(sandbox, 'test.scss');
+      await writeTextFile(path, 'a {b: c}');
+
+      var result = sass.renderSync(new RenderOptions(
+          file: p.join(sandbox, "test.scss"), sourceMap: "out.css.map"));
+      var map = _jsonUtf8.decode(result.map) as Map<String, Object>;
+      expect(
+          map,
+          containsPair(
+              "file", p.toUri(p.join(sandbox, "test.css")).toString()));
+    });
+
+    test("derives the target URL from the input file without an extension",
+        () async {
+      var path = p.join(sandbox, 'test');
+      await writeTextFile(path, 'a {b: c}');
+
+      var result = sass.renderSync(new RenderOptions(
+          file: p.join(sandbox, "test"), sourceMap: "out.css.map"));
+      var map = _jsonUtf8.decode(result.map) as Map<String, Object>;
+      expect(
+          map,
+          containsPair(
+              "file", p.toUri(p.join(sandbox, "test.css")).toString()));
+    });
+
+    test("derives the target URL from stdin", () {
+      var result = sass.renderSync(
+          new RenderOptions(data: "a {b: c}", sourceMap: "out.css.map"));
+      var map = _jsonUtf8.decode(result.map) as Map<String, Object>;
+      expect(map, containsPair("file", "stdin.css"));
+    });
   });
 
   test("with omitSourceMapUrl, doesn't include a source map comment", () {


### PR DESCRIPTION
When sourceMap is a string and outFile is null, Node Sass determines
the source map filename from the input filename.