### PR TITLE
Temporarily limit source_span to 1.4.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,9 @@ dependencies:
   package_resolver: "^1.0.0"
   path: "^1.6.0"
   source_maps: "^0.10.5"
-  source_span: "^1.4.0"
+  # Temporarily limit source_span to 1.4.x so we can land other fixes before we
+  # fix all the tests for the new source_span format. See #566.
+  source_span: ">=1.4.0 <1.5.0"
   stack_trace: ">=0.9.0 <2.0.0"
   stream_transform: "^0.0.1"
   string_scanner: ">=0.1.5 <2.0.0"


### PR DESCRIPTION
Getting all the tests update and the output looking nice is proving
more difficult than expected, and I want to unblock other pull
requests for Dart Sass in the meantime.

See #566