### PR TITLE
Clamp saturation and lightness rather than throwing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   command-line interface, Dart API, and JS API. These load paths are checked
   just after the load paths explicitly passed by the user.
 
+* Allow saturation and lightness values outside of the `0%` to `100%` range in
+  the `hsl()` and `hsla()` functions. They're now clamped to be within that
+  range rather than producing an error if they're outside it.
+
 [content-args]: https://github.com/sass/language/blob/master/accepted/content-args.md
 [at-rule-interpolation]: https://github.com/sass/language/blob/master/accepted/at-rule-interpolation.md
 

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -174,7 +174,8 @@ final List<BuiltInCallable> coreFunctions = new UnmodifiableListView([
       var saturation = arguments[1].assertNumber("saturation");
       var lightness = arguments[2].assertNumber("lightness");
 
-      return new SassColor.hsl(hue.value, saturation.value, lightness.value);
+      return new SassColor.hsl(hue.value, saturation.value.clamp(0, 100),
+          lightness.value.clamp(0, 100));
     },
     r"$hue, $saturation": (arguments) {
       // hsl(123, var(--foo)) is valid CSS because --foo might be `10%, 20%` and
@@ -208,7 +209,10 @@ final List<BuiltInCallable> coreFunctions = new UnmodifiableListView([
       var lightness = arguments[2].assertNumber("lightness");
       var alpha = arguments[3].assertNumber("alpha");
 
-      return new SassColor.hsl(hue.value, saturation.value, lightness.value,
+      return new SassColor.hsl(
+          hue.value,
+          saturation.value.clamp(0, 100),
+          lightness.value.clamp(0, 100),
           _percentageOrUnitless(alpha, 1, "alpha"));
     },
     r"$hue, $saturation, $lightness": (arguments) {


### PR DESCRIPTION
This matches Ruby Sass's behavior.

See sass/sass-spec#1300