### PR TITLE
Properly parse escaped digits at the beginning of identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.14.1
 
+* Canonicalize escaped digits at the beginning of identifiers as hex escapes.
+
 * Properly parse property declarations that are both *in* content blocks and
   written *after* content blocks.
 

--- a/lib/src/parse/parser.dart
+++ b/lib/src/parse/parser.dart
@@ -395,7 +395,9 @@ abstract class Parser {
 
     if (identifierStart ? isNameStart(value) : isName(value)) {
       return new String.fromCharCode(value);
-    } else if (value < 0x1F || value == 0x7F || (identifierStart && isDigit(value))) {
+    } else if (value < 0x1F ||
+        value == 0x7F ||
+        (identifierStart && isDigit(value))) {
       var buffer = new StringBuffer()..writeCharCode($backslash);
       if (value > 0xF) buffer.writeCharCode(hexCharFor(value >> 4));
       buffer.writeCharCode(hexCharFor(value & 0xF));

--- a/lib/src/parse/parser.dart
+++ b/lib/src/parse/parser.dart
@@ -395,7 +395,7 @@ abstract class Parser {
 
     if (identifierStart ? isNameStart(value) : isName(value)) {
       return new String.fromCharCode(value);
-    } else if (value < 0x1F || value == 0x7F) {
+    } else if (value < 0x1F || value == 0x7F || (identifierStart && isDigit(value))) {
       var buffer = new StringBuffer()..writeCharCode($backslash);
       if (value > 0xF) buffer.writeCharCode(hexCharFor(value >> 4));
       buffer.writeCharCode(hexCharFor(value & 0xF));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.14.1-dev
+version: 1.14.1
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
See sass/sass#1542
Closes sass/dart-sass#485

See sass/sass-spec#1286