### PR TITLE
Move some compilation logic from the executable to compile.dart

### DIFF
--- a/lib/sass.dart
+++ b/lib/sass.dart
@@ -9,9 +9,11 @@ import 'dart:async';
 
 import 'package:source_maps/source_maps.dart';
 
+import 'src/async_import_cache.dart';
 import 'src/callable.dart';
 import 'src/compile.dart' as c;
 import 'src/exception.dart';
+import 'src/import_cache.dart';
 import 'src/importer.dart';
 import 'src/logger.dart';
 import 'src/sync_package_resolver.dart';
@@ -86,11 +88,13 @@ String compile(String path,
     Iterable<Callable> functions,
     OutputStyle style,
     void sourceMap(SingleMapping map)}) {
+  logger ??= Logger.stderr(color: color);
   var result = c.compile(path,
-      logger: logger ?? Logger.stderr(color: color),
-      importers: importers,
-      loadPaths: loadPaths,
-      packageResolver: packageResolver,
+      logger: logger,
+      importCache: ImportCache(importers,
+          logger: logger,
+          loadPaths: loadPaths,
+          packageResolver: packageResolver),
       functions: functions,
       style: style,
       sourceMap: sourceMap != null);
@@ -167,12 +171,14 @@ String compileString(String source,
     url,
     void sourceMap(SingleMapping map),
     @Deprecated("Use syntax instead.") bool indented = false}) {
+  logger ??= Logger.stderr(color: color);
   var result = c.compileString(source,
       syntax: syntax ?? (indented ? Syntax.sass : Syntax.scss),
-      logger: logger ?? Logger.stderr(color: color),
-      importers: importers,
-      packageResolver: packageResolver,
-      loadPaths: loadPaths,
+      logger: logger,
+      importCache: ImportCache(importers,
+          logger: logger,
+          packageResolver: packageResolver,
+          loadPaths: loadPaths),
       functions: functions,
       style: style,
       importer: importer,
@@ -196,11 +202,13 @@ Future<String> compileAsync(String path,
     Iterable<AsyncCallable> functions,
     OutputStyle style,
     void sourceMap(SingleMapping map)}) async {
+  logger ??= Logger.stderr(color: color);
   var result = await c.compileAsync(path,
-      logger: logger ?? Logger.stderr(color: color),
-      importers: importers,
-      loadPaths: loadPaths,
-      packageResolver: packageResolver,
+      logger: logger,
+      importCache: AsyncImportCache(importers,
+          logger: logger,
+          loadPaths: loadPaths,
+          packageResolver: packageResolver),
       functions: functions,
       style: style,
       sourceMap: sourceMap != null);
@@ -226,12 +234,14 @@ Future<String> compileStringAsync(String source,
     url,
     void sourceMap(SingleMapping map),
     @Deprecated("Use syntax instead.") bool indented = false}) async {
+  logger ??= Logger.stderr(color: color);
   var result = await c.compileStringAsync(source,
       syntax: syntax ?? (indented ? Syntax.sass : Syntax.scss),
-      logger: logger ?? Logger.stderr(color: color),
-      importers: importers,
-      packageResolver: packageResolver,
-      loadPaths: loadPaths,
+      logger: logger,
+      importCache: AsyncImportCache(importers,
+          logger: logger,
+          packageResolver: packageResolver,
+          loadPaths: loadPaths),
       functions: functions,
       style: style,
       importer: importer,

--- a/lib/src/async_compile.dart
+++ b/lib/src/async_compile.dart
@@ -23,20 +23,12 @@ import 'visitor/serialize.dart';
 /// Like [compileAsync] in `lib/sass.dart`, but provides more options to support
 /// the node-sass compatible API and the executable.
 ///
-/// No more than one of the following arguments or sets of arguments may be
-/// provided:
-///
-/// * `importCache`;
-/// * `nodeImporter`;
-/// * `importers`, `packageResolver`, and/or `loadPaths`.
+/// At most one of `importCache` and `nodeImporter` may be provided at once.
 Future<CompileResult> compileAsync(String path,
     {Syntax syntax,
     Logger logger,
     AsyncImportCache importCache,
     NodeImporter nodeImporter,
-    Iterable<AsyncImporter> importers,
-    Iterable<String> loadPaths,
-    SyncPackageResolver packageResolver,
     Iterable<AsyncCallable> functions,
     OutputStyle style,
     bool useSpaces = true,
@@ -48,8 +40,7 @@ Future<CompileResult> compileAsync(String path,
   Stylesheet stylesheet;
   if (nodeImporter == null &&
       (syntax == null || syntax == Syntax.forPath(path))) {
-    importCache ??= AsyncImportCache(importers,
-        loadPaths: loadPaths, packageResolver: packageResolver, logger: logger);
+    importCache ??= AsyncImportCache.none(logger: logger);
     stylesheet = await importCache.importCanonical(
         FilesystemImporter('.'), p.toUri(p.canonicalize(path)), p.toUri(path));
   } else {
@@ -75,12 +66,7 @@ Future<CompileResult> compileAsync(String path,
 /// Like [compileStringAsync] in `lib/sass.dart`, but provides more options to
 /// support the node-sass compatible API.
 ///
-/// No more than one of the following arguments or sets of arguments may be
-/// provided:
-///
-/// * `importCache`;
-/// * `nodeImporter`;
-/// * `importers`, `packageResolver`, and/or `loadPaths`.
+/// At most one of `importCache` and `nodeImporter` may be provided at once.
 Future<CompileResult> compileStringAsync(String source,
     {Syntax syntax,
     Logger logger,
@@ -99,11 +85,6 @@ Future<CompileResult> compileStringAsync(String source,
     bool sourceMap = false}) async {
   var stylesheet =
       Stylesheet.parse(source, syntax ?? Syntax.scss, url: url, logger: logger);
-
-  if (nodeImporter == null) {
-    importCache ??= AsyncImportCache(importers,
-        loadPaths: loadPaths, packageResolver: packageResolver, logger: logger);
-  }
 
   return _compileStylesheet(
       stylesheet,

--- a/lib/src/async_compile.dart
+++ b/lib/src/async_compile.dart
@@ -2,22 +2,14 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-// DO NOT EDIT. This file was generated from async_compile.dart.
-// See tool/synchronize.dart for details.
-//
-// Checksum: 5ce549b3c33e03ea84c9caf4933d88be9c993ba1
-//
-// ignore_for_file: unused_import
-
-import 'async_compile.dart';
-export 'async_compile.dart';
+import 'dart:async';
 
 import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:source_span/source_span.dart';
 
 import 'ast/sass.dart';
-import 'import_cache.dart';
+import 'async_import_cache.dart';
 import 'callable.dart';
 import 'importer.dart';
 import 'importer/node.dart';
@@ -25,25 +17,25 @@ import 'io.dart';
 import 'logger.dart';
 import 'sync_package_resolver.dart';
 import 'syntax.dart';
-import 'visitor/evaluate.dart';
+import 'visitor/async_evaluate.dart';
 import 'visitor/serialize.dart';
 
-/// Like [compile] in `lib/sass.dart`, but provides more options to support
+/// Like [compileAsync] in `lib/sass.dart`, but provides more options to support
 /// the node-sass compatible API.
-CompileResult compile(String path,
+Future<CompileResult> compileAsync(String path,
         {Syntax syntax,
         Logger logger,
-        Iterable<Importer> importers,
+        Iterable<AsyncImporter> importers,
         NodeImporter nodeImporter,
         SyncPackageResolver packageResolver,
         Iterable<String> loadPaths,
-        Iterable<Callable> functions,
+        Iterable<AsyncCallable> functions,
         OutputStyle style,
         bool useSpaces = true,
         int indentWidth,
         LineFeed lineFeed,
         bool sourceMap = false}) =>
-    compileString(readFile(path),
+    compileStringAsync(readFile(path),
         syntax: syntax ?? Syntax.forPath(path),
         logger: logger,
         importers: importers,
@@ -59,28 +51,28 @@ CompileResult compile(String path,
         url: p.toUri(path),
         sourceMap: sourceMap);
 
-/// Like [compileString] in `lib/sass.dart`, but provides more options to
+/// Like [compileStringAsync] in `lib/sass.dart`, but provides more options to
 /// support the node-sass compatible API.
-CompileResult compileString(String source,
+Future<CompileResult> compileStringAsync(String source,
     {Syntax syntax,
     Logger logger,
-    Iterable<Importer> importers,
+    Iterable<AsyncImporter> importers,
     NodeImporter nodeImporter,
     SyncPackageResolver packageResolver,
     Iterable<String> loadPaths,
-    Importer importer,
-    Iterable<Callable> functions,
+    AsyncImporter importer,
+    Iterable<AsyncCallable> functions,
     OutputStyle style,
     bool useSpaces = true,
     int indentWidth,
     LineFeed lineFeed,
     url,
-    bool sourceMap = false}) {
+    bool sourceMap = false}) async {
   var stylesheet =
       Stylesheet.parse(source, syntax ?? Syntax.scss, url: url, logger: logger);
 
-  var evaluateResult = evaluate(stylesheet,
-      importCache: ImportCache(importers,
+  var evaluateResult = await evaluateAsync(stylesheet,
+      importCache: AsyncImportCache(importers,
           loadPaths: loadPaths,
           packageResolver: packageResolver,
           logger: logger),
@@ -98,4 +90,37 @@ CompileResult compileString(String source,
       sourceMap: sourceMap);
 
   return CompileResult(evaluateResult, serializeResult);
+}
+
+/// The result of compiling a Sass document to CSS, along with metadata about
+/// the compilation process.
+class CompileResult {
+  /// The result of evaluating the source file.
+  final EvaluateResult _evaluate;
+
+  /// The result of serializing the CSS AST to CSS text.
+  final SerializeResult _serialize;
+
+  /// The compiled CSS.
+  String get css => _serialize.css;
+
+  /// The source map indicating how the source files map to [css].
+  ///
+  /// This is `null` if source mapping was disabled for this compilation.
+  SingleMapping get sourceMap => _serialize.sourceMap;
+
+  /// A map from source file URLs to the corresponding [SourceFile]s.
+  ///
+  /// This can be passed to [sourceMap]'s [Mapping.spanFor] method. It's `null`
+  /// if source mapping was disabled for this compilation.
+  Map<String, SourceFile> get sourceFiles => _serialize.sourceFiles;
+
+  /// The set that will eventually populate the JS API's
+  /// `result.stats.includedFiles` field.
+  ///
+  /// For filesystem imports, this contains the import path. For all other
+  /// imports, it contains the URL passed to the `@import`.
+  Set<String> get includedFiles => _evaluate.includedFiles;
+
+  CompileResult(this._evaluate, this._serialize);
 }

--- a/lib/src/async_import_cache.dart
+++ b/lib/src/async_import_cache.dart
@@ -17,9 +17,6 @@ import 'utils.dart'; // ignore: unused_import
 
 /// An in-memory cache of parsed stylesheets that have been imported by Sass.
 class AsyncImportCache {
-  /// A cache that contains no importers.
-  static const none = AsyncImportCache._none();
-
   /// The importers to use when loading new Sass files.
   final List<AsyncImporter> _importers;
 
@@ -59,6 +56,13 @@ class AsyncImportCache {
       SyncPackageResolver packageResolver,
       Logger logger})
       : _importers = _toImporters(importers, loadPaths, packageResolver),
+        _logger = logger ?? const Logger.stderr(),
+        _canonicalizeCache = {},
+        _importCache = {};
+
+  /// Creates an import cache without any globally-avaiable importers.
+  AsyncImportCache.none({Logger logger})
+      : _importers = const [],
         _logger = logger ?? const Logger.stderr(),
         _canonicalizeCache = {},
         _importCache = {};

--- a/lib/src/compile.dart
+++ b/lib/src/compile.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_compile.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: ece42e2134684c290c8d921521c863857664d323
+// Checksum: e6de63e581c0f4da96756b9e2904bd81a090dc5b
 //
 // ignore_for_file: unused_import
 
@@ -31,20 +31,12 @@ import 'visitor/serialize.dart';
 /// Like [compile] in `lib/sass.dart`, but provides more options to support
 /// the node-sass compatible API and the executable.
 ///
-/// No more than one of the following arguments or sets of arguments may be
-/// provided:
-///
-/// * `importCache`;
-/// * `nodeImporter`;
-/// * `importers`, `packageResolver`, and/or `loadPaths`.
+/// At most one of `importCache` and `nodeImporter` may be provided at once.
 CompileResult compile(String path,
     {Syntax syntax,
     Logger logger,
     ImportCache importCache,
     NodeImporter nodeImporter,
-    Iterable<Importer> importers,
-    Iterable<String> loadPaths,
-    SyncPackageResolver packageResolver,
     Iterable<Callable> functions,
     OutputStyle style,
     bool useSpaces = true,
@@ -56,8 +48,7 @@ CompileResult compile(String path,
   Stylesheet stylesheet;
   if (nodeImporter == null &&
       (syntax == null || syntax == Syntax.forPath(path))) {
-    importCache ??= ImportCache(importers,
-        loadPaths: loadPaths, packageResolver: packageResolver, logger: logger);
+    importCache ??= ImportCache.none(logger: logger);
     stylesheet = importCache.importCanonical(
         FilesystemImporter('.'), p.toUri(p.canonicalize(path)), p.toUri(path));
   } else {
@@ -83,12 +74,7 @@ CompileResult compile(String path,
 /// Like [compileString] in `lib/sass.dart`, but provides more options to
 /// support the node-sass compatible API.
 ///
-/// No more than one of the following arguments or sets of arguments may be
-/// provided:
-///
-/// * `importCache`;
-/// * `nodeImporter`;
-/// * `importers`, `packageResolver`, and/or `loadPaths`.
+/// At most one of `importCache` and `nodeImporter` may be provided at once.
 CompileResult compileString(String source,
     {Syntax syntax,
     Logger logger,
@@ -107,11 +93,6 @@ CompileResult compileString(String source,
     bool sourceMap = false}) {
   var stylesheet =
       Stylesheet.parse(source, syntax ?? Syntax.scss, url: url, logger: logger);
-
-  if (nodeImporter == null) {
-    importCache ??= ImportCache(importers,
-        loadPaths: loadPaths, packageResolver: packageResolver, logger: logger);
-  }
 
   return _compileStylesheet(
       stylesheet,

--- a/lib/src/environment.dart
+++ b/lib/src/environment.dart
@@ -6,6 +6,8 @@
 // See tool/synchronize.dart for details.
 //
 // Checksum: 9e0f9274f4778b701f268bcf4fc349a1cf17a159
+//
+// ignore_for_file: unused_import
 
 import 'package:source_span/source_span.dart';
 

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -6,6 +6,8 @@
 // See tool/synchronize.dart for details.
 //
 // Checksum: 54045771e1267d445a733a83d9fb7e40439d886e
+//
+// ignore_for_file: unused_import
 
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_import_cache.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 54045771e1267d445a733a83d9fb7e40439d886e
+// Checksum: 4989811a7b432e181ccc42004e91f4fe54a786ca
 //
 // ignore_for_file: unused_import
 
@@ -22,9 +22,6 @@ import 'utils.dart'; // ignore: unused_import
 
 /// An in-memory cache of parsed stylesheets that have been imported by Sass.
 class ImportCache {
-  /// A cache that contains no importers.
-  static const none = ImportCache._none();
-
   /// The importers to use when loading new Sass files.
   final List<Importer> _importers;
 
@@ -64,6 +61,13 @@ class ImportCache {
       SyncPackageResolver packageResolver,
       Logger logger})
       : _importers = _toImporters(importers, loadPaths, packageResolver),
+        _logger = logger ?? const Logger.stderr(),
+        _canonicalizeCache = {},
+        _importCache = {};
+
+  /// Creates an import cache without any globally-avaiable importers.
+  ImportCache.none({Logger logger})
+      : _importers = const [],
         _logger = logger ?? const Logger.stderr(),
         _canonicalizeCache = {},
         _importCache = {};

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -204,7 +204,9 @@ class _EvaluateVisitor
       Map<String, Value> variables,
       Logger logger,
       bool sourceMap})
-      : _importCache = importCache ?? AsyncImportCache.none,
+      : _importCache = nodeImporter == null
+            ? importCache ?? AsyncImportCache.none(logger: logger)
+            : null,
         _importer = importer ?? Importer.noOp,
         _nodeImporter = nodeImporter,
         _logger = logger ?? const Logger.stderr(),
@@ -1815,10 +1817,11 @@ class _EvaluateVisitor
 
   /// Creates a new stack frame with location information from [member] and
   /// [span].
-  Frame _stackFrame(String member, FileSpan span) => frameForSpan(span, member,
-      url: span.sourceUrl == null
-          ? null
-          : _importCache.humanize(span.sourceUrl));
+  Frame _stackFrame(String member, FileSpan span) {
+    var url = span.sourceUrl;
+    if (url != null && _importCache != null) url = _importCache.humanize(url);
+    return frameForSpan(span, member, url: url);
+  }
 
   /// Returns a stack trace at the current point.
   ///

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 07e2cda457e3bca4efd3b3f4742744c91c2970d8
+// Checksum: 2065f7d701646283e536c5300b0f20f38c4acb46
 //
 // ignore_for_file: unused_import
 
@@ -211,7 +211,9 @@ class _EvaluateVisitor
       Map<String, Value> variables,
       Logger logger,
       bool sourceMap})
-      : _importCache = importCache ?? ImportCache.none,
+      : _importCache = nodeImporter == null
+            ? importCache ?? ImportCache.none(logger: logger)
+            : null,
         _importer = importer ?? Importer.noOp,
         _nodeImporter = nodeImporter,
         _logger = logger ?? const Logger.stderr(),
@@ -1790,10 +1792,11 @@ class _EvaluateVisitor
 
   /// Creates a new stack frame with location information from [member] and
   /// [span].
-  Frame _stackFrame(String member, FileSpan span) => frameForSpan(span, member,
-      url: span.sourceUrl == null
-          ? null
-          : _importCache.humanize(span.sourceUrl));
+  Frame _stackFrame(String member, FileSpan span) {
+    var url = span.sourceUrl;
+    if (url != null && _importCache != null) url = _importCache.humanize(url);
+    return frameForSpan(span, member, url: url);
+  }
 
   /// Returns a stack trace at the current point.
   ///

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -6,6 +6,8 @@
 // See tool/synchronize.dart for details.
 //
 // Checksum: 07e2cda457e3bca4efd3b3f4742744c91c2970d8
+//
+// ignore_for_file: unused_import
 
 import 'async_evaluate.dart' show EvaluateResult;
 export 'async_evaluate.dart' show EvaluateResult;


### PR DESCRIPTION
This doesn't reduce code size, but it does make it easier to add
functionality to *all* Sass compilations.