### PR TITLE
Don't emit ANSI codes to Windows terminals that don't support them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.1
+
+* Don't emit ANSI codes to Windows terminals that don't support them.
+
 ## 1.9.0
 
 ### Node API

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -147,8 +147,9 @@ class ExecutableOptions {
   bool get indented => _ifParsed('indented') as bool;
 
   /// Whether to use ANSI terminal colors.
-  bool get color =>
-      _options.wasParsed('color') ? _options['color'] as bool : hasTerminal;
+  bool get color => _options.wasParsed('color')
+      ? _options['color'] as bool
+      : supportsAnsiEscapes;
 
   /// Whether to silence normal output.
   bool get quiet => _options['quiet'] as bool;

--- a/lib/src/io/interface.dart
+++ b/lib/src/io/interface.dart
@@ -39,6 +39,10 @@ bool get hasTerminal => false;
 /// Whether we're running as Node.JS.
 bool get isNode => false;
 
+/// Whether this process is connected to a terminal that supports ANSI escape
+/// sequences.
+bool get supportsAnsiEscapes => false;
+
 /// The current working directory.
 String get currentPath => null;
 

--- a/lib/src/io/node.dart
+++ b/lib/src/io/node.dart
@@ -228,6 +228,9 @@ bool get isWindows => _process.platform == 'win32';
 
 bool get isNode => true;
 
+// Node seems to support ANSI escapes on all terminals.
+bool get supportsAnsiEscapes => hasTerminal;
+
 String get currentPath => _process.cwd();
 
 @JS("process.stdout.isTTY")

--- a/lib/src/io/vm.dart
+++ b/lib/src/io/vm.dart
@@ -23,6 +23,15 @@ bool get hasTerminal => io.stdout.hasTerminal;
 
 bool get isNode => false;
 
+bool get supportsAnsiEscapes {
+  if (!hasTerminal) return false;
+
+  // We don't trust [io.stdout.supportsAnsiEscapes] except on Windows because it
+  // relies on the TERM environment variable which has many false negatives.
+  if (!isWindows) return true;
+  return io.stdout.supportsAnsiEscapes;
+}
+
 String get currentPath => io.Directory.current.path;
 
 String readFile(String path) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.9.0
+version: 1.9.1-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
These codes *could* be supported on all Windows terminals, but
dart-lang/sdk#28614 means that they won't actually be recognized.

Partially addresses #395