### PR TITLE
Prettify URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.14.1
+
+### Command-Line Interface
+
+* Print more readable paths in `--watch` mode.
+
 ## 1.14.0
 
 ### BREAKING CHANGE

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -79,6 +79,7 @@ Future compileStylesheet(ExecutableOptions options, StylesheetGraph graph,
   if (options.color) buffer.write('\u001b[32m');
 
   var sourceName = source == null ? 'stdin' : p.prettyUri(p.toUri(source));
+  destination = p.prettyUri(destination);
   buffer.write('Compiled $sourceName to $destination.');
   if (options.color) buffer.write('\u001b[0m');
   print(buffer);

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -79,7 +79,7 @@ Future compileStylesheet(ExecutableOptions options, StylesheetGraph graph,
   if (options.color) buffer.write('\u001b[32m');
 
   var sourceName = source == null ? 'stdin' : p.prettyUri(p.toUri(source));
-  var destinationName = p.prettyUri(destination);
+  var destinationName = p.prettyUri(p.toUri(destination));
   buffer.write('Compiled $sourceName to $destinationName.');
   if (options.color) buffer.write('\u001b[0m');
   print(buffer);

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -79,8 +79,8 @@ Future compileStylesheet(ExecutableOptions options, StylesheetGraph graph,
   if (options.color) buffer.write('\u001b[32m');
 
   var sourceName = source == null ? 'stdin' : p.prettyUri(p.toUri(source));
-  destination = p.prettyUri(destination);
-  buffer.write('Compiled $sourceName to $destination.');
+  var destinationName = p.prettyUri(destination);
+  buffer.write('Compiled $sourceName to $destinationName.');
   if (options.color) buffer.write('\u001b[0m');
   print(buffer);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.14.0
+version: 1.14.1-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
This issue closes #464.
The changes I have made include prettifying the destination variable with this: `p.prettyUri(destination)` at line 82. In the relevant issue, I raised two questions:
 
> - use backslashes OR forward slashes
> - include the WHOLE path (including the ./) or leaving small "prefixes" out

- To answer the first prompt. In order not to confuse anyone who is used to current system, I have not made any changes. In Windows it will still print `\` and other OSes will print `/`.
- To answer the second prompt, I have left the small prefixes out. This is to ensure that nested directories with lots of `../../` and other crowded file prefixes won't clog up the screen. One disadvantage is for people who have many of the same filenames, not knowing which file has been compiled, however that should really be a problem for more disorganised systems (no saltiness).
@nex3 