### PR TITLE
Fix an import-resolution bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 * Don't crash when using `@debug` in a stylesheet passed on standard input.
 
+### Dart API
+
+* `AsyncImporter.canonicalize()` and `Importer.canonicalize()` must now return
+  absolute URLs. Relative URLs are still supported, but are deprecated and will
+  be removed in a future release.
+
 ## 1.14.1
 
 * Canonicalize escaped digits at the beginning of identifiers as hex escapes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.14.2
+
+* Fix a bug where loading the same stylesheet from two different import paths
+  could cause its imports to fail to resolve.
+
 ## 1.14.1
 
 * Canonicalize escaped digits at the beginning of identifiers as hex escapes.

--- a/lib/src/async_import_cache.dart
+++ b/lib/src/async_import_cache.dart
@@ -115,7 +115,7 @@ class AsyncImportCache {
 
   /// Calls [importer.canonicalize] and prints a deprecation warning if it
   /// returns a relative URL.
-  void _canonicalize(AsyncImporter importer, Uri url) async {
+  Future<Uri> _canonicalize(AsyncImporter importer, Uri url) async {
     var result = await importer.canonicalize(url);
     if (result?.scheme == '') {
       _logger.warn("""

--- a/lib/src/async_import_cache.dart
+++ b/lib/src/async_import_cache.dart
@@ -180,12 +180,7 @@ Relative canonical URLs are deprecated and will eventually be disallowed.
             .where((tuple) => tuple?.item2 == canonicalUrl)
             .map((tuple) => tuple.item3),
         (url) => url.path.length);
-    if (url == null) {
-      if (_importCache.containsKey(canonicalUrl)) return canonicalUrl;
-
-      throw new StateError(
-          "URL $canonicalUrl hasn't been loaded by this import cache.");
-    }
+    if (url == null) return canonicalUrl;
 
     // Use the canonicalized basename so that we display e.g.
     // package:example/_example.scss rather than package:example/example in

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_import_cache.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: ceb41be9992077bf36e5797c5e4a8ee3838e1bdf
+// Checksum: 57c42546fb8e0b68e29ea841ba106ee99127bede
 
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
@@ -182,12 +182,7 @@ Relative canonical URLs are deprecated and will eventually be disallowed.
             .where((tuple) => tuple?.item2 == canonicalUrl)
             .map((tuple) => tuple.item3),
         (url) => url.path.length);
-    if (url == null) {
-      if (_importCache.containsKey(canonicalUrl)) return canonicalUrl;
-
-      throw new StateError(
-          "URL $canonicalUrl hasn't been loaded by this import cache.");
-    }
+    if (url == null) return canonicalUrl;
 
     // Use the canonicalized basename so that we display e.g.
     // package:example/_example.scss rather than package:example/example in

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -173,8 +173,8 @@ Relative canonical URLs are deprecated and will eventually be disallowed.
 
   /// Return a human-friendly URL for [canonicalUrl] to use in a stack trace.
   ///
-  /// Throws a [StateError] if the stylesheet for [canonicalUrl] hasn't been
-  /// loaded by this cache.
+  /// If the stylesheet for [canonicalUrl] hasn't been loaded by this cache,
+  /// returns it as-is.
   Uri humanize(Uri canonicalUrl) {
     // Display the URL with the shortest path length.
     var url = minBy(
@@ -182,12 +182,7 @@ Relative canonical URLs are deprecated and will eventually be disallowed.
             .where((tuple) => tuple?.item2 == canonicalUrl)
             .map((tuple) => tuple.item3),
         (url) => url.path.length);
-    if (url == null) {
-      if (_importCache.containsKey(canonicalUrl)) return canonicalUrl;
-
-      throw new StateError(
-          "URL $canonicalUrl hasn't been loaded by this import cache.");
-    }
+    if (url == null) return canonicalUrl;
 
     // Use the canonicalized basename so that we display e.g.
     // package:example/_example.scss rather than package:example/example in

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_import_cache.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 09ad5f694ab3b542f0a961502906e8deb67ae229
+// Checksum: ceb41be9992077bf36e5797c5e4a8ee3838e1bdf
 
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
@@ -118,7 +118,7 @@ class ImportCache {
 
   /// Calls [importer.canonicalize] and prints a deprecation warning if it
   /// returns a relative URL.
-  void _canonicalize(Importer importer, Uri url) {
+  Uri _canonicalize(Importer importer, Uri url) {
     var result = importer.canonicalize(url);
     if (result?.scheme == '') {
       _logger.warn("""
@@ -173,8 +173,8 @@ Relative canonical URLs are deprecated and will eventually be disallowed.
 
   /// Return a human-friendly URL for [canonicalUrl] to use in a stack trace.
   ///
-  /// If the stylesheet for [canonicalUrl] hasn't been loaded by this cache,
-  /// returns it as-is.
+  /// Throws a [StateError] if the stylesheet for [canonicalUrl] hasn't been
+  /// loaded by this cache.
   Uri humanize(Uri canonicalUrl) {
     // Display the URL with the shortest path length.
     var url = minBy(
@@ -182,7 +182,12 @@ Relative canonical URLs are deprecated and will eventually be disallowed.
             .where((tuple) => tuple?.item2 == canonicalUrl)
             .map((tuple) => tuple.item3),
         (url) => url.path.length);
-    if (url == null) return canonicalUrl;
+    if (url == null) {
+      if (_importCache.containsKey(canonicalUrl)) return canonicalUrl;
+
+      throw new StateError(
+          "URL $canonicalUrl hasn't been loaded by this import cache.");
+    }
 
     // Use the canonicalized basename so that we display e.g.
     // package:example/_example.scss rather than package:example/example in

--- a/lib/src/importer/async.dart
+++ b/lib/src/importer/async.dart
@@ -22,6 +22,10 @@ import 'result.dart';
 abstract class AsyncImporter {
   /// If [url] is recognized by this importer, returns its canonical format.
   ///
+  /// Note that canonical URLs *must* be absolute, including a scheme. Returning
+  /// `file:` URLs is encouraged if the imported stylesheet comes from a file on
+  /// disk.
+  ///
   /// If Sass has already loaded a stylesheet with the returned canonical URL,
   /// it re-uses the existing parse tree. This means that importers **must
   /// ensure** that the same canonical URL always refers to the same stylesheet,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -138,8 +138,11 @@ bool listEquals<T>(List<T> list1, List<T> list2) =>
 int listHash(List list) => const ListEquality().hash(list);
 
 /// Returns a stack frame for the given [span] with the given [member] name.
-Frame frameForSpan(SourceSpan span, String member) => new Frame(
-    span.sourceUrl ?? _noSourceUrl,
+///
+/// By default, the frame's URL is set to `span.sourceUrl`. However, if [url] is
+/// passed, it's used instead.
+Frame frameForSpan(SourceSpan span, String member, {Uri url}) => new Frame(
+    url ?? span.sourceUrl ?? _noSourceUrl,
     span.start.line + 1,
     span.start.column + 1,
     member);

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -1805,7 +1805,7 @@ class _EvaluateVisitor
   /// Runs [callback] with the new stack.
   Future<T> _withStackFrame<T>(
       String member, FileSpan span, Future<T> callback()) async {
-    _stack.add(new Tuple2(member, span));
+    _stack.add(new Tuple2(_member, span));
     var oldMember = _member;
     _member = member;
     var result = await callback();

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 11e77e1df658d69b4ecab6447225f79c358db535
+// Checksum: fb47d76b7f9b646926e3973ba73f6634af256279
 
 import 'async_evaluate.dart' show EvaluateResult;
 export 'async_evaluate.dart' show EvaluateResult;
@@ -193,7 +193,10 @@ class _EvaluateVisitor
 
   /// The dynamic call stack representing function invocations, mixin
   /// invocations, and imports surrounding the current context.
-  final _stack = <Frame>[];
+  ///
+  /// Each member is a tuple of the span where the stack trace starts and the
+  /// name of the member being invoked.
+  final _stack = <Tuple2<String, FileSpan>>[];
 
   /// Whether we're running in Node Sass-compatibility mode.
   bool get _asNodeSass => _nodeImporter != null;
@@ -773,8 +776,7 @@ class _EvaluateVisitor
       }
     } on SassException catch (error) {
       var frames = error.trace.frames.toList()
-        ..add(_stackFrame(import.span))
-        ..addAll(_stack.toList());
+        ..addAll(_stackTrace(import.span).frames);
       throw new SassRuntimeException(
           error.message, error.span, new Trace(frames));
     } catch (error) {
@@ -1774,7 +1776,7 @@ class _EvaluateVisitor
   ///
   /// Runs [callback] with the new stack.
   T _withStackFrame<T>(String member, FileSpan span, T callback()) {
-    _stack.add(_stackFrame(span));
+    _stack.add(new Tuple2(member, span));
     var oldMember = _member;
     _member = member;
     var result = callback();
@@ -1783,15 +1785,21 @@ class _EvaluateVisitor
     return result;
   }
 
-  /// Creates a new stack frame with location information from [span] and
-  /// [_member].
-  Frame _stackFrame(FileSpan span) => frameForSpan(span, _member);
+  /// Creates a new stack frame with location information from [member] and
+  /// [span].
+  Frame _stackFrame(String member, FileSpan span) => frameForSpan(span, member,
+      url: span.sourceUrl == null
+          ? null
+          : _importCache.humanize(span.sourceUrl));
 
   /// Returns a stack trace at the current point.
   ///
   /// [span] is the current location, used for the bottom-most stack frame.
   Trace _stackTrace(FileSpan span) {
-    var frames = _stack.toList()..add(_stackFrame(span));
+    var frames = _stack
+        .map((tuple) => _stackFrame(tuple.item1, tuple.item2))
+        .toList()
+          ..add(_stackFrame(_member, span));
     return new Trace(frames.reversed);
   }
 

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: fb47d76b7f9b646926e3973ba73f6634af256279
+// Checksum: f20e0967bae462f7d1728053fa0a41c09bcc0e03
 
 import 'async_evaluate.dart' show EvaluateResult;
 export 'async_evaluate.dart' show EvaluateResult;

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -1776,7 +1776,7 @@ class _EvaluateVisitor
   ///
   /// Runs [callback] with the new stack.
   T _withStackFrame<T>(String member, FileSpan span, T callback()) {
-    _stack.add(new Tuple2(member, span));
+    _stack.add(new Tuple2(_member, span));
     var oldMember = _member;
     _member = member;
     var result = callback();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.14.1
+version: 1.14.2
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
When a stylesheet is imported, the parsed stylesheet object is cached
based on its canonical URL. However, the stylesheet.span.sourceUrl was
based on the text of the import that was used to load that stylesheet.
The idea was to make the source URL in stack traces look nicer, but it
meant that relative URLs could be resolved based on the old importer's
URL before being sent to the new importer, which caused bugs.

Now stylesheet.span.sourceUrl is always the canonical URL of the
stylesheet, and thus safe to cache. We then use the import cache to
convert the canonical URL to a human-friendly URL at the point at
which we generate stack traces.