### PR TITLE
Fix pushing to Bazel again

### DIFF
--- a/tool/grind/bazel.dart
+++ b/tool/grind/bazel.dart
@@ -53,7 +53,7 @@ updateBazel() async {
       arguments: [
         "push",
         "https://$username:$password@github.com/bazelbuild/rules_sass.git",
-        "master:master"
+        "HEAD:master"
       ],
       workingDirectory: repo);
 }


### PR DESCRIPTION
With #506, we're pushing the master branch to the Bazel repo. But
we're actually committing to a detached HEAD, rather than the master
branch. This pushes the current HEAD instead.

Closes bazelbuild/rules_sass#61