### PR TITLE
Improvements in locating the sass binary

### DIFF
--- a/package/dart-sass.sh
+++ b/package/dart-sass.sh
@@ -7,19 +7,12 @@
 # executable and a snapshot of Sass. It can be created with `pub run grinder
 # package`.
 
-follow_links() {
-  file="$1"
-  while [ -h "$file" ]; do
-    # On Mac OS, readlink -f doesn't work.
-    file="$(readlink "$file")"
-  done
-  echo "$file"
-}
+path="$(which "$0")"
+path="$(realpath "$path")"
+path="$(dirname "$path")"
 
 if [ -t 1 ]; then
   echo -e "\e[1;33mWarning\e[0;0m: The \e[1;1mdart-sass\e[0;0m executable is deprecated, use \e[1;1msass\e[0;0m instead."
 fi
 
-# Unlike $0, $BASH_SOURCE points to the absolute path of this file.
-path=`dirname "$(follow_links "$BASH_SOURCE")"`
 exec "$path/src/dart" --no-preview-dart-2 "-Dversion=SASS_VERSION" "$path/src/sass.dart.snapshot" "$@"

--- a/package/sass.sh
+++ b/package/sass.sh
@@ -7,15 +7,8 @@
 # executable and a snapshot of Sass. It can be created with `pub run grinder
 # package`.
 
-follow_links() {
-  file="$1"
-  while [ -h "$file" ]; do
-    # On Mac OS, readlink -f doesn't work.
-    file="$(readlink "$file")"
-  done
-  echo "$file"
-}
+path="$(which "$0")"
+path="$(realpath "$path")"
+path="$(dirname "$path")"
 
-# Unlike $0, $BASH_SOURCE points to the absolute path of this file.
-path=`dirname "$(follow_links "$0")"`
 exec "$path/src/dart" --no-preview-dart-2 "-Dversion=SASS_VERSION" "$path/src/sass.dart.snapshot" "$@"


### PR DESCRIPTION
I don't like adding paths to my `$PATH`. To install sass system-wide, I installed it in `/usr/local/lib/sass` and symlinked the binary to `/usr/local/bin`. The package script does not work with that approach. Also, the path canonicalization logic is simpler with realpath. As readlink's manpage states:

> Note the `realpath` command is the preferred command to use for canonicalization.

I hereby sign the Google Individual Contributor License Agreement.