### PR TITLE
Fix "compound selectors may *no* longer be extended" error message

### DIFF
--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -611,7 +611,7 @@ class _EvaluateVisitor
       var compound = complex.components.first as CompoundSelector;
       if (compound.components.length != 1) {
         throw SassFormatException(
-            "compound selectors may longer be extended.\n"
+            "compound selectors may no longer be extended.\n"
             "Consider `@extend ${compound.components.join(', ')}` instead.\n"
             "See http://bit.ly/ExtendCompound for details.\n",
             targetText.span);

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 816959e86ecf3e10aaa0ced8a58a35cf3604b3b2
+// Checksum: 262c642b0cda0a5ed4984e763e9970422405efaa
 //
 // ignore_for_file: unused_import
 

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -615,7 +615,7 @@ class _EvaluateVisitor
       var compound = complex.components.first as CompoundSelector;
       if (compound.components.length != 1) {
         throw SassFormatException(
-            "compound selectors may longer be extended.\n"
+            "compound selectors may no longer be extended.\n"
             "Consider `@extend ${compound.components.join(', ')}` instead.\n"
             "See http://bit.ly/ExtendCompound for details.\n",
             targetText.span);

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 47ed1d2d77cf7e8f169e4e6b6c9d62d07455425a
+// Checksum: 8f251e6678ba3dd9a6687f7ad3405dd10bc2425d
 //
 // ignore_for_file: unused_import
 


### PR DESCRIPTION
As the title says. I just got this message in console and was confused for a second. Figured it was a typo.

See https://github.com/sass/sass-spec/pull/1335