### PR TITLE
Get rid of the dart2 test tag

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -2,7 +2,4 @@ tags:
   # Indicates tests that require Node.js.
   node:
 
-  # Indicates tests that only run on Dart 2.
-  dart2:
-
 platforms: [vm, node]

--- a/test/node_api/function_test.dart
+++ b/test/node_api/function_test.dart
@@ -327,10 +327,7 @@ void main() {
         expect(error.toString(), contains('must be a Sass value type'));
       });
     });
-  },
-      // render() and renderError() use Zone.bindBinaryCallbackGuarded(), which
-      // is only available on Dart 2.
-      tags: "dart2");
+  });
 
   // Node Sass currently doesn't provide any representation of first-class
   // functions, but they shouldn't crash or be corrupted.

--- a/test/node_api/importer_test.dart
+++ b/test/node_api/importer_test.dart
@@ -3,7 +3,7 @@
 // https://opensource.org/licenses/MIT.
 
 @TestOn('node')
-@Tags(const ['node', 'dart2'])
+@Tags(const ['node'])
 
 import 'dart:async';
 
@@ -661,8 +661,5 @@ void main() {
                     "  stdin 1:9  root stylesheet")));
       });
     });
-  },
-      // render() and renderError() use Zone.bindBinaryCallbackGuarded(), which
-      // is only available on Dart 2.
-      tags: "dart2");
+  });
 }

--- a/test/node_api/source_map_test.dart
+++ b/test/node_api/source_map_test.dart
@@ -3,7 +3,7 @@
 // https://opensource.org/licenses/MIT.
 
 @TestOn('node')
-@Tags(const ['node', 'dart2'])
+@Tags(const ['node'])
 
 import 'dart:convert';
 

--- a/test/node_api_test.dart
+++ b/test/node_api_test.dart
@@ -460,8 +460,5 @@ a {
           equals("Error: Expected expression.\n"
               "  $sassPath 1:7  root stylesheet"));
     });
-  },
-      // render() and renderError() use Zone.bindBinaryCallbackGuarded(), which
-      // is only available on Dart 2.
-      tags: "dart2");
+  });
 }

--- a/tool/travis/test.sh
+++ b/tool/travis/test.sh
@@ -15,18 +15,10 @@ elif [ "$TASK" = format ]; then
 elif [ "$TASK" = tests ]; then
   if [ -z "$NODE_VERSION" ]; then
     echo "${bold}Running Dart tests against $(dart --version &> /dev/stdout).$none"
-    if [ "$DART_CHANNEL" = dev ]; then
-      pub run test -p vm -x node
-    else
-      pub run test -p vm -x dart2 -x node
-    fi
+    pub run test -p vm -x node
   else
     echo "${bold}Running Node tests against Node $(node --version).$none"
-    if [ "$DART_CHANNEL" = dev ]; then
-      pub run test -j 2 -t node
-    else
-      pub run test -j 2 -x dart2 -t node
-    fi
+    pub run test -j 2 -t node
   fi;
 else
   echo "${bold}Running sass-spec against $(dart --version &> /dev/stdout).$none"


### PR DESCRIPTION
We're only ever running tests under Dart 2 now, so it's irrelevant
whether they're Dart 2-only.