### PR TITLE
Properly use ImportResult.sourceMapUrl for source map URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 * Match Ruby Sass's behavior in some edge-cases involving numbers with many
   significant digits.
 
+### Command-Line Interface
+
+* The source map generated for a stylesheet read from standard input now uses a
+  `data:` URL to include that stylesheet's contents in the source map.
+
+### Dart API
+
+* The URL used in a source map to refer to a stylesheet loaded from an importer
+  is now `ImportResult.sourceMapUrl` as documented.
+
 ## 1.15.2
 
 ### Node JS API

--- a/lib/src/async_compile.dart
+++ b/lib/src/async_compile.dart
@@ -3,6 +3,7 @@
 // https://opensource.org/licenses/MIT.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
@@ -17,6 +18,7 @@ import 'io.dart';
 import 'logger.dart';
 import 'sync_package_resolver.dart';
 import 'syntax.dart';
+import 'utils.dart';
 import 'visitor/async_evaluate.dart';
 import 'visitor/serialize.dart';
 
@@ -129,6 +131,18 @@ Future<CompileResult> _compileStylesheet(
       indentWidth: indentWidth,
       lineFeed: lineFeed,
       sourceMap: sourceMap);
+
+  if (serializeResult.sourceMap != null && importCache != null) {
+    // TODO(nweiz): Don't explicitly use a type parameter when dart-lang/sdk#25490
+    // is fixed.
+    mapInPlace<String>(
+        serializeResult.sourceMap.urls,
+        (url) => url == ''
+            ? Uri.dataFromString(stylesheet.span.file.getText(0),
+                    encoding: utf8)
+                .toString()
+            : importCache.sourceMapUrl(Uri.parse(url)).toString());
+  }
 
   return CompileResult(evaluateResult, serializeResult);
 }

--- a/lib/src/compile.dart
+++ b/lib/src/compile.dart
@@ -5,12 +5,14 @@
 // DO NOT EDIT. This file was generated from async_compile.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: e6de63e581c0f4da96756b9e2904bd81a090dc5b
+// Checksum: 2bb00947655b3add16335253802a82188d730595
 //
 // ignore_for_file: unused_import
 
 import 'async_compile.dart';
 export 'async_compile.dart';
+
+import 'dart:convert';
 
 import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
@@ -25,6 +27,7 @@ import 'io.dart';
 import 'logger.dart';
 import 'sync_package_resolver.dart';
 import 'syntax.dart';
+import 'utils.dart';
 import 'visitor/evaluate.dart';
 import 'visitor/serialize.dart';
 
@@ -137,6 +140,18 @@ CompileResult _compileStylesheet(
       indentWidth: indentWidth,
       lineFeed: lineFeed,
       sourceMap: sourceMap);
+
+  if (serializeResult.sourceMap != null && importCache != null) {
+    // TODO(nweiz): Don't explicitly use a type parameter when dart-lang/sdk#25490
+    // is fixed.
+    mapInPlace<String>(
+        serializeResult.sourceMap.urls,
+        (url) => url == ''
+            ? Uri.dataFromString(stylesheet.span.file.getText(0),
+                    encoding: utf8)
+                .toString()
+            : importCache.sourceMapUrl(Uri.parse(url)).toString());
+  }
 
   return CompileResult(evaluateResult, serializeResult);
 }

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -15,6 +15,7 @@ import '../importer/filesystem.dart';
 import '../io.dart';
 import '../stylesheet_graph.dart';
 import '../syntax.dart';
+import '../utils.dart';
 import 'options.dart';
 
 /// Compiles the stylesheet at [source] to [destination].
@@ -126,15 +127,10 @@ String _writeSourceMap(
     sourceMap.targetUrl = p.toUri(p.basename(destination)).toString();
   }
 
-  for (var i = 0; i < sourceMap.urls.length; i++) {
-    var url = sourceMap.urls[i];
-
-    // The special URL "" indicates a file that came from stdin.
-    if (url == "") continue;
-
-    sourceMap.urls[i] =
-        options.sourceMapUrl(Uri.parse(url), destination).toString();
-  }
+  // TODO(nweiz): Don't explicitly use a type parameter when dart-lang/sdk#25490
+  // is fixed.
+  mapInPlace<String>(sourceMap.urls,
+      (url) => options.sourceMapUrl(Uri.parse(url), destination).toString());
   var sourceMapText =
       jsonEncode(sourceMap.toJson(includeSourceContents: options.embedSources));
 

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -402,7 +402,11 @@ class ExecutableOptions {
 
   /// Makes [url] absolute or relative (to the directory containing
   /// [destination]) according to the `source-map-urls` option.
+  ///
+  /// If [url] isn't a `file:` URL, returns it as-is.
   Uri sourceMapUrl(Uri url, String destination) {
+    if (url.scheme.isNotEmpty && url.scheme != 'file') return url;
+
     var path = p.canonicalize(p.fromUri(url));
     return p.toUri(_options['source-map-urls'] == 'relative'
         ? p.relative(path, from: p.dirname(destination))

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -289,6 +289,13 @@ Map<String, V2> normalizedMapMap<K, V1, V2>(Map<K, V1> map,
   return result;
 }
 
+/// Destructively updates every element of [list] with the result of [function].
+void mapInPlace<T>(List<T> list, T function(T element)) {
+  for (var i = 0; i < list.length; i++) {
+    list[i] = function(list[i]);
+  }
+}
+
 /// Returns the longest common subsequence between [list1] and [list2].
 ///
 /// If there are more than one equally long common subsequence, returns the one

--- a/test/cli/shared/source_maps.dart
+++ b/test/cli/shared/source_maps.dart
@@ -116,13 +116,16 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
     });
   });
 
-  test("with --stdin uses an empty string", () async {
+  test("with --stdin uses a data: URL", () async {
     var sass = await runSass(["--stdin", "out.css"]);
     sass.stdin.writeln("a {b: c}");
     sass.stdin.close();
     await sass.shouldExit(0);
 
-    expect(_readJson("out.css.map"), containsPair("sources", [""]));
+    expect(
+        _readJson("out.css.map"),
+        containsPair("sources",
+            [Uri.dataFromString("a {b: c}\n", encoding: utf8).toString()]));
   });
 
   group("with --no-source-map,", () {

--- a/test/synchronize_test.dart
+++ b/test/synchronize_test.dart
@@ -10,14 +10,11 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
 
+import '../tool/grind/synchronize.dart' as synchronize;
+
 void main() {
   test("synchronized files are up-to-date", () {
-    ({
-      'lib/src/visitor/async_evaluate.dart': 'lib/src/visitor/evaluate.dart',
-      'lib/src/async_environment.dart': 'lib/src/environment.dart',
-      'lib/src/async_import_cache.dart': 'lib/src/import_cache.dart'
-    })
-        .forEach((sourcePath, targetPath) {
+    synchronize.sources.forEach((sourcePath, targetPath) {
       var source = File(sourcePath).readAsStringSync();
       var target = File(targetPath).readAsStringSync();
 

--- a/tool/grind/synchronize.dart
+++ b/tool/grind/synchronize.dart
@@ -13,7 +13,7 @@ import 'package:grinder/grinder.dart';
 import 'package:path/path.dart' as p;
 
 /// The files to compile to synchronous versions.
-final _sources = const {
+final sources = const {
   'lib/src/visitor/async_evaluate.dart': 'lib/src/visitor/evaluate.dart',
   'lib/src/async_compile.dart': 'lib/src/compile.dart',
   'lib/src/async_environment.dart': 'lib/src/environment.dart',
@@ -38,7 +38,7 @@ final _sharedClasses = const ['EvaluateResult', 'CompileResult'];
 /// to a synchronous equivalent.
 @Task('Compile async code to synchronous code.')
 synchronize() {
-  _sources.forEach((source, target) {
+  sources.forEach((source, target) {
     var visitor = _Visitor(File(source).readAsStringSync(), source);
     parseDartFile(source).accept(visitor);
     var formatted = DartFormatter().format(visitor.result);


### PR DESCRIPTION
This also uses data: URLs to refer to stylesheets from stdin in source
maps.