### PR TITLE
Match Node Sass's this.includePaths behavior for importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Match Ruby Sass's behavior in some edge-cases involving numbers with many
   significant digits.
 
+### Node JS API
+
+* `this.includePaths` for a running importer is now a `;`-separated string on
+  Windows, rather than `:`-separated. This matches Node Sass's behavior.
+
 ## 1.15.2
 
 ### Node JS API

--- a/lib/src/io/vm.dart
+++ b/lib/src/io/vm.dart
@@ -82,8 +82,7 @@ DateTime modificationTime(String path) {
   return stat.modified;
 }
 
-String getEnvironmentVariable(String name) =>
-    io.Platform.environment['SASS_PATH'];
+String getEnvironmentVariable(String name) => io.Platform.environment[name];
 
 Future<Stream<WatchEvent>> watchDir(String path, {bool poll = false}) async {
   var watcher = poll ? PollingDirectoryWatcher(path) : DirectoryWatcher(path);

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -16,6 +16,7 @@ import 'callable.dart';
 import 'compile.dart';
 import 'exception.dart';
 import 'executable.dart' as executable;
+import 'io.dart';
 import 'importer/node.dart';
 import 'node/error.dart';
 import 'node/exports.dart';

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -253,7 +253,8 @@ NodeImporter _parseImporter(RenderOptions options, DateTime start) {
         options: RenderContextOptions(
             file: options.file,
             data: options.data,
-            includePaths: ([p.current]..addAll(includePaths)).join(":"),
+            includePaths:
+                ([p.current]..addAll(includePaths)).join(isWindows ? ';' : ':'),
             precision: SassNumber.precision,
             style: 1,
             indentType: options.indentType == 'tab' ? 1 : 0,

--- a/test/node_api/importer_test.dart
+++ b/test/node_api/importer_test.dart
@@ -405,7 +405,8 @@ void main() {
           includePaths: [sandbox],
           importer: allowInteropCaptureThis(
               expectAsync3((RenderContext this_, _, __) {
-            expect(this_.options.includePaths, equals("${p.current}:$sandbox"));
+            expect(this_.options.includePaths,
+                equals("${p.current}${isWindows ? ';' : ':'}$sandbox"));
             return NodeImporterResult(contents: '');
           }))));
     });


### PR DESCRIPTION
On Windows, paths are separated with a semicolon rather than a colon.

Closes #549