### PR TITLE
Re-enable deploying to Bazel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,16 @@ jobs:
       skip_cleanup: true
       on: {tags: true}
 
+  # Deploy to Bazel.
+  - if: *deploy-if
+    env: *github-env
+    script: skip
+    deploy:
+      provider: script
+      script: pub run grinder update_bazel
+      skip_cleanup: true
+      on: {tags: true}
+
   # Deploy to Chocolatey.
   - if: *deploy-if
     env:


### PR DESCRIPTION
The @sassbot account now has full permissions to push to
bazelbuild/rules_sass.