### PR TITLE
Fix a new missing_return error in Dart 2.1.0-dev.0.0

### DIFF
--- a/lib/src/value/number.dart
+++ b/lib/src/value/number.dart
@@ -437,6 +437,7 @@ class SassNumber extends Value implements ext.SassNumber {
         return true;
       }, orElse: () {
         newNumerators.add(numerator);
+        return null;
       });
     }
 
@@ -449,6 +450,7 @@ class SassNumber extends Value implements ext.SassNumber {
         return true;
       }, orElse: () {
         newNumerators.add(numerator);
+        return null;
       });
     }
 

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -853,6 +853,7 @@ class _EvaluateVisitor
         });
         return null;
       });
+      return null;
     });
 
     return null;

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: cea0e92bb537cb123b876fb0f8feef54140885b9
+// Checksum: dc6fe04e787c9f74e54e0b6dcc31ba7ba95de786
 
 import 'async_evaluate.dart' show EvaluateResult;
 export 'async_evaluate.dart' show EvaluateResult;

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -850,6 +850,7 @@ class _EvaluateVisitor
         });
         return null;
       });
+      return null;
     });
 
     return null;


### PR DESCRIPTION
Dart 2.1.0-dev.0.0 raises new missing_return hints on closures assigned as arguments where the parameter return type has been specified. This cleans up those hints for dart-sass.