### PR TITLE
Fix typo in async_evaluate.dart

### DIFF
--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -599,7 +599,7 @@ class _EvaluateVisitor
       var compound = complex.components.first as CompoundSelector;
       if (compound.components.length != 1) {
         throw SassFormatException(
-            "compound selectors may longer be extended.\n"
+            "compound selectors may no longer be extended.\n"
             "Consider `@extend ${compound.components.join(', ')}` instead.\n"
             "See http://bit.ly/ExtendCompound for details.\n",
             targetText.span);


### PR DESCRIPTION
Line [602](https://github.com/sass/dart-sass/blob/master/lib/src/visitor/async_evaluate.dart#L602): "compound selectors may longer be extended" -> "compound selectors may no longer be extended"