### PR TITLE
Remove the source map comment from the JS blob we release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Add a `SassException` type that provides information about Sass compilation
   failures.
 
+### JS API
+
+* Remove the source map comment from the compiled JS. We don't ship with the
+  source map, so this pointed to nothing.
+
 ## 1.11.0
 
 * Add support for importing plain CSS files. They can only be imported *without*

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.12.0-dev
+version: 1.12.0
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/tool/grind/npm.dart
+++ b/tool/grind/npm.dart
@@ -40,6 +40,13 @@ void _js({@required bool release}) {
   Dart2js.compile(new File('bin/sass.dart'),
       outFile: destination, extraArgs: args);
   var text = destination.readAsStringSync();
+
+  if (release) {
+    // We don't ship the source map, so remove the source map comment.
+    text = text.replaceFirst(
+        new RegExp(r"\n*//# sourceMappingURL=[^\n]+\n*$"), "\n");
+  }
+
   destination.writeAsStringSync(preamble.getPreamble() + text);
 }
 


### PR DESCRIPTION
See bazelbuild/rules_sass#44