### PR TITLE
Pass the --fast-startup flag to dart2js

### DIFF
--- a/tool/grind/npm.dart
+++ b/tool/grind/npm.dart
@@ -35,7 +35,9 @@ void _js({@required bool release}) {
     '-Dversion=$version',
     '-Ddart-version=$dartVersion',
   ];
-  if (release) args..add("--minify")..add("--omit-implicit-checks");
+  if (release) {
+    args..add("--minify")..add("--omit-implicit-checks")..add("--fast-startup");
+  }
 
   Dart2js.compile(new File('bin/sass.dart'),
       outFile: destination, extraArgs: args);


### PR DESCRIPTION
My benchmarks indicate a small but reliable improvement in startup
time with this option.