### PR TITLE
Allow a BOM at the beginning of a document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@
   `\E9clair` are parsed to the same value. See
   [the proposal][identifier-escapes] for details.
 
+* Don't choke on a [byte-order mark][] at the beginning of a document when
+  running in JavaScript.
+
 [math functions]: https://drafts.csswg.org/css-values/#math-function
 [css-min-max]: https://github.com/sass/language/blob/master/accepted/min-max.md
 [media-ranges]: https://github.com/sass/language/blob/master/accepted/media-ranges.md
 [identifier-escapes]: https://github.com/sass/language/blob/master/accepted/identifier-escapes.md
+[byte-order mark]: https://en.wikipedia.org/wiki/Byte_order_mark
 
 ### Command-Line Interface
 

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -65,6 +65,8 @@ abstract class StylesheetParser extends Parser {
   Stylesheet parse() {
     return wrapSpanFormatException(() {
       var start = scanner.state;
+      // Allow a byte-order mark at the beginning of the document.
+      scanner.scanChar(0xFEFF);
       var statements = this.statements(() => _statement(root: true));
       scanner.expectDone();
       return new Stylesheet(statements, scanner.spanFrom(start));

--- a/test/cli/shared.dart
+++ b/test/cli/shared.dart
@@ -50,9 +50,7 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
     await d.file("test.scss", "\uFEFF\$color: red;").create();
 
     var sass = await runSass(["test.scss"]);
-    expect(
-        sass.stdout,
-        emitsDone);
+    expect(sass.stdout, emitsDone);
     await sass.shouldExit(0);
   });
 

--- a/test/cli/shared.dart
+++ b/test/cli/shared.dart
@@ -3,6 +3,7 @@
 // https://opensource.org/licenses/MIT.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -41,6 +42,17 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
           "  b: 3;",
           "}",
         ]));
+    await sass.shouldExit(0);
+  });
+
+  // Regression test for #437.
+  test("compiles a Sass file with a BOM to CSS", () async {
+    await d.file("test.scss", "\uFEFF\$color: red;").create();
+
+    var sass = await runSass(["test.scss"]);
+    expect(
+        sass.stdout,
+        emitsDone);
     await sass.shouldExit(0);
   });
 


### PR DESCRIPTION
This was only breaking in JS because apparently dart:io automatically
filters out BOMs.

Closes #437