### PR TITLE
Pass --omit-implicit-checks to dart2js in release mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.13.4
+
+### Node JS
+
+* Tweak JS compilation options to substantially improve performance.
+
 ## 1.13.3
 
 * Properly generate source maps for stylesheets that emit `@charset`
@@ -38,7 +44,7 @@
 * Add a `SassException` type that provides information about Sass compilation
   failures.
 
-### JS API
+### Node JS API
 
 * Remove the source map comment from the compiled JS. We don't ship with the
   source map, so this pointed to nothing.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.13.3
+version: 1.13.4
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/tool/grind/npm.dart
+++ b/tool/grind/npm.dart
@@ -35,7 +35,7 @@ void _js({@required bool release}) {
     '-Dversion=$version',
     '-Ddart-version=$dartVersion',
   ];
-  if (release) args..add("--minify")..add("--trust-type-annotations");
+  if (release) args..add("--minify")..add("--omit-implicit-checks");
 
   Dart2js.compile(new File('bin/sass.dart'),
       outFile: destination, extraArgs: args);


### PR DESCRIPTION
Substantially addresses #113