### PR TITLE
Always include the error location in JS error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.14.5
+
+### JavaScript API
+
+* Always include the error location in error messages.
+
 ## 1.14.4
 
 * Properly escape U+0009 CHARACTER TABULATION in unquoted strings.

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -169,7 +169,7 @@ RenderResult _renderSync(RenderOptions options) {
 /// Converts an exception to a [JSError].
 JSError _wrapException(exception) {
   if (exception is SassException) {
-    return _newRenderError(exception.toString(),
+    return _newRenderError(exception.toString().replaceFirst("Error: ", ""),
         line: exception.span.start.line + 1,
         column: exception.span.start.column + 1,
         file: exception.span.sourceUrl == null
@@ -383,7 +383,7 @@ bool _enableSourceMaps(RenderOptions options) =>
 JSError _newRenderError(String message,
     {int line, int column, String file, int status}) {
   var error = new JSError(message);
-  setProperty(error, 'formatted', message);
+  setProperty(error, 'formatted', 'Error: $message');
   if (line != null) setProperty(error, 'line', line);
   if (column != null) setProperty(error, 'column', column);
   if (file != null) setProperty(error, 'file', file);

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -169,20 +169,7 @@ RenderResult _renderSync(RenderOptions options) {
 /// Converts an exception to a [JSError].
 JSError _wrapException(exception) {
   if (exception is SassException) {
-    var trace = exception is SassRuntimeException
-        ? "\n" +
-            exception.trace
-                .toString()
-                .trimRight()
-                .split("\n")
-                .map((frame) => "  $frame")
-                .join("\n")
-        : "\n  ${p.prettyUri(exception.span.sourceUrl ?? '-')} "
-        "${exception.span.start.line + 1}:${exception.span.start.column + 1}  "
-        "root stylesheet";
-
-    return _newRenderError(exception.message + trace,
-        formatted: exception.toString(),
+    return _newRenderError(exception.toString(),
         line: exception.span.start.line + 1,
         column: exception.span.start.column + 1,
         file: exception.span.sourceUrl == null
@@ -394,9 +381,9 @@ bool _enableSourceMaps(RenderOptions options) =>
 /// Creates a [JSError] with the given fields added to it so it acts like a Node
 /// Sass error.
 JSError _newRenderError(String message,
-    {String formatted, int line, int column, String file, int status}) {
+    {int line, int column, String file, int status}) {
   var error = new JSError(message);
-  if (formatted != null) setProperty(error, 'formatted', formatted);
+  setProperty(error, 'formatted', message);
   if (line != null) setProperty(error, 'line', line);
   if (column != null) setProperty(error, 'column', column);
   if (file != null) setProperty(error, 'file', file);

--- a/test/node_api/importer_test.dart
+++ b/test/node_api/importer_test.dart
@@ -501,6 +501,8 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
+              "@import 'foo'\n"
+              "        ^^^^^\n"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -512,6 +514,8 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("oh no\n"
+              "@import 'foo'\n"
+              "        ^^^^^\n"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -524,6 +528,8 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
+              "@import 'foo'\n"
+              "        ^^^^^\n"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -533,6 +539,8 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
+              "@import 'foo'\n"
+              "        ^^^^^\n"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -542,6 +550,8 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
+              "@import 'foo'\n"
+              "        ^^^^^\n"
               "  stdin 1:9  root stylesheet"));
     });
   });
@@ -569,6 +579,8 @@ void main() {
                 });
               }))),
           completion(toStringAndMessageEqual("oh no\n"
+              "@import 'foo'\n"
+              "        ^^^^^\n"
               "  stdin 1:9  root stylesheet")));
     });
 
@@ -588,6 +600,8 @@ void main() {
               importer: allowInterop((_, __, ___) => jsNull))),
           completion(
               toStringAndMessageEqual("Can't find stylesheet to import.\n"
+                  "@import 'foo'\n"
+                  "        ^^^^^\n"
                   "  stdin 1:9  root stylesheet")));
     });
 
@@ -647,6 +661,8 @@ void main() {
                 }),
                 fiber: fiber)),
             completion(toStringAndMessageEqual("oh no\n"
+                "@import 'foo'\n"
+                "        ^^^^^\n"
                 "  stdin 1:9  root stylesheet")));
       });
 
@@ -658,6 +674,8 @@ void main() {
                 fiber: fiber)),
             completion(
                 toStringAndMessageEqual("Can't find stylesheet to import.\n"
+                    "@import 'foo'\n"
+                    "        ^^^^^\n"
                     "  stdin 1:9  root stylesheet")));
       });
     });

--- a/test/node_api/utils.dart
+++ b/test/node_api/utils.dart
@@ -32,6 +32,7 @@ void useSandbox() {
 Matcher toStringAndMessageEqual(String text) => predicate((error) {
       expect(error.toString(), equals("Error: $text"));
       expect(error.message, equals(text));
+      expect(error.formatted, equals("Error: $text"));
       return true;
     });
 

--- a/test/node_api_test.dart
+++ b/test/node_api_test.dart
@@ -242,6 +242,8 @@ a {
         expect(
             error.toString(),
             equals("Error: Expected expression.\n"
+                "x {y: }\n"
+                "      ^\n"
                 "  $sassPath 1:7  root stylesheet"));
       });
     });
@@ -313,16 +315,9 @@ a {
           expect(
               error,
               toStringAndMessageEqual("Expected expression.\n"
+                  "a {b: }\n"
+                  "      ^\n"
                   "  $sassPath 1:7  root stylesheet"));
-        });
-
-        test("has a useful formatted message", () async {
-          expect(
-              error.formatted,
-              "Error: Expected expression.\n"
-              "a {b: }\n"
-              "      ^\n"
-              "  $sassPath 1:7  root stylesheet");
         });
 
         test("sets the line, column, and filename", () {
@@ -345,16 +340,9 @@ a {
           expect(
               error,
               toStringAndMessageEqual("Expected expression.\n"
+                  "a {b: }\n"
+                  "      ^\n"
                   "  stdin 1:7  root stylesheet"));
-        });
-
-        test("has a useful formatted message", () {
-          expect(
-              error.formatted,
-              "Error: Expected expression.\n"
-              "a {b: }\n"
-              "      ^\n"
-              "  stdin 1:7  root stylesheet");
         });
 
         test("sets the line, column, and filename", () {
@@ -374,16 +362,9 @@ a {
           expect(
               error,
               toStringAndMessageEqual('Undefined operation "1 % a".\n'
+                  'a {b: 1 % a}\n'
+                  '      ^^^^^\n'
                   '  $sassPath 1:7  root stylesheet'));
-        });
-
-        test("has a useful formatted message", () async {
-          expect(
-              error.formatted,
-              'Error: Undefined operation "1 % a".\n'
-              'a {b: 1 % a}\n'
-              '      ^^^^^\n'
-              '  $sassPath 1:7  root stylesheet');
         });
 
         test("sets the line, column, and filename", () {
@@ -402,16 +383,9 @@ a {
           expect(
               error,
               toStringAndMessageEqual('Undefined operation "1 % a".\n'
+                  'a {b: 1 % a}\n'
+                  '      ^^^^^\n'
                   '  stdin 1:7  root stylesheet'));
-        });
-
-        test("has a useful formatted message", () {
-          expect(
-              error.formatted,
-              'Error: Undefined operation "1 % a".\n'
-              'a {b: 1 % a}\n'
-              '      ^^^^^\n'
-              '  stdin 1:7  root stylesheet');
         });
 
         test("sets the line, column, and filename", () {
@@ -458,6 +432,8 @@ a {
       expect(
           error.toString(),
           equals("Error: Expected expression.\n"
+              "a {b: }\n"
+              "      ^\n"
               "  $sassPath 1:7  root stylesheet"));
     });
   });


### PR DESCRIPTION
I was trying to match Node Sass's behavior by having Error.formatted
property have more detail than Error.message, but our errors rely on
source snippets for context so this just ended up making them
confusing.