### PR TITLE
Simplify trimming for extend

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.13.0
+version: 1.13.1-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
We were previously trimming at bath the compound selector level and
the selector list level. This now only trims at the selector list
level.

The _trim() function also took a list of selector lists, on the
idea (from Ruby Sass) that it could avoid trimming selectors generated
from the same extension that were very unlikely to be redundant. In
practice, though, the fact that we weaved together selector lists at
the compound level meant that we didn't have meaningful
known-non-redundant lists like Ruby Sass did, so this wasn't useful.

This has no behavioral effect, although it does seem to improve
performance slightly for extend-heavy stylesheets.