### PR TITLE
Re-add support for Dart 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ language: ruby
 
 env:
 # Language specs, defined in sass/sass-spec
-- TASK=specs   DART_CHANNEL=dev DART_VERSION=latest
-- TASK=specs   DART_CHANNEL=dev DART_VERSION=latest ASYNC=true
+- TASK=specs   DART_CHANNEL=dev    DART_VERSION=latest
+- TASK=specs   DART_CHANNEL=stable DART_VERSION=latest
+- TASK=specs   DART_CHANNEL=stable DART_VERSION=latest ASYNC=true
 
 # Unit tests, defined in test/.
 - TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest
+- TASK=tests   DART_CHANNEL=stable DART_VERSION=latest
 
 # This should be NODE_VERSION=latest, but that's breaking due to
 # laverdet/node-fibers#378.
@@ -21,8 +23,8 @@ env:
 - TASK=tests   DART_CHANNEL=dev    DART_VERSION=latest NODE_VERSION=lts/carbon
 
 # Miscellaneous checks.
-- TASK=analyze DART_CHANNEL=dev DART_VERSION=latest
-- TASK=format  DART_CHANNEL=dev DART_VERSION=latest
+- TASK=analyze DART_CHANNEL=dev    DART_VERSION=latest
+- TASK=format  DART_CHANNEL=dev    DART_VERSION=latest
 
 rvm:
 - 2.3.1

--- a/lib/src/async_import_cache.dart
+++ b/lib/src/async_import_cache.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:path/path.dart' as p;
 import 'package:tuple/tuple.dart';
 
 import 'ast/sass.dart';
@@ -12,6 +11,7 @@ import 'importer.dart';
 import 'logger.dart';
 import 'sync_package_resolver.dart';
 import 'utils.dart'; // ignore: unused_import
+import 'util/path.dart';
 
 /// An in-memory cache of parsed stylesheets that have been imported by Sass.
 class AsyncImportCache {
@@ -142,7 +142,7 @@ class AsyncImportCache {
       // stack traces.
       var displayUrl = originalUrl == null
           ? canonicalUrl
-          : originalUrl.resolve(p.url.basename(canonicalUrl.path));
+          : originalUrl.resolve(pUrl.basename(canonicalUrl.path));
       return result.isIndented
           ? new Stylesheet.parseSass(result.contents,
               url: displayUrl, logger: _logger)

--- a/lib/src/compile.dart
+++ b/lib/src/compile.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:source_span/source_span.dart';
 
@@ -17,6 +16,7 @@ import 'importer/node.dart';
 import 'io.dart';
 import 'logger.dart';
 import 'sync_package_resolver.dart';
+import 'util/path.dart';
 import 'visitor/async_evaluate.dart';
 import 'visitor/evaluate.dart';
 import 'visitor/serialize.dart';

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:dart2_constant/convert.dart' as convert;
-import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:stack_trace/stack_trace.dart';
 
@@ -19,6 +18,7 @@ import 'executable/repl.dart';
 import 'import_cache.dart';
 import 'io.dart';
 import 'stylesheet_graph.dart';
+import 'util/path.dart';
 import 'visitor/async_evaluate.dart';
 import 'visitor/evaluate.dart';
 import 'visitor/serialize.dart';

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -4,10 +4,10 @@
 
 import 'package:args/args.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p;
 
 import '../../sass.dart';
 import '../io.dart';
+import '../util/path.dart';
 
 /// The parsed and processed command-line options for the Sass executable.
 ///

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -5,9 +5,8 @@
 // DO NOT EDIT. This file was generated from async_import_cache.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: fd88387ce5993289dae18840be7ff05edfc1a611
+// Checksum: a4cda7503f4d6276fa18bf77306d9e58e0901ced
 
-import 'package:path/path.dart' as p;
 import 'package:tuple/tuple.dart';
 
 import 'ast/sass.dart';
@@ -15,6 +14,7 @@ import 'importer.dart';
 import 'logger.dart';
 import 'sync_package_resolver.dart';
 import 'utils.dart'; // ignore: unused_import
+import 'util/path.dart';
 
 /// An in-memory cache of parsed stylesheets that have been imported by Sass.
 class ImportCache {
@@ -145,7 +145,7 @@ class ImportCache {
       // stack traces.
       var displayUrl = originalUrl == null
           ? canonicalUrl
-          : originalUrl.resolve(p.url.basename(canonicalUrl.path));
+          : originalUrl.resolve(pUrl.basename(canonicalUrl.path));
       return result.isIndented
           ? new Stylesheet.parseSass(result.contents,
               url: displayUrl, logger: _logger)

--- a/lib/src/importer/filesystem.dart
+++ b/lib/src/importer/filesystem.dart
@@ -2,10 +2,9 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'package:path/path.dart' as p;
-
 import '../importer.dart';
 import '../io.dart' as io;
+import '../util/path.dart';
 import 'result.dart';
 import 'utils.dart';
 

--- a/lib/src/importer/node/implementation.dart
+++ b/lib/src/importer/node/implementation.dart
@@ -5,12 +5,12 @@
 import 'dart:async';
 
 import 'package:js/js.dart';
-import 'package:path/path.dart' as p;
 import 'package:tuple/tuple.dart';
 
 import '../../io.dart';
 import '../../node/importer_result.dart';
 import '../../node/utils.dart';
+import '../../util/path.dart';
 import '../utils.dart';
 
 typedef _Importer(String url, String prev, [void done(result)]);

--- a/lib/src/importer/utils.dart
+++ b/lib/src/importer/utils.dart
@@ -20,7 +20,7 @@ String resolveImportPath(String path) {
 
 /// Like [_tryPath], but checks both `.sass` and `.scss` extensions.
 List<String> _tryPathWithExtensions(String path) =>
-    _tryPath(path + '.sass') + _tryPath(path + '.scss');
+    _tryPath(path + '.sass')..addAll(_tryPath(path + '.scss'));
 
 /// Returns the [path] and/or the partial with the same name, if either or both
 /// exists.

--- a/lib/src/importer/utils.dart
+++ b/lib/src/importer/utils.dart
@@ -2,9 +2,8 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'package:path/path.dart' as p;
-
 import '../io.dart';
+import '../util/path.dart';
 
 /// Resolves an imported path using the same logic as the filesystem importer.
 ///

--- a/lib/src/io/node.dart
+++ b/lib/src/io/node.dart
@@ -7,10 +7,10 @@ import 'dart:convert';
 
 import 'package:dart2_constant/convert.dart' as convert;
 import 'package:js/js.dart';
-import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 
 import '../exception.dart';
+import '../util/path.dart';
 
 @JS()
 class _FS {

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -6,6 +6,7 @@ import 'package:source_span/source_span.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'logger/stderr.dart';
+import 'util/path.dart';
 
 /// An interface for loggers that print messages produced by Sass stylesheets.
 ///

--- a/lib/src/logger/stderr.dart
+++ b/lib/src/logger/stderr.dart
@@ -2,12 +2,12 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import '../io.dart';
 import '../logger.dart';
+import '../util/path.dart';
 import '../utils.dart';
 
 /// A logger that prints warnings to standard error.

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -9,7 +9,6 @@ import 'dart:typed_data';
 import 'package:collection/collection.dart';
 import 'package:dart2_constant/convert.dart' as convert;
 import 'package:js/js.dart';
-import 'package:path/path.dart' as p;
 import 'package:tuple/tuple.dart';
 
 import 'ast/sass.dart';
@@ -28,6 +27,7 @@ import 'node/types.dart';
 import 'node/value.dart';
 import 'node/utils.dart';
 import 'parse/scss.dart';
+import 'util/path.dart';
 import 'value.dart';
 import 'visitor/serialize.dart';
 
@@ -358,7 +358,7 @@ RenderResult _newRenderResult(
     for (var i = 0; i < result.sourceMap.urls.length; i++) {
       var source = result.sourceMap.urls[i];
       if (source == "stdin") continue;
-      result.sourceMap.urls[i] = p.url.relative(source, from: sourceMapDirUrl);
+      result.sourceMap.urls[i] = pUrl.relative(source, from: sourceMapDirUrl);
     }
 
     var json = result.sourceMap

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -6,7 +6,8 @@ import 'dart:math' as math;
 
 import 'package:charcode/charcode.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p;
+// This is unsafe prior to sdk#30098, which landed in Dart 1.25.0-dev.7.0.
+import 'package:path/path.dart' as unsafePath;
 import 'package:string_scanner/string_scanner.dart';
 import 'package:tuple/tuple.dart';
 
@@ -778,7 +779,9 @@ abstract class StylesheetParser extends Parser {
   String parseImportUrl(String url) {
     // Backwards-compatibility for implementations that allow absolute Windows
     // paths in imports.
-    if (p.windows.isAbsolute(url)) return p.windows.toUri(url).toString();
+    if (unsafePath.windows.isAbsolute(url)) {
+      return unsafePath.windows.toUri(url).toString();
+    }
 
     // Throw a [FormatException] if [url] is invalid.
     Uri.parse(url);

--- a/lib/src/util/path.dart
+++ b/lib/src/util/path.dart
@@ -1,0 +1,24 @@
+// Copyright 2017 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:path/path.dart' as path;
+
+import '../io.dart';
+
+/// A path context for the current operating system.
+///
+/// We define our own context rather than using the default one to work around
+/// the issue that sdk#30098 fixes.
+path.Context get p {
+  if (_p != null && _p.current == currentPath) return _p;
+  _p = new path.Context(
+      style: isWindows ? path.Style.windows : path.Style.posix,
+      current: currentPath);
+  return _p;
+}
+
+path.Context _p;
+
+/// A path context for working with URLs.
+path.Context get pUrl => path.url;

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -7,7 +7,6 @@ import 'dart:math' as math;
 
 import 'package:charcode/charcode.dart';
 import 'package:collection/collection.dart';
-import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:tuple/tuple.dart';
@@ -26,6 +25,7 @@ import '../importer/node.dart';
 import '../logger.dart';
 import '../parse/keyframe_selector.dart';
 import '../utils.dart';
+import '../util/path.dart';
 import '../value.dart';
 import 'interface/statement.dart';
 import 'interface/expression.dart';
@@ -800,7 +800,7 @@ class _EvaluateVisitor
       _includedFiles.add(url);
     }
 
-    return url.startsWith('file') && p.url.extension(url) == '.sass'
+    return url.startsWith('file') && pUrl.extension(url) == '.sass'
         ? new Stylesheet.parseSass(contents, url: url, logger: _logger)
         : new Stylesheet.parseScss(contents, url: url, logger: _logger);
   }

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 44efde158d897ad67b2cc6a199d6338b20f4feb9
+// Checksum: ff6c50c58c86529e7fed4247a7381649cec1900c
 
 import 'async_evaluate.dart' show EvaluateResult;
 export 'async_evaluate.dart' show EvaluateResult;
@@ -14,7 +14,6 @@ import 'dart:math' as math;
 
 import 'package:charcode/charcode.dart';
 import 'package:collection/collection.dart';
-import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:tuple/tuple.dart';
@@ -33,6 +32,7 @@ import '../importer/node.dart';
 import '../logger.dart';
 import '../parse/keyframe_selector.dart';
 import '../utils.dart';
+import '../util/path.dart';
 import '../value.dart';
 import 'interface/statement.dart';
 import 'interface/expression.dart';
@@ -798,7 +798,7 @@ class _EvaluateVisitor
       _includedFiles.add(url);
     }
 
-    return url.startsWith('file') && p.url.extension(url) == '.sass'
+    return url.startsWith('file') && pUrl.extension(url) == '.sass'
         ? new Stylesheet.parseSass(contents, url: url, logger: _logger)
         : new Stylesheet.parseScss(contents, url: url, logger: _logger);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ executables:
   dart-sass: sass
 
 environment:
-  sdk: '>=1.25.0-dev.29.0 <2.0.0'
+  sdk: '>=1.22.0 <2.0.0'
 
 dependencies:
   args: ">=1.4.0 <2.0.0"

--- a/test/cli/dart_test.dart
+++ b/test/cli/dart_test.dart
@@ -7,10 +7,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
+
+import 'package:sass/src/util/path.dart';
 
 import 'shared.dart';
 

--- a/test/cli/node_test.dart
+++ b/test/cli/node_test.dart
@@ -7,10 +7,11 @@
 
 import 'dart:async';
 
-import 'package:path/path.dart' as p;
 import 'package:test_process/test_process.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test/test.dart';
+
+import 'package:sass/src/util/path.dart';
 
 import '../ensure_npm_package.dart';
 import 'shared.dart';

--- a/test/cli/shared/source_maps.dart
+++ b/test/cli/shared/source_maps.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:dart2_constant/convert.dart' as convert;
-import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
@@ -13,6 +12,7 @@ import 'package:test_process/test_process.dart';
 
 import 'package:sass/sass.dart' as sass;
 import 'package:sass/src/io.dart';
+import 'package:sass/src/util/path.dart';
 
 import '../../utils.dart';
 

--- a/test/cli_shared.dart
+++ b/test/cli_shared.dart
@@ -1,0 +1,842 @@
+// Copyright 2016 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'dart:async';
+
+import 'package:dart2_constant/convert.dart' as convert;
+import 'package:source_maps/source_maps.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+import 'package:test_process/test_process.dart';
+
+import 'package:sass/sass.dart' as sass;
+import 'package:sass/src/io.dart';
+import 'package:sass/src/util/path.dart';
+
+import 'utils.dart';
+
+/// Defines test that are shared between the Dart and Node.js CLI test suites.
+void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
+  /// Runs the executable on [arguments] plus an output file, then verifies that
+  /// the contents of the output file match [expected].
+  Future expectCompiles(List<String> arguments, expected) async {
+    var sass = await runSass(
+        arguments.toList()..add("out.css")..add("--no-source-map"));
+    await sass.shouldExit(0);
+    await d.file("out.css", expected).validate();
+  }
+
+  test("--help prints the usage documentation", () async {
+    // Checking the entire output is brittle, so just do a sanity check to make
+    // sure it's not totally busted.
+    var sass = await runSass(["--help"]);
+    expect(sass.stdout, emits("Compile Sass to CSS."));
+    expect(
+        sass.stdout, emitsThrough(contains("Print this usage information.")));
+    await sass.shouldExit(64);
+  });
+
+  test("compiles a Sass file to CSS", () async {
+    await d.file("test.scss", "a {b: 1 + 2}").create();
+
+    var sass = await runSass(["test.scss"]);
+    expect(
+        sass.stdout,
+        emitsInOrder([
+          "a {",
+          "  b: 3;",
+          "}",
+        ]));
+    await sass.shouldExit(0);
+  });
+
+  test("writes a CSS file to disk", () async {
+    await d.file("test.scss", "a {b: 1 + 2}").create();
+
+    var sass = await runSass(["--no-source-map", "test.scss", "out.css"]);
+    expect(sass.stdout, emitsDone);
+    await sass.shouldExit(0);
+    await d.file("out.css", equalsIgnoringWhitespace("a { b: 3; }")).validate();
+  });
+
+  test("creates directories if necessary", () async {
+    await d.file("test.scss", "a {b: 1 + 2}").create();
+
+    var sass =
+        await runSass(["--no-source-map", "test.scss", "some/new/dir/out.css"]);
+    expect(sass.stdout, emitsDone);
+    await sass.shouldExit(0);
+    await d
+        .file("some/new/dir/out.css", equalsIgnoringWhitespace("a { b: 3; }"))
+        .validate();
+  });
+
+  test("compiles from stdin with the magic path -", () async {
+    var sass = await runSass(["-"]);
+    sass.stdin.writeln("a {b: 1 + 2}");
+    sass.stdin.close();
+    expect(
+        sass.stdout,
+        emitsInOrder([
+          "a {",
+          "  b: 3;",
+          "}",
+        ]));
+    await sass.shouldExit(0);
+  });
+
+  group("can import files", () {
+    test("relative to the entrypoint", () async {
+      await d.file("test.scss", "@import 'dir/test'").create();
+
+      await d.dir("dir", [d.file("test.scss", "a {b: 1 + 2}")]).create();
+
+      await expectCompiles(
+          ["test.scss"], equalsIgnoringWhitespace("a { b: 3; }"));
+    });
+
+    test("from the load path", () async {
+      await d.file("test.scss", "@import 'test2'").create();
+
+      await d.dir("dir", [d.file("test2.scss", "a {b: c}")]).create();
+
+      await expectCompiles(["--load-path", "dir", "test.scss"],
+          equalsIgnoringWhitespace("a { b: c; }"));
+    });
+
+    test("relative in preference to from the load path", () async {
+      await d.file("test.scss", "@import 'test2'").create();
+      await d.file("test2.scss", "x {y: z}").create();
+
+      await d.dir("dir", [d.file("test2.scss", "a {b: c}")]).create();
+
+      await expectCompiles(["--load-path", "dir", "test.scss"],
+          equalsIgnoringWhitespace("x { y: z; }"));
+    });
+
+    test("in load path order", () async {
+      await d.file("test.scss", "@import 'test2'").create();
+
+      await d.dir("dir1", [d.file("test2.scss", "a {b: c}")]).create();
+      await d.dir("dir2", [d.file("test2.scss", "x {y: z}")]).create();
+
+      await expectCompiles(
+          ["--load-path", "dir2", "--load-path", "dir1", "test.scss"],
+          equalsIgnoringWhitespace("x { y: z; }"));
+    });
+  });
+
+  group("with --stdin", () {
+    test("compiles from stdin", () async {
+      var sass = await runSass(["--stdin"]);
+      sass.stdin.writeln("a {b: 1 + 2}");
+      sass.stdin.close();
+      expect(
+          sass.stdout,
+          emitsInOrder([
+            "a {",
+            "  b: 3;",
+            "}",
+          ]));
+      await sass.shouldExit(0);
+    });
+
+    test("writes a CSS file to disk", () async {
+      var sass = await runSass(["--no-source-map", "--stdin", "out.css"]);
+      sass.stdin.writeln("a {b: 1 + 2}");
+      sass.stdin.close();
+      expect(sass.stdout, emitsDone);
+
+      await sass.shouldExit(0);
+      await d
+          .file("out.css", equalsIgnoringWhitespace("a { b: 3; }"))
+          .validate();
+    });
+
+    test("uses the indented syntax with --indented", () async {
+      var sass = await runSass(["--no-source-map", "--stdin", "--indented"]);
+      sass.stdin.writeln("a\n  b: 1 + 2");
+      sass.stdin.close();
+      expect(
+          sass.stdout,
+          emitsInOrder([
+            "a {",
+            "  b: 3;",
+            "}",
+          ]));
+      await sass.shouldExit(0);
+    });
+  });
+
+  group("with colon arguments", () {
+    test("compiles multiple sources to multiple destinations", () async {
+      await d.file("test1.scss", "a {b: c}").create();
+      await d.file("test2.scss", "x {y: z}").create();
+
+      var sass = await runSass(
+          ["--no-source-map", "test1.scss:out1.css", "test2.scss:out2.css"]);
+      expect(sass.stdout, emitsDone);
+      await sass.shouldExit(0);
+
+      await d
+          .file("out1.css", equalsIgnoringWhitespace("a { b: c; }"))
+          .validate();
+      await d
+          .file("out2.css", equalsIgnoringWhitespace("x { y: z; }"))
+          .validate();
+    });
+
+    test("creates destination directories", () async {
+      await d.file("test.scss", "a {b: c}").create();
+
+      var sass = await runSass(["--no-source-map", "test.scss:dir/out.css"]);
+      expect(sass.stdout, emitsDone);
+      await sass.shouldExit(0);
+
+      await d.dir("dir", [
+        d.file("out.css", equalsIgnoringWhitespace("a { b: c; }"))
+      ]).validate();
+    });
+
+    test("creates source maps for each compilation", () async {
+      await d.file("test1.scss", "a {b: c}").create();
+      await d.file("test2.scss", "x {y: z}").create();
+
+      var sass = await runSass(["test1.scss:out1.css", "test2.scss:out2.css"]);
+      expect(sass.stdout, emitsDone);
+      await sass.shouldExit(0);
+
+      await d.file("out1.css", contains("out1.css.map")).validate();
+      await d.file("out1.css.map", contains("test1.scss")).validate();
+      await d.file("out2.css", contains("out2.css.map")).validate();
+      await d.file("out2.css.map", contains("test2.scss")).validate();
+    });
+
+    group("with a directory argument", () {
+      test("compiles all the stylesheets in the directory", () async {
+        await d.dir("in", [
+          d.file("test1.scss", "a {b: c}"),
+          d.file("test2.sass", "x\n  y: z")
+        ]).create();
+
+        var sass = await runSass(["--no-source-map", "in:out"]);
+        expect(sass.stdout, emitsDone);
+        await sass.shouldExit(0);
+
+        await d.dir("out", [
+          d.file("test1.css", equalsIgnoringWhitespace("a { b: c; }")),
+          d.file("test2.css", equalsIgnoringWhitespace("x { y: z; }"))
+        ]).validate();
+      });
+
+      test("creates subdirectories in the destination", () async {
+        await d.dir("in", [
+          d.dir("sub", [d.file("test.scss", "a {b: c}")])
+        ]).create();
+
+        var sass = await runSass(["--no-source-map", "in:out"]);
+        expect(sass.stdout, emitsDone);
+        await sass.shouldExit(0);
+
+        await d.dir("out", [
+          d.dir("sub",
+              [d.file("test.css", equalsIgnoringWhitespace("a { b: c; }"))])
+        ]).validate();
+      });
+
+      test("ignores partials", () async {
+        await d.dir("in", [
+          d.file("_fake.scss", "a {b:"),
+          d.file("real.scss", "x {y: z}")
+        ]).create();
+
+        var sass = await runSass(["--no-source-map", "in:out"]);
+        expect(sass.stdout, emitsDone);
+        await sass.shouldExit(0);
+
+        await d.dir("out", [
+          d.file("real.css", equalsIgnoringWhitespace("x { y: z; }")),
+          d.nothing("fake.css"),
+          d.nothing("_fake.css")
+        ]).validate();
+      });
+
+      test("ignores files without a Sass extension", () async {
+        await d.dir("in", [
+          d.file("fake.szss", "a {b:"),
+          d.file("real.scss", "x {y: z}")
+        ]).create();
+
+        var sass = await runSass(["--no-source-map", "in:out"]);
+        expect(sass.stdout, emitsDone);
+        await sass.shouldExit(0);
+
+        await d.dir("out", [
+          d.file("real.css", equalsIgnoringWhitespace("x { y: z; }")),
+          d.nothing("fake.css")
+        ]).validate();
+      });
+    });
+
+    group("reports all", () {
+      test("file-not-found errors", () async {
+        var sass =
+            await runSass(["test1.scss:out1.css", "test2.scss:out2.css"]);
+        expect(
+            sass.stderr,
+            emitsInOrder([
+              startsWith("Error reading test1.scss: "),
+              "",
+              startsWith("Error reading test2.scss: ")
+            ]));
+        await sass.shouldExit(66);
+      });
+
+      test("compilation errors", () async {
+        await d.file("test1.scss", "a {b: }").create();
+        await d.file("test2.scss", "x {y: }").create();
+
+        var sass =
+            await runSass(["test1.scss:out1.css", "test2.scss:out2.css"]);
+        expect(
+            sass.stderr,
+            emitsInOrder([
+              "Error: Expected expression.",
+              "a {b: }",
+              "      ^",
+              "  test1.scss 1:7  root stylesheet",
+              "",
+              "Error: Expected expression.",
+              "x {y: }",
+              "      ^",
+              "  test2.scss 1:7  root stylesheet"
+            ]));
+        await sass.shouldExit(65);
+      });
+
+      test("runtime errors", () async {
+        await d.file("test1.scss", "a {b: 1 + #abc}").create();
+        await d.file("test2.scss", "x {y: 1 + #abc}").create();
+
+        var sass =
+            await runSass(["test1.scss:out1.css", "test2.scss:out2.css"]);
+        expect(
+            sass.stderr,
+            emitsInOrder([
+              'Error: Undefined operation "1 + #abc".',
+              "a {b: 1 + #abc}",
+              "      ^^^^^^^^",
+              "  test1.scss 1:7  root stylesheet",
+              "",
+              'Error: Undefined operation "1 + #abc".',
+              "x {y: 1 + #abc}",
+              "      ^^^^^^^^",
+              "  test2.scss 1:7  root stylesheet"
+            ]));
+        await sass.shouldExit(65);
+      });
+    });
+
+    group("doesn't allow", () {
+      group("positional arguments", () {
+        test("before", () async {
+          var sass = await runSass(["positional", "test.scss:out.css"]);
+          expect(sass.stdout,
+              emits('Positional and ":" arguments may not both be used.'));
+          await sass.shouldExit(64);
+        });
+
+        test("after", () async {
+          var sass = await runSass(["test.scss:out.css", "positional"]);
+          expect(sass.stdout,
+              emits('Positional and ":" arguments may not both be used.'));
+          await sass.shouldExit(64);
+        });
+      });
+
+      test("--stdin", () async {
+        var sass = await runSass(["--stdin", "test.scss:out.css"]);
+        expect(
+            sass.stdout, emits('--stdin may not be used with ":" arguments.'));
+        await sass.shouldExit(64);
+      });
+
+      test("multiple colons", () async {
+        var sass = await runSass(["test.scss:out.css:wut"]);
+        expect(sass.stdout,
+            emits('"test.scss:out.css:wut" may only contain one ":".'));
+        await sass.shouldExit(64);
+      });
+
+      test("duplicate sources", () async {
+        var sass = await runSass(["test.scss:out1.css", "test.scss:out2.css"]);
+        expect(sass.stdout, emits('Duplicate source "test.scss".'));
+        await sass.shouldExit(64);
+      });
+    });
+  });
+
+  test("gracefully reports errors from stdin", () async {
+    var sass = await runSass(["-"]);
+    sass.stdin.writeln("a {b: 1 + }");
+    sass.stdin.close();
+    expect(
+        sass.stderr,
+        emitsInOrder([
+          "Error: Expected expression.",
+          "a {b: 1 + }",
+          "          ^",
+          "  - 1:11  root stylesheet",
+        ]));
+    await sass.shouldExit(65);
+  });
+
+  test("supports relative imports", () async {
+    await d.file("test.scss", "@import 'dir/test'").create();
+
+    await d.dir("dir", [d.file("test.scss", "a {b: 1 + 2}")]).create();
+
+    var sass = await runSass(["test.scss"]);
+    expect(
+        sass.stdout,
+        emitsInOrder([
+          "a {",
+          "  b: 3;",
+          "}",
+        ]));
+    await sass.shouldExit(0);
+  });
+
+  test("emits warnings on standard error", () async {
+    await d.file("test.scss", "@warn 'aw beans'").create();
+
+    var sass = await runSass(["test.scss"]);
+    expect(sass.stdout, emitsDone);
+    expect(
+        sass.stderr,
+        emitsInOrder([
+          "WARNING: aw beans",
+          "    test.scss 1:1  root stylesheet",
+        ]));
+    await sass.shouldExit(0);
+  });
+
+  test("emits debug messages on standard error", () async {
+    await d.file("test.scss", "@debug 'what the heck'").create();
+
+    var sass = await runSass(["test.scss"]);
+    expect(sass.stdout, emitsDone);
+    expect(sass.stderr, emits("test.scss:1 DEBUG: what the heck"));
+    await sass.shouldExit(0);
+  });
+
+  group("with --quiet", () {
+    test("doesn't emit @warn", () async {
+      await d.file("test.scss", "@warn heck").create();
+
+      var sass = await runSass(["--quiet", "test.scss"]);
+      expect(sass.stderr, emitsDone);
+      await sass.shouldExit(0);
+    });
+
+    test("doesn't emit @debug", () async {
+      await d.file("test.scss", "@debug heck").create();
+
+      var sass = await runSass(["--quiet", "test.scss"]);
+      expect(sass.stderr, emitsDone);
+      await sass.shouldExit(0);
+    });
+
+    test("doesn't emit parser warnings", () async {
+      await d.file("test.scss", "a {b: c && d}").create();
+
+      var sass = await runSass(["--quiet", "test.scss"]);
+      expect(sass.stderr, emitsDone);
+      await sass.shouldExit(0);
+    });
+
+    test("doesn't emit runner warnings", () async {
+      await d.file("test.scss", "#{blue} {x: y}").create();
+
+      var sass = await runSass(["--quiet", "test.scss"]);
+      expect(sass.stderr, emitsDone);
+      await sass.shouldExit(0);
+    });
+  });
+
+  group("source maps:", () {
+    group("for a simple compilation", () {
+      Map<String, Object> map;
+      setUp(() async {
+        await d.file("test.scss", "a {b: 1 + 2}").create();
+
+        await (await runSass(["test.scss", "out.css"])).shouldExit(0);
+        map = _readJson("out.css.map");
+      });
+
+      test("refers to the source file", () {
+        expect(map, containsPair("sources", ["test.scss"]));
+      });
+
+      test("refers to the target file", () {
+        expect(map, containsPair("file", "out.css"));
+      });
+
+      test("contains mappings", () {
+        SingleMapping sourceMap;
+        sass.compileString("a {b: 1 + 2}", sourceMap: (map) => sourceMap = map);
+        expect(map, containsPair("mappings", sourceMap.toJson()["mappings"]));
+      });
+    });
+
+    group("with multiple sources", () {
+      setUp(() async {
+        await d.file("test.scss", """
+        @import 'dir/other';
+        x {y: z}
+      """).create();
+        await d.dir("dir", [d.file("other.scss", "a {b: 1 + 2}")]).create();
+      });
+
+      test("refers to them using relative URLs by default", () async {
+        await (await runSass(["test.scss", "out.css"])).shouldExit(0);
+        expect(_readJson("out.css.map"),
+            containsPair("sources", ["dir/other.scss", "test.scss"]));
+      });
+
+      test("refers to them using relative URLs with --source-map-urls=relative",
+          () async {
+        await (await runSass(
+                ["--source-map-urls=relative", "test.scss", "out.css"]))
+            .shouldExit(0);
+        expect(_readJson("out.css.map"),
+            containsPair("sources", ["dir/other.scss", "test.scss"]));
+      });
+
+      test("refers to them using absolute URLs with --source-map-urls=absolute",
+          () async {
+        await (await runSass(
+                ["--source-map-urls=absolute", "test.scss", "out.css"]))
+            .shouldExit(0);
+        expect(
+            _readJson("out.css.map"),
+            containsPair("sources", [
+              p
+                  .toUri(p.canonicalize(p.join(d.sandbox, "dir/other.scss")))
+                  .toString(),
+              p.toUri(p.canonicalize(p.join(d.sandbox, "test.scss"))).toString()
+            ]));
+      });
+
+      test("includes source contents with --embed-sources", () async {
+        await (await runSass(["--embed-sources", "test.scss", "out.css"]))
+            .shouldExit(0);
+        expect(
+            _readJson("out.css.map"),
+            containsPair("sourcesContent",
+                ["a {b: 1 + 2}", readFile(p.join(d.sandbox, "test.scss"))]));
+      });
+    });
+
+    test("refers to a source in another directory", () async {
+      await d.dir("in", [d.file("test.scss", "x {y: z}")]).create();
+      await (await runSass(["in/test.scss", "out/test.css"])).shouldExit(0);
+      expect(_readJson("out/test.css.map"),
+          containsPair("sources", ["../in/test.scss"]));
+    });
+
+    test("includes a source map comment", () async {
+      await d.file("test.scss", "a {b: c}").create();
+      await (await runSass(["test.scss", "out.css"])).shouldExit(0);
+      await d
+          .file(
+              "out.css", endsWith("\n\n/*# sourceMappingURL=out.css.map */\n"))
+          .validate();
+    });
+
+    test("with --stdin uses an empty string", () async {
+      var sass = await runSass(["--stdin", "out.css"]);
+      sass.stdin.writeln("a {b: c}");
+      sass.stdin.close();
+      await sass.shouldExit(0);
+
+      expect(_readJson("out.css.map"), containsPair("sources", [""]));
+    });
+
+    group("with --no-source-map,", () {
+      setUp(() async {
+        await d.file("test.scss", "a {b: c}").create();
+      });
+
+      test("no source map is generated", () async {
+        await (await runSass(["--no-source-map", "test.scss", "out.css"]))
+            .shouldExit(0);
+
+        await d.file("out.css", isNot(contains("/*#"))).validate();
+        await d.nothing("out.css.map").validate();
+      });
+
+      test("--source-map-urls is disallowed", () async {
+        var sass = await runSass([
+          "--no-source-map",
+          "--source-map-urls=absolute",
+          "test.scss",
+          "out.css"
+        ]);
+        expect(sass.stdout,
+            emits("--source-map-urls isn't allowed with --no-source-map."));
+        expect(sass.stdout,
+            emitsThrough(contains("Print this usage information.")));
+        await sass.shouldExit(64);
+      });
+
+      test("--embed-sources is disallowed", () async {
+        var sass = await runSass(
+            ["--no-source-map", "--embed-sources", "test.scss", "out.css"]);
+        expect(sass.stdout,
+            emits("--embed-sources isn't allowed with --no-source-map."));
+        expect(sass.stdout,
+            emitsThrough(contains("Print this usage information.")));
+        await sass.shouldExit(64);
+      });
+
+      test("--embed-source-map is disallowed", () async {
+        var sass = await runSass(
+            ["--no-source-map", "--embed-source-map", "test.scss", "out.css"]);
+        expect(sass.stdout,
+            emits("--embed-source-map isn't allowed with --no-source-map."));
+        expect(sass.stdout,
+            emitsThrough(contains("Print this usage information.")));
+        await sass.shouldExit(64);
+      });
+    });
+
+    group("when emitting to stdout", () {
+      test("--source-map isn't allowed", () async {
+        await d.file("test.scss", "a {b: c}").create();
+        var sass = await runSass(["--source-map", "test.scss"]);
+        expect(
+            sass.stdout,
+            emits("When printing to stdout, --source-map requires "
+                "--embed-source-map."));
+        expect(sass.stdout,
+            emitsThrough(contains("Print this usage information.")));
+        await sass.shouldExit(64);
+      });
+
+      test("--source-map-urls is disallowed", () async {
+        await d.file("test.scss", "a {b: c}").create();
+        var sass = await runSass(["--source-map-urls=absolute", "test.scss"]);
+        expect(
+            sass.stdout,
+            emits("When printing to stdout, --source-map-urls requires "
+                "--embed-source-map."));
+        expect(sass.stdout,
+            emitsThrough(contains("Print this usage information.")));
+        await sass.shouldExit(64);
+      });
+
+      test("--embed-sources is disallowed", () async {
+        await d.file("test.scss", "a {b: c}").create();
+        var sass = await runSass(["--embed-sources", "test.scss"]);
+        expect(
+            sass.stdout,
+            emits("When printing to stdout, --embed-sources requires "
+                "--embed-source-map."));
+        expect(sass.stdout,
+            emitsThrough(contains("Print this usage information.")));
+        await sass.shouldExit(64);
+      });
+
+      test(
+          "--source-map-urls=relative is disallowed even with "
+          "--embed-source-map", () async {
+        await d.file("test.scss", "a {b: c}").create();
+        var sass = await runSass(
+            ["--source-map-urls=relative", "--embed-source-map", "test.scss"]);
+        expect(
+            sass.stdout,
+            emits("--source-map-urls=relative isn't allowed when printing to "
+                "stdout."));
+        expect(sass.stdout,
+            emitsThrough(contains("Print this usage information.")));
+        await sass.shouldExit(64);
+      });
+
+      test("everything is allowed with --embed-source-map", () async {
+        await d.file("test.scss", "a {b: c}").create();
+        var sass = await runSass([
+          "--source-map",
+          "--source-map-urls=absolute",
+          "--embed-sources",
+          "--embed-source-map",
+          "test.scss"
+        ]);
+        var css = (await sass.stdout.rest.toList()).join("\n");
+        await sass.shouldExit(0);
+
+        var map = embeddedSourceMap(css);
+        expect(map, isNotEmpty);
+        expect(map, isNot(contains("file")));
+      });
+    });
+
+    group("with --embed-source-map", () {
+      setUp(() async {
+        await d.file("test.scss", "a {b: 1 + 2}").create();
+      });
+
+      Map<String, Object> map;
+      group("with the target in the same directory", () {
+        setUp(() async {
+          await (await runSass(["--embed-source-map", "test.scss", "out.css"]))
+              .shouldExit(0);
+          var css = readFile(p.join(d.sandbox, "out.css"));
+          map = embeddedSourceMap(css);
+        });
+
+        test("contains mappings in the generated CSS", () {
+          SingleMapping sourceMap;
+          sass.compileString("a {b: 1 + 2}",
+              sourceMap: (map) => sourceMap = map);
+          expect(map, containsPair("mappings", sourceMap.toJson()["mappings"]));
+        });
+
+        test("refers to the source file", () {
+          expect(map, containsPair("sources", ["test.scss"]));
+        });
+
+        test("refers to the target file", () {
+          expect(map, containsPair("file", "out.css"));
+        });
+
+        test("doesn't generate a source map file", () async {
+          await d.nothing("out.css.map").validate();
+        });
+      });
+
+      group("with the target in a different directory", () {
+        setUp(() async {
+          await ensureDir(p.join(d.sandbox, "dir"));
+          await (await runSass(
+                  ["--embed-source-map", "test.scss", "dir/out.css"]))
+              .shouldExit(0);
+          var css = readFile(p.join(d.sandbox, "dir/out.css"));
+          map = embeddedSourceMap(css);
+        });
+
+        test("refers to the source file", () {
+          expect(map, containsPair("sources", ["../test.scss"]));
+        });
+
+        test("refers to the target file", () {
+          expect(map, containsPair("file", "out.css"));
+        });
+      });
+    });
+  });
+
+  group("reports errors", () {
+    test("from invalid arguments", () async {
+      var sass = await runSass(["--asdf"]);
+      expect(
+          sass.stdout, emitsThrough(contains("Print this usage information.")));
+      await sass.shouldExit(64);
+    });
+
+    test("from too many positional arguments", () async {
+      var sass = await runSass(["abc", "def", "ghi"]);
+      expect(
+          sass.stdout, emitsThrough(contains("Print this usage information.")));
+      await sass.shouldExit(64);
+    });
+
+    test("from too many positional arguments with --stdin", () async {
+      var sass = await runSass(["--stdin", "abc", "def"]);
+      expect(
+          sass.stdout, emitsThrough(contains("Print this usage information.")));
+      await sass.shouldExit(64);
+    });
+
+    test("from a file that doesn't exist", () async {
+      var sass = await runSass(["asdf"]);
+      expect(sass.stderr, emits(startsWith("Error reading asdf:")));
+      expect(sass.stderr, emitsDone);
+      await sass.shouldExit(66);
+    });
+
+    test("from invalid syntax", () async {
+      await d.file("test.scss", "a {b: }").create();
+
+      var sass = await runSass(["test.scss"]);
+      expect(
+          sass.stderr,
+          emitsInOrder([
+            "Error: Expected expression.",
+            "a {b: }",
+            "      ^",
+            "  test.scss 1:7  root stylesheet",
+          ]));
+      await sass.shouldExit(65);
+    });
+
+    test("from the runtime", () async {
+      await d.file("test.scss", "a {b: 1px + 1deg}").create();
+
+      var sass = await runSass(["test.scss"]);
+      expect(
+          sass.stderr,
+          emitsInOrder([
+            "Error: Incompatible units deg and px.",
+            "a {b: 1px + 1deg}",
+            "      ^^^^^^^^^^",
+            "  test.scss 1:7  root stylesheet",
+          ]));
+      await sass.shouldExit(65);
+    });
+
+    test("with colors with --color", () async {
+      await d.file("test.scss", "a {b: }").create();
+
+      var sass = await runSass(["--color", "test.scss"]);
+      expect(
+          sass.stderr,
+          emitsInOrder([
+            "Error: Expected expression.",
+            "a {b: \u001b[31m\u001b[0m}",
+            "      \u001b[31m^\u001b[0m",
+            "  test.scss 1:7  root stylesheet",
+          ]));
+      await sass.shouldExit(65);
+    });
+
+    test("with full stack traces with --trace", () async {
+      await d.file("test.scss", "a {b: }").create();
+
+      var sass = await runSass(["--trace", "test.scss"]);
+      expect(sass.stderr, emitsThrough(contains("\.dart")));
+      await sass.shouldExit(65);
+    });
+
+    test("for package urls", () async {
+      await d.file("test.scss", "@import 'package:nope/test';").create();
+
+      var sass = await runSass(["test.scss"]);
+      expect(
+          sass.stderr,
+          emitsInOrder([
+            "Error: \"package:\" URLs aren't supported on this platform.",
+            "@import 'package:nope/test';",
+            "        ^^^^^^^^^^^^^^^^^^^",
+            "  test.scss 1:9  root stylesheet"
+          ]));
+      await sass.shouldExit(65);
+    });
+  });
+}
+
+/// Reads the file at [path] within [d.sandbox] and JSON-decodes it.
+Map<String, Object> _readJson(String path) =>
+    convert.json.decode(readFile(p.join(d.sandbox, path)))
+        as Map<String, Object>;

--- a/test/dart_api_test.dart
+++ b/test/dart_api_test.dart
@@ -5,12 +5,12 @@
 @TestOn('vm')
 
 import 'package:package_resolver/package_resolver.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'package:sass/sass.dart';
 import 'package:sass/src/exception.dart';
+import 'package:sass/src/util/path.dart';
 
 main() {
   group("importers", () {

--- a/test/node_api/api.dart
+++ b/test/node_api/api.dart
@@ -6,17 +6,18 @@
 /// to Dart. This is kind of convoluted, but it allows us to test the API as it
 /// will be used in the real world without having to manually write any JS.
 
+import 'package:sass/src/node/fiber.dart';
+import 'package:sass/src/node/render_options.dart';
+import 'package:sass/src/node/render_result.dart';
+import 'package:sass/src/util/path.dart';
+
 import 'package:js/js.dart';
-import 'package:path/path.dart' as p;
 
 export 'package:sass/src/node/error.dart';
 export 'package:sass/src/node/importer_result.dart';
 export 'package:sass/src/node/render_context.dart';
 export 'package:sass/src/node/render_options.dart';
 export 'package:sass/src/node/render_result.dart';
-import 'package:sass/src/node/fiber.dart';
-import 'package:sass/src/node/render_options.dart';
-import 'package:sass/src/node/render_result.dart';
 
 /// The Sass module.
 final sass = _requireSass(p.absolute("build/npm/sass.dart"));

--- a/test/node_api/importer_test.dart
+++ b/test/node_api/importer_test.dart
@@ -9,10 +9,10 @@ import 'dart:async';
 
 import 'package:dart2_constant/core.dart' as core;
 import 'package:js/js.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'package:sass/src/io.dart';
+import 'package:sass/src/util/path.dart';
 import 'package:sass/src/value/number.dart';
 
 import '../ensure_npm_package.dart';

--- a/test/node_api/source_map_test.dart
+++ b/test/node_api/source_map_test.dart
@@ -9,11 +9,11 @@ import 'dart:convert';
 
 import 'package:dart2_constant/convert.dart' as convert;
 import 'package:js/js.dart';
-import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:test/test.dart';
 
 import 'package:sass/sass.dart' as dartSass;
+import 'package:sass/src/util/path.dart';
 
 import '../ensure_npm_package.dart';
 import '../hybrid.dart';

--- a/test/node_api_test.dart
+++ b/test/node_api_test.dart
@@ -7,9 +7,11 @@
 
 import 'dart:convert';
 
-import 'package:path/path.dart' as p;
+// This is unsafe prior to sdk#30098, which landed in Dart 1.25.0-dev.7.0.
+import 'package:path/path.dart' as unsafePath;
 import 'package:test/test.dart';
 
+import 'package:sass/src/util/path.dart';
 import 'package:sass/src/node/utils.dart';
 
 import 'ensure_npm_package.dart';
@@ -321,7 +323,7 @@ a {
               "Error: Expected expression.\n"
               "a {b: }\n"
               "      ^\n"
-              "  $sassPath 1:7  root stylesheet");
+              "  ${tracePath(sassPath)} 1:7  root stylesheet");
         });
 
         test("sets the line, column, and filename", () {
@@ -373,7 +375,7 @@ a {
           expect(
               error,
               toStringAndMessageEqual('Undefined operation "1 % a".\n'
-                  '  $sassPath 1:7  root stylesheet'));
+                  '  ${tracePath(sassPath)} 1:7  root stylesheet'));
         });
 
         test("has a useful formatted message", () async {
@@ -382,7 +384,7 @@ a {
               'Error: Undefined operation "1 % a".\n'
               'a {b: 1 % a}\n'
               '      ^^^^^\n'
-              '  $sassPath 1:7  root stylesheet');
+              '  ${tracePath(sassPath)} 1:7  root stylesheet');
         });
 
         test("sets the line, column, and filename", () {
@@ -442,3 +444,9 @@ a {
       // is only available on Dart 2.
       tags: "dart2");
 }
+
+/// Returns [path] in the format it appears in formatted stack traces.
+///
+/// Stack traces use the global `path` context, which is broken on Node prior to
+/// Dart 1.25.0-dev.7.0.
+String tracePath(String path) => unsafePath.prettyUri(p.toUri(path));

--- a/tool/grind/github.dart
+++ b/tool/grind/github.dart
@@ -9,9 +9,10 @@ import 'package:charcode/charcode.dart';
 import 'package:dart2_constant/convert.dart' as convert;
 import 'package:grinder/grinder.dart';
 import 'package:http/http.dart' as http;
-import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:string_scanner/string_scanner.dart';
+
+import 'package:sass/src/util/path.dart';
 
 import '../grind.dart';
 import 'utils.dart';

--- a/tool/grind/npm.dart
+++ b/tool/grind/npm.dart
@@ -9,9 +9,10 @@ import 'package:dart2_constant/convert.dart' as convert;
 import 'package:grinder/grinder.dart';
 import 'package:meta/meta.dart';
 import 'package:node_preamble/preamble.dart' as preamble;
-import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:source_span/source_span.dart';
+
+import 'package:sass/src/util/path.dart';
 
 import 'utils.dart';
 

--- a/tool/grind/standalone.dart
+++ b/tool/grind/standalone.dart
@@ -8,8 +8,9 @@ import 'dart:io';
 import 'package:archive/archive.dart';
 import 'package:collection/collection.dart';
 import 'package:grinder/grinder.dart';
-import 'package:path/path.dart' as p;
 import 'package:http/http.dart' as http;
+
+import 'package:sass/src/util/path.dart';
 
 import 'utils.dart';
 


### PR DESCRIPTION
It's currently impossible to depend on Dart 2 from Homebrew. See
sass/homebrew-sass#5 and dart-lang/homebrew-dart#52.