### PR TITLE
Add a missing _ignoreErrors() call in StylesheetGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.1
+
+### Command-Line Interface
+
+* Don't crash when a syntax error is added to a watched file.
+
 ## 1.7.0
 
 * Emit deprecation warnings for tokens such as `#abcd` that are ambiguous

--- a/lib/src/stylesheet_graph.dart
+++ b/lib/src/stylesheet_graph.dart
@@ -122,7 +122,8 @@ class StylesheetGraph {
     _transitiveModificationTimes.clear();
 
     importCache.clearImport(canonicalUrl);
-    var stylesheet = importCache.importCanonical(node.importer, canonicalUrl);
+    var stylesheet = _ignoreErrors(
+        () => importCache.importCanonical(node.importer, canonicalUrl));
     if (stylesheet == null) {
       remove(canonicalUrl);
       return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.7.0
+version: 1.7.1-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/test/cli/shared/watch.dart
+++ b/test/cli/shared/watch.dart
@@ -118,6 +118,21 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
           .validate();
     });
 
+    test("when it gets a parse error", () async {
+      await d.file("test.scss", "a {b: c}").create();
+
+      var sass = await watch(["test.scss:out.css"]);
+      await expectLater(sass.stdout, emits('Compiled test.scss to out.css.'));
+      await expectLater(sass.stdout, _watchingForChanges);
+
+      await d.file("test.scss", "a {b: }").create();
+      await expectLater(sass.stderr, emits('Error: Expected expression.'));
+      await expectLater(sass.stderr, emitsThrough(contains('test.scss 1:7')));
+      await sass.kill();
+
+      await d.nothing("out.css").validate();
+    });
+
     group("when its dependency is deleted", () {
       test("and removes the output", () async {
         await d.file("_other.scss", "a {b: c}").create();


### PR DESCRIPTION
We weren't ignoring errors when reloading a file, which meant that
syntax errors would get surfaced in the wrong place and cause a crash.

Closes #359