### PR TITLE
Properly escape U+001F INFORMATION SEPARATOR ONE in unquoted strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.14.2
+
+* Properly escape U+001F INFORMATION SEPARATOR ONE in unquoted strings.
+
 ## 1.14.1
 
 * Canonicalize escaped digits at the beginning of identifiers as hex escapes.

--- a/lib/src/parse/parser.dart
+++ b/lib/src/parse/parser.dart
@@ -395,7 +395,7 @@ abstract class Parser {
 
     if (identifierStart ? isNameStart(value) : isName(value)) {
       return new String.fromCharCode(value);
-    } else if (value < 0x1F ||
+    } else if (value <= 0x1F ||
         value == 0x7F ||
         (identifierStart && isDigit(value))) {
       var buffer = new StringBuffer()..writeCharCode($backslash);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.14.1
+version: 1.14.2
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,6 @@
 name: sass
-version: 1.14.2
+version: 1.14.2-dev
+
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
See sass/sass-spec#1288