### PR TITLE
Remove the ignoreCase flag from scanIdentifier and expectIdentifier

### DIFF
--- a/lib/src/parse/keyframe_selector.dart
+++ b/lib/src/parse/keyframe_selector.dart
@@ -57,7 +57,7 @@ class KeyframeSelectorParser extends Parser {
       }
     }
 
-    if (scanIdentifier("e", ignoreCase: true)) {
+    if (scanIdentifier("e")) {
       buffer.write(scanner.readChar());
       var next = scanner.peekChar();
       if (next == $plus || next == $minus) buffer.write(scanner.readChar());

--- a/lib/src/parse/media_query.dart
+++ b/lib/src/parse/media_query.dart
@@ -49,7 +49,7 @@ class MediaQueryParser extends Parser {
       } else {
         modifier = identifier1;
         type = identifier2;
-        if (scanIdentifier("and", ignoreCase: true)) {
+        if (scanIdentifier("and")) {
           // For example, "@media only screen and ..."
           whitespace();
         } else {
@@ -69,7 +69,7 @@ class MediaQueryParser extends Parser {
       features.add("(${declarationValue()})");
       scanner.expectChar($rparen);
       whitespace();
-    } while (scanIdentifier("and", ignoreCase: true));
+    } while (scanIdentifier("and"));
 
     if (type == null) {
       return new CssMediaQuery.condition(features);

--- a/lib/src/parse/parser.dart
+++ b/lib/src/parse/parser.dart
@@ -315,7 +315,7 @@ abstract class Parser {
     // Most changes here should be mirrored there.
 
     var start = scanner.state;
-    if (!scanIdentifier("url", ignoreCase: true)) return null;
+    if (!scanIdentifier("url")) return null;
 
     if (!scanner.scanChar($lparen)) {
       scanner.state = start;
@@ -537,10 +537,8 @@ abstract class Parser {
   }
 
   /// Consumes an identifier if its name exactly matches [text].
-  ///
-  /// If [ignoreCase] is `true`, does a case-insensitive match.
   @protected
-  bool scanIdentifier(String text, {bool ignoreCase: false}) {
+  bool scanIdentifier(String text) {
     if (!lookingAtIdentifier()) return false;
 
     var start = scanner.state;
@@ -557,10 +555,8 @@ abstract class Parser {
   }
 
   /// Consumes an identifier and asserts that its name exactly matches [text].
-  ///
-  /// If [ignoreCase] is `true`, does a case-insensitive match.
   @protected
-  void expectIdentifier(String text, {String name, bool ignoreCase: false}) {
+  void expectIdentifier(String text, {String name}) {
     name ??= '"$text"';
 
     var start = scanner.position;

--- a/lib/src/parse/sass.dart
+++ b/lib/src/parse/sass.dart
@@ -74,7 +74,7 @@ class SassParser extends StylesheetParser {
       case $u:
       case $U:
         var start = scanner.state;
-        if (scanIdentifier("url", ignoreCase: true)) {
+        if (scanIdentifier("url")) {
           if (scanner.scanChar($lparen)) {
             scanner.state = start;
             return super.importArgument();

--- a/lib/src/parse/selector.dart
+++ b/lib/src/parse/selector.dart
@@ -305,7 +305,7 @@ class SelectorParser extends Parser {
       argument = _aNPlusB();
       whitespace();
       if (isWhitespace(scanner.peekChar(-1)) && scanner.peekChar() != $rparen) {
-        expectIdentifier("of", ignoreCase: true);
+        expectIdentifier("of");
         argument += " of";
         whitespace();
 
@@ -328,12 +328,12 @@ class SelectorParser extends Parser {
     switch (scanner.peekChar()) {
       case $e:
       case $E:
-        expectIdentifier("even", ignoreCase: true);
+        expectIdentifier("even");
         return "even";
 
       case $o:
       case $O:
-        expectIdentifier("odd", ignoreCase: true);
+        expectIdentifier("odd");
         return "odd";
 
       case $plus:

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -855,10 +855,10 @@ abstract class StylesheetParser extends Parser {
   /// Returns `null` if neither type of query can be found.
   Tuple2<SupportsCondition, Interpolation> tryImportQueries() {
     SupportsCondition supports;
-    if (scanIdentifier("supports", ignoreCase: true)) {
+    if (scanIdentifier("supports")) {
       scanner.expectChar($lparen);
       var start = scanner.state;
-      if (scanIdentifier("not", ignoreCase: true)) {
+      if (scanIdentifier("not")) {
         whitespace();
         supports = new SupportsNegation(
             _supportsConditionInParens(), scanner.spanFrom(start));
@@ -1923,7 +1923,7 @@ relase. For details, see http://bit.ly/moz-document.
     var start = scanner.state;
     scanner.readChar();
     whitespace();
-    expectIdentifier("important", ignoreCase: true);
+    expectIdentifier("important");
     return new StringExpression.plain("!important", scanner.spanFrom(start));
   }
 
@@ -2380,7 +2380,7 @@ relase. For details, see http://bit.ly/moz-document.
   ///
   /// Returns whether such a function could be consumed.
   bool _tryMinMaxFunction(InterpolationBuffer buffer, String name) {
-    if (!scanIdentifier(name, ignoreCase: true)) return false;
+    if (!scanIdentifier(name)) return false;
     if (!scanner.scanChar($lparen)) return false;
     buffer
       ..write(name)
@@ -2445,7 +2445,7 @@ relase. For details, see http://bit.ly/moz-document.
   @protected
   Expression dynamicUrl() {
     var start = scanner.state;
-    expectIdentifier("url", ignoreCase: true);
+    expectIdentifier("url");
     var contents = _tryUrlContents(start);
     if (contents != null) return new StringExpression(contents);
 
@@ -2524,7 +2524,7 @@ relase. For details, see http://bit.ly/moz-document.
         case $u:
         case $U:
           var beforeUrl = scanner.state;
-          if (!scanIdentifier("url", ignoreCase: true)) {
+          if (!scanIdentifier("url")) {
             buffer.writeCharCode(scanner.readChar());
             break;
           }
@@ -2646,7 +2646,7 @@ relase. For details, see http://bit.ly/moz-document.
         case $u:
         case $U:
           var beforeUrl = scanner.state;
-          if (!scanIdentifier("url", ignoreCase: true)) {
+          if (!scanIdentifier("url")) {
             buffer.writeCharCode(scanner.readChar());
             wroteNewline = false;
             break;
@@ -2778,7 +2778,7 @@ relase. For details, see http://bit.ly/moz-document.
         buffer.write(" and ");
       } else {
         buffer.addInterpolation(identifier);
-        if (scanIdentifier("and", ignoreCase: true)) {
+        if (scanIdentifier("and")) {
           // For example, "@media only screen and ..."
           whitespace();
           buffer.write(" and ");
@@ -2796,7 +2796,7 @@ relase. For details, see http://bit.ly/moz-document.
       whitespace();
       buffer.addInterpolation(_mediaFeature());
       whitespace();
-      if (!scanIdentifier("and", ignoreCase: true)) break;
+      if (!scanIdentifier("and")) break;
       buffer.write(" and ");
     }
   }
@@ -2867,7 +2867,7 @@ relase. For details, see http://bit.ly/moz-document.
     var first = scanner.peekChar();
     if (first != $lparen && first != $hash) {
       var start = scanner.state;
-      expectIdentifier("not", ignoreCase: true);
+      expectIdentifier("not");
       whitespace();
       return new SupportsNegation(
           _supportsConditionInParens(), scanner.spanFrom(start));
@@ -2877,10 +2877,10 @@ relase. For details, see http://bit.ly/moz-document.
     whitespace();
     while (lookingAtIdentifier()) {
       String operator;
-      if (scanIdentifier("or", ignoreCase: true)) {
+      if (scanIdentifier("or")) {
         operator = "or";
       } else {
-        expectIdentifier("and", ignoreCase: true);
+        expectIdentifier("and");
         operator = "and";
       }
 
@@ -2932,7 +2932,7 @@ relase. For details, see http://bit.ly/moz-document.
   /// Returns `null` if it fails.
   SupportsNegation _trySupportsNegation() {
     var start = scanner.state;
-    if (!scanIdentifier("not", ignoreCase: true) || scanner.isDone) {
+    if (!scanIdentifier("not") || scanner.isDone) {
       scanner.state = start;
       return null;
     }


### PR DESCRIPTION
This flag wasn't being respected, so all of these identifiers were de
facto case-insensitive. Changing that now would be breaking, and it's
probably better to make them case-insensitive anyway since CSS
identifiers are.