### PR TITLE
Properly parse CR, CR LF, and FF as newlines everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.17.4
+
+* Consistently parse U+000C FORM FEED, U+000D CARRIAGE RETURN, and sequences of
+  U+000D CARRIAGE RETURN followed by U+000A LINE FEED as individual newlines.
+
 ## 1.17.3
 
 * Fix an edge case where slash-separated numbers were written to the stylesheet

--- a/lib/src/parse/scss.dart
+++ b/lib/src/parse/scss.dart
@@ -184,6 +184,16 @@ class ScssParser extends StylesheetParser {
           buffer.writeCharCode(scanner.readChar());
           return LoudComment(buffer.interpolation(scanner.spanFrom(start)));
 
+        case $cr:
+          scanner.readChar();
+          if (scanner.peekChar() != $lf) buffer.writeCharCode($lf);
+          break;
+
+        case $ff:
+          scanner.readChar();
+          buffer.writeCharCode($lf);
+          break;
+
         default:
           buffer.writeCharCode(scanner.readChar());
           break;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.17.3
+version: 1.17.4
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.17.4
+version: 1.17.4-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/test/output_test.dart
+++ b/test/output_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2019 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+// Almost all CSS output tests should go in sass-spec rather than here. This
+// just covers tests that explicitly validate out that's considered too
+// implementation-specific to verify in sass-spec.
+
+import 'package:test/test.dart';
+
+import 'package:sass/sass.dart';
+
+void main() {
+  // Regression test for sass/dart-sass#623. This needs to be tested here
+  // because sass-spec normalizes CR LF newlines.
+  group("normalizes newlines in a loud comment", () {
+    test("in SCSS", () {
+      expect(compileString("/* foo\r\n * bar */"), equals("/* foo\n * bar */"));
+    });
+
+    test("in Sass", () {
+      expect(compileString("/*\r\n  foo\r\n  bar", syntax: Syntax.sass),
+          equals("/* foo\n * bar */"));
+    });
+  });
+}


### PR DESCRIPTION
Closes #623

See https://github.com/sass/sass-spec/pull/1360