### PR TITLE
Remove unused import

### DIFF
--- a/lib/src/ast/sass/statement/silent_comment.dart
+++ b/lib/src/ast/sass/statement/silent_comment.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:math' as math;
-
 import 'package:source_span/source_span.dart';
 import 'package:string_scanner/string_scanner.dart';
 


### PR DESCRIPTION
Originally added in #548 but after changes during review it is no longer needed.