### PR TITLE
Fix an Importer-calling bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1
+
+* Fix a bug where an importer would be passed an incorrectly-resolved URL when
+  handling a relative import.
+
 ## 1.4.0
 
 * Improve the error message for invalid semicolons in the indented syntax.

--- a/lib/src/async_import_cache.dart
+++ b/lib/src/async_import_cache.dart
@@ -116,7 +116,7 @@ class AsyncImportCache {
       [AsyncImporter baseImporter, Uri baseUrl]) async {
     var tuple = await canonicalize(url, baseImporter, baseUrl);
     if (tuple == null) return null;
-    var stylesheet = await importCanonical(tuple.item1, tuple.item2);
+    var stylesheet = await importCanonical(tuple.item1, tuple.item2, url);
     return new Tuple2(tuple.item1, stylesheet);
   }
 

--- a/lib/src/async_import_cache.dart
+++ b/lib/src/async_import_cache.dart
@@ -116,7 +116,8 @@ class AsyncImportCache {
       [AsyncImporter baseImporter, Uri baseUrl]) async {
     var tuple = await canonicalize(url, baseImporter, baseUrl);
     if (tuple == null) return null;
-    var stylesheet = await importCanonical(tuple.item1, tuple.item2, url);
+    var stylesheet = await importCanonical(tuple.item1, tuple.item2,
+        baseUrl != null ? baseUrl.resolveUri(url) : url);
     return new Tuple2(tuple.item1, stylesheet);
   }
 

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_import_cache.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: f499c5bf2076dd934ae3df7d133912401282c5c5
+// Checksum: fd88387ce5993289dae18840be7ff05edfc1a611
 
 import 'package:path/path.dart' as p;
 import 'package:tuple/tuple.dart';
@@ -119,7 +119,8 @@ class ImportCache {
       [Importer baseImporter, Uri baseUrl]) {
     var tuple = canonicalize(url, baseImporter, baseUrl);
     if (tuple == null) return null;
-    var stylesheet = importCanonical(tuple.item1, tuple.item2, url);
+    var stylesheet = importCanonical(tuple.item1, tuple.item2,
+        baseUrl != null ? baseUrl.resolveUri(url) : url);
     return new Tuple2(tuple.item1, stylesheet);
   }
 

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_import_cache.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: cc71af242380acde8a8e8c2bd57b384a747ff991
+// Checksum: f499c5bf2076dd934ae3df7d133912401282c5c5
 
 import 'package:path/path.dart' as p;
 import 'package:tuple/tuple.dart';

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -119,7 +119,7 @@ class ImportCache {
       [Importer baseImporter, Uri baseUrl]) {
     var tuple = canonicalize(url, baseImporter, baseUrl);
     if (tuple == null) return null;
-    var stylesheet = importCanonical(tuple.item1, tuple.item2);
+    var stylesheet = importCanonical(tuple.item1, tuple.item2, url);
     return new Tuple2(tuple.item1, stylesheet);
   }
 

--- a/lib/src/stylesheet_graph.dart
+++ b/lib/src/stylesheet_graph.dart
@@ -60,7 +60,7 @@ class StylesheetGraph {
     var canonicalUrl = tuple.item2;
 
     return _nodes.putIfAbsent(canonicalUrl, () {
-      var stylesheet = importCache.importCanonical(importer, canonicalUrl);
+      var stylesheet = importCache.importCanonical(importer, canonicalUrl, url);
       if (stylesheet == null) return null;
 
       var active = new Set<Uri>.from([canonicalUrl]);
@@ -98,7 +98,7 @@ class StylesheetGraph {
     /// error will be produced during compilation.
     if (active.contains(canonicalUrl)) return null;
 
-    var stylesheet = importCache.importCanonical(importer, canonicalUrl);
+    var stylesheet = importCache.importCanonical(importer, canonicalUrl, url);
     if (stylesheet == null) return null;
 
     active.add(canonicalUrl);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.4.0
+version: 1.4.1-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
We were resolving URLs relative to the canonical URL rather than the
original URL, which broke importers for which those were different,
like the package importer.

Closes #334