### PR TITLE
Parse :nth-child() selectors with extra whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.13.2
+
+* Properly parse `:nth-child()` and `:nth-last-child()` selectors with
+  whitespace around the argument.
+  
+* Don't emit extra whitespace in the arguments for `:nth-child()` and
+  `:nth-last-child()` selectors.
+
 ## 1.13.1
 
 * Allow an IE-style single equals operator in plain CSS imports.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.13.1
+version: 1.13.2
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
As a side effect of the new parse, this also removes extra whitespace
from :nth-child() selectors.

Closes #465

See https://github.com/sass/sass-spec/pull/1282