### PR TITLE
Remove space around combinators in compressed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.14.3
+
+* When running in compressed mode, remove spaces around combinators in complex
+selectors, so a selector like `a > b` is output as `a>b`.
+
 ## 1.14.2
 
 * Fix a bug where loading the same stylesheet from two different import paths
@@ -59,7 +64,7 @@ deprecation period.
 
 * Properly parse `:nth-child()` and `:nth-last-child()` selectors with
   whitespace around the argument.
-  
+
 * Don't emit extra whitespace in the arguments for `:nth-child()` and
   `:nth-last-child()` selectors.
 

--- a/lib/src/visitor/serialize.dart
+++ b/lib/src/visitor/serialize.dart
@@ -934,22 +934,25 @@ class _SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisitor {
   }
 
   void visitComplexSelector(ComplexSelector complex) {
-    omitSpacesAround(ComplexSelectorComponent component) {
-      return _isCompressed && component is Combinator;
-    }
-
-    bool spaceAfterLast = false;
+    ComplexSelectorComponent lastComponent;
     for (var component in complex.components) {
-      if (spaceAfterLast && !omitSpacesAround(component)) _buffer.write(" ");
-
+      if (lastComponent != null &&
+          !_omitSpacesAround(lastComponent) &&
+          !_omitSpacesAround(component)) {
+        _buffer.write(" ");
+      }
       if (component is CompoundSelector) {
         visitCompoundSelector(component);
       } else {
         _buffer.write(component);
       }
-
-      spaceAfterLast = !omitSpacesAround(component);
+      lastComponent = component;
     }
+  }
+
+  /// When [_style] is [OutputStyle.compressed], omit spaces around combinators.
+  bool _omitSpacesAround(ComplexSelectorComponent component) {
+    return _isCompressed && component is Combinator;
   }
 
   void visitCompoundSelector(CompoundSelector compound) {

--- a/lib/src/visitor/serialize.dart
+++ b/lib/src/visitor/serialize.dart
@@ -934,13 +934,22 @@ class _SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisitor {
   }
 
   void visitComplexSelector(ComplexSelector complex) {
-    _writeBetween(complex.components, " ", (component) {
+    omitSpacesAround(ComplexSelectorComponent component) {
+      return _isCompressed && component is Combinator;
+    }
+
+    bool spaceAfterLast = false;
+    for (var component in complex.components) {
+      if (spaceAfterLast && !omitSpacesAround(component)) _buffer.write(" ");
+
       if (component is CompoundSelector) {
         visitCompoundSelector(component);
       } else {
         _buffer.write(component);
       }
-    });
+
+      spaceAfterLast = !omitSpacesAround(component);
+    }
   }
 
   void visitCompoundSelector(CompoundSelector compound) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.14.2
+version: 1.14.3-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/test/compressed_test.dart
+++ b/test/compressed_test.dart
@@ -25,6 +25,12 @@ void main() {
         expect(_compile("a,\nb,\n.c {x: y}"), equals("a,b,.c{x:y}"));
       });
 
+      test("removes whitespace around combinators", () {
+        expect(_compile("a > b {x: y}"), equals("a>b{x:y}"));
+        expect(_compile("a + b {x: y}"), equals("a+b{x:y}"));
+        expect(_compile("a ~ b {x: y}"), equals("a~b{x:y}"));
+      });
+
       group("in prefixed pseudos", () {
         test("preserves whitespace", () {
           expect(_compile("a:nth-child(2n of b) {x: y}"),


### PR DESCRIPTION
Fixes #285.

Complex selectors like "a > b" will now be output as "a>b" in compressed mode.