### PR TITLE
Properly escape U+0009 CHARACTER TABULATION in unquoted strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.14.4
+
+* Properly escape U+0009 CHARACTER TABULATION in unquoted strings.
+
 ## 1.14.3
 
 * Treat `:before`, `:after`, `:first-line`, and `:first-letter` as

--- a/lib/src/parse/parser.dart
+++ b/lib/src/parse/parser.dart
@@ -395,7 +395,7 @@ abstract class Parser {
 
     if (identifierStart ? isNameStart(value) : isName(value)) {
       return new String.fromCharCode(value);
-    } else if (value <= 0x1F ||
+    } else if ((value <= 0x1F && value != $tab) ||
         value == 0x7F ||
         (identifierStart && isDigit(value))) {
       var buffer = new StringBuffer()..writeCharCode($backslash);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.14.3
+version: 1.14.4
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
See https://github.com/sass/sass-spec/pull/1294