### PR TITLE
Support dart-lang/source_span#25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.17.0
+
+* Improve error output, particularly for errors that cover multiple lines.
+
+### Command-Line Interface
+
+* The new error output uses non-ASCII Unicode characters by default. Add a
+  `--no-unicode` flag to disable this.
+
 ## 1.16.0
 
 * `rgb()` and `hsl()` now treat unquoted strings beginning with `env()`,

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -7,6 +7,7 @@ import 'dart:isolate';
 
 import 'package:path/path.dart' as p;
 import 'package:stack_trace/stack_trace.dart';
+import 'package:term_glyph/term_glyph.dart' as term_glyph;
 
 import 'exception.dart';
 import 'executable/compile_stylesheet.dart';
@@ -38,6 +39,8 @@ main(List<String> args) async {
   ExecutableOptions options;
   try {
     options = ExecutableOptions.parse(args);
+    term_glyph.ascii = !options.unicode;
+
     if (options.version) {
       print(await _loadVersion());
       exitCode = 0;

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -9,6 +9,7 @@ import 'package:charcode/charcode.dart';
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:term_glyph/term_glyph.dart' as term_glyph;
 
 import '../../sass.dart';
 import '../io.dart';
@@ -85,7 +86,10 @@ class ExecutableOptions {
           abbr: 'i',
           help: 'Run an interactive SassScript shell.',
           negatable: false)
-      ..addFlag('color', abbr: 'c', help: 'Whether to emit terminal colors.')
+      ..addFlag('color',
+          abbr: 'c', help: 'Whether to use terminal colors for messages.')
+      ..addFlag('unicode',
+          help: 'Whether to use Unicode characters for messages.')
       ..addFlag('quiet', abbr: 'q', help: "Don't print warnings.")
       ..addFlag('trace', help: 'Print full Dart stack traces for exceptions.')
       ..addFlag('help',
@@ -150,6 +154,11 @@ class ExecutableOptions {
   bool get color => _options.wasParsed('color')
       ? _options['color'] as bool
       : supportsAnsiEscapes;
+
+  /// Whether to use non-ASCII Unicode glyphs.
+  bool get unicode => _options.wasParsed('unicode')
+      ? _options['unicode'] as bool
+      : !term_glyph.ascii;
 
   /// Whether to silence normal output.
   bool get quiet => _options['quiet'] as bool;

--- a/lib/src/executable/repl.dart
+++ b/lib/src/executable/repl.dart
@@ -3,6 +3,7 @@
 // https://opensource.org/licenses/MIT.
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:cli_repl/cli_repl.dart';
 import 'package:stack_trace/stack_trace.dart';
@@ -54,21 +55,20 @@ void _logError(SassException error, StackTrace stackTrace, String line,
   }
 
   // Otherwise, highlight the bad input from the previous line.
-  var arrows = error.span.highlight().split('\n').last.trimRight();
   var buffer = StringBuffer();
   if (options.color) buffer.write("\u001b[31m");
 
-  if (options.color && arrows.length <= line.length) {
-    int start = arrows.length - arrows.trimLeft().length;
+  var spacesBeforeError = repl.prompt.length + error.span.start.column;
+  if (options.color && error.span.start.column < line.length) {
     // Position the cursor at the beginning of the error text.
-    buffer.write("\u001b[1F\u001b[${start + 3}C");
+    buffer.write("\u001b[1F\u001b[${spacesBeforeError}C");
     // Rewrite the bad input, this time in red text.
-    buffer.writeln(line.substring(start, arrows.length));
+    buffer.writeln(error.span.text);
   }
 
   // Write arrows underneath the error text.
-  buffer.write(" " * repl.prompt.length);
-  buffer.writeln(arrows);
+  buffer.write(" " * spacesBeforeError);
+  buffer.writeln("^" * math.max(1, error.span.length));
   if (options.color) buffer.write("\u001b[0m");
 
   buffer.writeln("Error: ${error.message}");

--- a/lib/src/parse/scss.dart
+++ b/lib/src/parse/scss.dart
@@ -92,7 +92,6 @@ class ScssParser extends StylesheetParser {
 
         case $rbrace:
           scanner.expectChar($rbrace);
-          whitespaceWithoutComments();
           return children;
 
         default:

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -944,7 +944,8 @@ abstract class StylesheetParser extends Parser {
       expectStatementSeparator();
     }
 
-    var span = scanner.spanFrom(start, start).expand((content ?? arguments).span);
+    var span =
+        scanner.spanFrom(start, start).expand((content ?? arguments).span);
     return IncludeRule(name, arguments, span, content: content);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,9 +20,7 @@ dependencies:
   package_resolver: "^1.0.0"
   path: "^1.6.0"
   source_maps: "^0.10.5"
-  # Temporarily limit source_span to 1.4.x so we can land other fixes before we
-  # fix all the tests for the new source_span format. See #566.
-  source_span: ">=1.4.0 <1.5.0"
+  source_span: "^1.4.0"
   stack_trace: ">=0.9.0 <2.0.0"
   stream_transform: "^0.0.1"
   string_scanner: ">=0.1.5 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.16.0
+version: 1.17.0-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass
@@ -24,6 +24,7 @@ dependencies:
   stack_trace: ">=0.9.0 <2.0.0"
   stream_transform: "^0.0.1"
   string_scanner: ">=0.1.5 <2.0.0"
+  term_glyph: "^1.0.0"
   tuple: "^1.0.0"
   watcher: "^0.9.6"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dev_dependencies:
   js: "^0.6.0"
   node_preamble: "^1.1.0"
   pub_semver: "^1.0.0"
+  source_span: "^1.5.2"
   stream_channel: "^1.0.0"
   test_descriptor: "^1.1.0"
   test_process: "^1.0.0-rc.1"

--- a/test/cli/shared.dart
+++ b/test/cli/shared.dart
@@ -282,15 +282,17 @@ void sharedTests(
   });
 
   test("gracefully reports errors from stdin", () async {
-    var sass = await runSass(["-"]);
+    var sass = await runSass(["--no-unicode", "-"]);
     sass.stdin.writeln("a {b: 1 + }");
     sass.stdin.close();
     expect(
         sass.stderr,
         emitsInOrder([
           "Error: Expected expression.",
-          "a {b: 1 + }",
-          "          ^",
+          "  ,",
+          "1 | a {b: 1 + }",
+          "  |           ^",
+          "  '",
           "  - 1:11  root stylesheet",
         ]));
     await sass.shouldExit(65);
@@ -300,15 +302,17 @@ void sharedTests(
   test(
       "gracefully reports errors for binary operations with parentheized "
       "operands", () async {
-    var sass = await runSass(["-"]);
+    var sass = await runSass(["--no-unicode", "-"]);
     sass.stdin.writeln("a {b: (#123) + (#456)}");
     sass.stdin.close();
     expect(
         sass.stderr,
         emitsInOrder([
           'Error: Undefined operation "#123 + #456".',
-          "a {b: (#123) + (#456)}",
-          "      ^^^^^^^^^^^^^^^",
+          "  ,",
+          "1 | a {b: (#123) + (#456)}",
+          "  |       ^^^^^^^^^^^^^^^",
+          "  '",
           "  - 1:7  root stylesheet",
         ]));
     await sass.shouldExit(65);

--- a/test/cli/shared/colon_args.dart
+++ b/test/cli/shared/colon_args.dart
@@ -186,18 +186,23 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
       await d.file("test1.scss", "a {b: }").create();
       await d.file("test2.scss", "x {y: }").create();
 
-      var sass = await runSass(["test1.scss:out1.css", "test2.scss:out2.css"]);
+      var sass = await runSass(
+          ["--no-unicode", "test1.scss:out1.css", "test2.scss:out2.css"]);
       expect(
           sass.stderr,
           emitsInOrder([
             "Error: Expected expression.",
-            "a {b: }",
-            "      ^",
+            "  ,",
+            "1 | a {b: }",
+            "  |       ^",
+            "  '",
             "  test1.scss 1:7  root stylesheet",
             "",
             "Error: Expected expression.",
-            "x {y: }",
-            "      ^",
+            "  ,",
+            "1 | x {y: }",
+            "  |       ^",
+            "  '",
             "  test2.scss 1:7  root stylesheet"
           ]));
       await sass.shouldExit(65);
@@ -207,18 +212,23 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
       await d.file("test1.scss", "a {b: 1 + #abc}").create();
       await d.file("test2.scss", "x {y: 1 + #abc}").create();
 
-      var sass = await runSass(["test1.scss:out1.css", "test2.scss:out2.css"]);
+      var sass = await runSass(
+          ["--no-unicode", "test1.scss:out1.css", "test2.scss:out2.css"]);
       expect(
           sass.stderr,
           emitsInOrder([
             'Error: Undefined operation "1 + #abc".',
-            "a {b: 1 + #abc}",
-            "      ^^^^^^^^",
+            "  ,",
+            "1 | a {b: 1 + #abc}",
+            "  |       ^^^^^^^^",
+            "  '",
             "  test1.scss 1:7  root stylesheet",
             "",
             'Error: Undefined operation "1 + #abc".',
-            "x {y: 1 + #abc}",
-            "      ^^^^^^^^",
+            "  ,",
+            "1 | x {y: 1 + #abc}",
+            "  |       ^^^^^^^^",
+            "  '",
             "  test2.scss 1:7  root stylesheet"
           ]));
       await sass.shouldExit(65);

--- a/test/cli/shared/errors.dart
+++ b/test/cli/shared/errors.dart
@@ -41,13 +41,15 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
   test("from invalid syntax", () async {
     await d.file("test.scss", "a {b: }").create();
 
-    var sass = await runSass(["test.scss"]);
+    var sass = await runSass(["--no-unicode", "test.scss"]);
     expect(
         sass.stderr,
         emitsInOrder([
           "Error: Expected expression.",
-          "a {b: }",
-          "      ^",
+          "  ,",
+          "1 | a {b: }",
+          "  |       ^",
+          "  '",
           "  test.scss 1:7  root stylesheet",
         ]));
     await sass.shouldExit(65);
@@ -56,13 +58,15 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
   test("from the runtime", () async {
     await d.file("test.scss", "a {b: 1px + 1deg}").create();
 
-    var sass = await runSass(["test.scss"]);
+    var sass = await runSass(["--no-unicode", "test.scss"]);
     expect(
         sass.stderr,
         emitsInOrder([
           "Error: Incompatible units deg and px.",
-          "a {b: 1px + 1deg}",
-          "      ^^^^^^^^^^",
+          "  ,",
+          "1 | a {b: 1px + 1deg}",
+          "  |       ^^^^^^^^^^",
+          "  '",
           "  test.scss 1:7  root stylesheet",
         ]));
     await sass.shouldExit(65);
@@ -71,13 +75,32 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
   test("with colors with --color", () async {
     await d.file("test.scss", "a {b: }").create();
 
-    var sass = await runSass(["--color", "test.scss"]);
+    var sass = await runSass(["--no-unicode", "--color", "test.scss"]);
     expect(
         sass.stderr,
         emitsInOrder([
           "Error: Expected expression.",
-          "a {b: \u001b[31m\u001b[0m}",
-          "      \u001b[31m^\u001b[0m",
+          "\u001b[34m  ,\u001b[0m",
+          "\u001b[34m1 |\u001b[0m a {b: \u001b[31m\u001b[0m}",
+          "\u001b[34m  |\u001b[0m       \u001b[31m^\u001b[0m",
+          "\u001b[34m  '\u001b[0m",
+          "  test.scss 1:7  root stylesheet",
+        ]));
+    await sass.shouldExit(65);
+  });
+
+  test("with Unicode by default", () async {
+    await d.file("test.scss", "a {b: }").create();
+
+    var sass = await runSass(["test.scss"]);
+    expect(
+        sass.stderr,
+        emitsInOrder([
+          "Error: Expected expression.",
+          "  ╷",
+          "1 │ a {b: }",
+          "  │       ^",
+          "  ╵",
           "  test.scss 1:7  root stylesheet",
         ]));
     await sass.shouldExit(65);
@@ -94,13 +117,15 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
   test("for package urls", () async {
     await d.file("test.scss", "@import 'package:nope/test';").create();
 
-    var sass = await runSass(["test.scss"]);
+    var sass = await runSass(["--no-unicode", "test.scss"]);
     expect(
         sass.stderr,
         emitsInOrder([
           "Error: \"package:\" URLs aren't supported on this platform.",
-          "@import 'package:nope/test';",
-          "        ^^^^^^^^^^^^^^^^^^^",
+          "  ,",
+          "1 | @import 'package:nope/test';",
+          "  |         ^^^^^^^^^^^^^^^^^^^",
+          "  '",
           "  test.scss 1:9  root stylesheet"
         ]));
     await sass.shouldExit(65);

--- a/test/cli/shared/repl.dart
+++ b/test/cli/shared/repl.dart
@@ -121,7 +121,7 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
     });
 
     test("an error after a warning", () async {
-      var sass = await runSass(["--interactive"]);
+      var sass = await runSass(["--no-unicode", "--interactive"]);
       sass.stdin.writeln("call('max', 1, 2) + blue");
       await expectLater(sass.stderr, emits(contains("DEPRECATION WARNING")));
       await expectLater(
@@ -129,8 +129,10 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
           emitsInOrder([
             ">> call('max', 1, 2) + blue",
             'Error: Undefined operation "2 + blue".',
-            "call('max', 1, 2) + blue",
-            "^^^^^^^^^^^^^^^^^^^^^^^^"
+            "  ,",
+            "1 | call('max', 1, 2) + blue",
+            "  | ^^^^^^^^^^^^^^^^^^^^^^^^",
+            "  '"
           ]));
       await sass.kill();
     });

--- a/test/node_api/importer_test.dart
+++ b/test/node_api/importer_test.dart
@@ -501,10 +501,10 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
-              "  ╷"
+              "  ╷\n"
               "1 │ @import 'foo'\n"
               "  │         ^^^^^\n"
-              "  ╵"
+              "  ╵\n"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -516,10 +516,10 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("oh no\n"
-              "  ╷"
+              "  ╷\n"
               "1 │ @import 'foo'\n"
               "  │         ^^^^^\n"
-              "  ╵"
+              "  ╵\n"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -532,10 +532,10 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
-              "  ╷"
+              "  ╷\n"
               "1 │ @import 'foo'\n"
               "  │         ^^^^^\n"
-              "  ╵"
+              "  ╵\n"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -545,10 +545,10 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
-              "  ╷"
+              "  ╷\n"
               "1 │ @import 'foo'\n"
               "  │         ^^^^^\n"
-              "  ╵"
+              "  ╵\n"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -558,10 +558,10 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
-              "  ╷"
+              "  ╷\n"
               "1 │ @import 'foo'\n"
               "  │         ^^^^^\n"
-              "  ╵"
+              "  ╵\n"
               "  stdin 1:9  root stylesheet"));
     });
   });
@@ -589,10 +589,10 @@ void main() {
                 });
               }))),
           completion(toStringAndMessageEqual("oh no\n"
-              "  ╷"
+              "  ╷\n"
               "1 │ @import 'foo'\n"
               "  │         ^^^^^\n"
-              "  ╵"
+              "  ╵\n"
               "  stdin 1:9  root stylesheet")));
     });
 
@@ -612,10 +612,10 @@ void main() {
               importer: allowInterop((_, __, ___) => jsNull))),
           completion(
               toStringAndMessageEqual("Can't find stylesheet to import.\n"
-                  "  ╷"
+                  "  ╷\n"
                   "1 │ @import 'foo'\n"
                   "  │         ^^^^^\n"
-                  "  ╵"
+                  "  ╵\n"
                   "  stdin 1:9  root stylesheet")));
     });
 
@@ -675,10 +675,10 @@ void main() {
                 }),
                 fiber: fiber)),
             completion(toStringAndMessageEqual("oh no\n"
-                "  ╷"
+                "  ╷\n"
                 "1 │ @import 'foo'\n"
                 "  │         ^^^^^\n"
-                "  ╵"
+                "  ╵\n"
                 "  stdin 1:9  root stylesheet")));
       });
 
@@ -690,10 +690,10 @@ void main() {
                 fiber: fiber)),
             completion(
                 toStringAndMessageEqual("Can't find stylesheet to import.\n"
-                    "  ╷"
+                    "  ╷\n"
                     "1 │ @import 'foo'\n"
                     "  │         ^^^^^\n"
-                    "  ╵"
+                    "  ╵\n"
                     "  stdin 1:9  root stylesheet")));
       });
     });

--- a/test/node_api/importer_test.dart
+++ b/test/node_api/importer_test.dart
@@ -501,8 +501,10 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
-              "@import 'foo'\n"
-              "        ^^^^^\n"
+              "  ╷"
+              "1 │ @import 'foo'\n"
+              "  │         ^^^^^\n"
+              "  ╵"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -514,8 +516,10 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("oh no\n"
-              "@import 'foo'\n"
-              "        ^^^^^\n"
+              "  ╷"
+              "1 │ @import 'foo'\n"
+              "  │         ^^^^^\n"
+              "  ╵"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -528,8 +532,10 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
-              "@import 'foo'\n"
-              "        ^^^^^\n"
+              "  ╷"
+              "1 │ @import 'foo'\n"
+              "  │         ^^^^^\n"
+              "  ╵"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -539,8 +545,10 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
-              "@import 'foo'\n"
-              "        ^^^^^\n"
+              "  ╷"
+              "1 │ @import 'foo'\n"
+              "  │         ^^^^^\n"
+              "  ╵"
               "  stdin 1:9  root stylesheet"));
     });
 
@@ -550,8 +558,10 @@ void main() {
       expect(
           error,
           toStringAndMessageEqual("Can't find stylesheet to import.\n"
-              "@import 'foo'\n"
-              "        ^^^^^\n"
+              "  ╷"
+              "1 │ @import 'foo'\n"
+              "  │         ^^^^^\n"
+              "  ╵"
               "  stdin 1:9  root stylesheet"));
     });
   });
@@ -579,8 +589,10 @@ void main() {
                 });
               }))),
           completion(toStringAndMessageEqual("oh no\n"
-              "@import 'foo'\n"
-              "        ^^^^^\n"
+              "  ╷"
+              "1 │ @import 'foo'\n"
+              "  │         ^^^^^\n"
+              "  ╵"
               "  stdin 1:9  root stylesheet")));
     });
 
@@ -600,8 +612,10 @@ void main() {
               importer: allowInterop((_, __, ___) => jsNull))),
           completion(
               toStringAndMessageEqual("Can't find stylesheet to import.\n"
-                  "@import 'foo'\n"
-                  "        ^^^^^\n"
+                  "  ╷"
+                  "1 │ @import 'foo'\n"
+                  "  │         ^^^^^\n"
+                  "  ╵"
                   "  stdin 1:9  root stylesheet")));
     });
 
@@ -661,8 +675,10 @@ void main() {
                 }),
                 fiber: fiber)),
             completion(toStringAndMessageEqual("oh no\n"
-                "@import 'foo'\n"
-                "        ^^^^^\n"
+                "  ╷"
+                "1 │ @import 'foo'\n"
+                "  │         ^^^^^\n"
+                "  ╵"
                 "  stdin 1:9  root stylesheet")));
       });
 
@@ -674,8 +690,10 @@ void main() {
                 fiber: fiber)),
             completion(
                 toStringAndMessageEqual("Can't find stylesheet to import.\n"
-                    "@import 'foo'\n"
-                    "        ^^^^^\n"
+                    "  ╷"
+                    "1 │ @import 'foo'\n"
+                    "  │         ^^^^^\n"
+                    "  ╵"
                     "  stdin 1:9  root stylesheet")));
       });
     });

--- a/test/node_api_test.dart
+++ b/test/node_api_test.dart
@@ -379,10 +379,10 @@ a {
           expect(
               error,
               toStringAndMessageEqual("Expected expression.\n"
-                  "  ╷"
+                  "  ╷\n"
                   "1 │ a {b: }\n"
                   "  │       ^\n"
-                  "  ╵"
+                  "  ╵\n"
                   "  stdin 1:7  root stylesheet"));
         });
 
@@ -403,10 +403,10 @@ a {
           expect(
               error,
               toStringAndMessageEqual('Undefined operation "1 % a".\n'
-                  '  ╷'
+                  '  ╷\n'
                   '1 │ a {b: 1 % a}\n'
                   '  │       ^^^^^\n'
-                  '  ╵'
+                  '  ╵\n'
                   '  $sassPath 1:7  root stylesheet'));
         });
 
@@ -426,10 +426,10 @@ a {
           expect(
               error,
               toStringAndMessageEqual('Undefined operation "1 % a".\n'
-                  '  ╷'
+                  '  ╷\n'
                   '1 │ a {b: 1 % a}\n'
                   '  │       ^^^^^\n'
-                  '  ╵'
+                  '  ╵\n'
                   '  stdin 1:7  root stylesheet'));
         });
 
@@ -477,10 +477,10 @@ a {
       expect(
           error.toString(),
           equals("Error: Expected expression.\n"
-              "  ╷"
+              "  ╷\n"
               "1 │ a {b: }\n"
               "  │       ^\n"
-              "  ╵"
+              "  ╵\n"
               "  $sassPath 1:7  root stylesheet"));
     });
   });

--- a/test/node_api_test.dart
+++ b/test/node_api_test.dart
@@ -277,8 +277,10 @@ a {
         expect(
             error.toString(),
             equals("Error: Expected expression.\n"
-                "x {y: }\n"
-                "      ^\n"
+                "  ╷"
+                "1 │ x {y: }\n"
+                "  │       ^\n"
+                "  ╵"
                 "  $sassPath 1:7  root stylesheet"));
       });
     });
@@ -350,8 +352,10 @@ a {
           expect(
               error,
               toStringAndMessageEqual("Expected expression.\n"
-                  "a {b: }\n"
-                  "      ^\n"
+                  "  ╷"
+                  "1 │ a {b: }\n"
+                  "  │       ^\n"
+                  "  ╵"
                   "  $sassPath 1:7  root stylesheet"));
         });
 
@@ -375,8 +379,10 @@ a {
           expect(
               error,
               toStringAndMessageEqual("Expected expression.\n"
-                  "a {b: }\n"
-                  "      ^\n"
+                  "  ╷"
+                  "1 │ a {b: }\n"
+                  "  │       ^\n"
+                  "  ╵"
                   "  stdin 1:7  root stylesheet"));
         });
 
@@ -397,8 +403,10 @@ a {
           expect(
               error,
               toStringAndMessageEqual('Undefined operation "1 % a".\n'
-                  'a {b: 1 % a}\n'
-                  '      ^^^^^\n'
+                  '  ╷'
+                  '1 │ a {b: 1 % a}\n'
+                  '  │       ^^^^^\n'
+                  '  ╵'
                   '  $sassPath 1:7  root stylesheet'));
         });
 
@@ -418,8 +426,10 @@ a {
           expect(
               error,
               toStringAndMessageEqual('Undefined operation "1 % a".\n'
-                  'a {b: 1 % a}\n'
-                  '      ^^^^^\n'
+                  '  ╷'
+                  '1 │ a {b: 1 % a}\n'
+                  '  │       ^^^^^\n'
+                  '  ╵'
                   '  stdin 1:7  root stylesheet'));
         });
 
@@ -467,8 +477,10 @@ a {
       expect(
           error.toString(),
           equals("Error: Expected expression.\n"
-              "a {b: }\n"
-              "      ^\n"
+              "  ╷"
+              "1 │ a {b: }\n"
+              "  │       ^\n"
+              "  ╵"
               "  $sassPath 1:7  root stylesheet"));
     });
   });

--- a/test/node_api_test.dart
+++ b/test/node_api_test.dart
@@ -277,10 +277,10 @@ a {
         expect(
             error.toString(),
             equals("Error: Expected expression.\n"
-                "  ╷"
+                "  ╷\n"
                 "1 │ x {y: }\n"
                 "  │       ^\n"
-                "  ╵"
+                "  ╵\n"
                 "  $sassPath 1:7  root stylesheet"));
       });
     });
@@ -352,10 +352,10 @@ a {
           expect(
               error,
               toStringAndMessageEqual("Expected expression.\n"
-                  "  ╷"
+                  "  ╷\n"
                   "1 │ a {b: }\n"
                   "  │       ^\n"
-                  "  ╵"
+                  "  ╵\n"
                   "  $sassPath 1:7  root stylesheet"));
         });
 


### PR DESCRIPTION
This adds a --no-unicode option to disable Unicode span rendering,
decouples repl highlighting from SourceSpan.highlight, and updates
tests to work with the new error highlighting.

See https://github.com/sass/sass-spec/pull/1334