### PR TITLE
Clone CSS after importing it

### DIFF
--- a/lib/src/ast/css/modifiable/node.dart
+++ b/lib/src/ast/css/modifiable/node.dart
@@ -91,6 +91,9 @@ abstract class ModifiableCssParentNode extends ModifiableCssNode
         children = UnmodifiableListView(children);
 
   /// Returns a copy of [this] with an empty [children] list.
+  ///
+  /// This is *not* a deep copy. If other parts of this node are modifiable,
+  /// they are shared between the new and old nodes.
   ModifiableCssParentNode copyWithoutChildren();
 
   /// Adds [child] as a child of this statement.

--- a/lib/src/ast/css/modifiable/style_rule.dart
+++ b/lib/src/ast/css/modifiable/style_rule.dart
@@ -31,7 +31,7 @@ class ModifiableCssStyleRule extends ModifiableCssParentNode
   T accept<T>(ModifiableCssVisitor<T> visitor) =>
       visitor.visitCssStyleRule(this);
 
-  ModifiableCssStyleRule copyWithoutChildren() =>
-      ModifiableCssStyleRule(selector, span,
-          originalSelector: originalSelector);
+  ModifiableCssStyleRule copyWithoutChildren() => ModifiableCssStyleRule(
+      ModifiableCssValue(selector.value, selector.span), span,
+      originalSelector: originalSelector);
 }

--- a/lib/src/ast/css/modifiable/style_rule.dart
+++ b/lib/src/ast/css/modifiable/style_rule.dart
@@ -31,7 +31,7 @@ class ModifiableCssStyleRule extends ModifiableCssParentNode
   T accept<T>(ModifiableCssVisitor<T> visitor) =>
       visitor.visitCssStyleRule(this);
 
-  ModifiableCssStyleRule copyWithoutChildren() => ModifiableCssStyleRule(
-      ModifiableCssValue(selector.value, selector.span), span,
-      originalSelector: originalSelector);
+  ModifiableCssStyleRule copyWithoutChildren() =>
+      ModifiableCssStyleRule(selector, span,
+          originalSelector: originalSelector);
 }

--- a/lib/src/async_environment.dart
+++ b/lib/src/async_environment.dart
@@ -16,6 +16,7 @@ import 'functions.dart';
 import 'util/public_member_map.dart';
 import 'utils.dart';
 import 'value.dart';
+import 'visitor/clone_css.dart';
 
 /// The lexical environment in which Sass is executed.
 ///
@@ -656,5 +657,13 @@ class _EnvironmentModule implements AsyncModule {
       _environment._variableNodes.first[name] = nodeWithSpan;
     }
     return;
+  }
+
+  AsyncModule cloneCss() {
+    if (css.children.isEmpty) return this;
+
+    var newCssAndExtender = cloneCssStylesheet(css, extender);
+    return _EnvironmentModule(
+        _environment, newCssAndExtender.item1, newCssAndExtender.item2);
   }
 }

--- a/lib/src/async_environment.dart
+++ b/lib/src/async_environment.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 
 import 'ast/css.dart';
@@ -621,6 +622,8 @@ class AsyncEnvironment {
 
 /// A module that represents the top-level members defined in an [Environment].
 class _EnvironmentModule implements AsyncModule {
+  Uri get url => css.span.sourceUrl;
+
   final List<AsyncModule> upstream;
   final Map<String, Value> variables;
   final Map<String, AstNode> variableNodes;
@@ -666,4 +669,6 @@ class _EnvironmentModule implements AsyncModule {
     return _EnvironmentModule(
         _environment, newCssAndExtender.item1, newCssAndExtender.item2);
   }
+
+  String toString() => p.prettyUri(css.span.sourceUrl);
 }

--- a/lib/src/async_environment.dart
+++ b/lib/src/async_environment.dart
@@ -632,6 +632,7 @@ class _EnvironmentModule implements AsyncModule {
   final Extender extender;
   final CssStylesheet css;
   final bool transitivelyContainsCss;
+  final bool transitivelyContainsExtensions;
 
   /// The environment that defines this module's members.
   final AsyncEnvironment _environment;
@@ -648,7 +649,10 @@ class _EnvironmentModule implements AsyncModule {
         mixins = PublicMemberMap(_environment._mixins.first),
         transitivelyContainsCss = css.children.isNotEmpty ||
             _environment._allModules
-                .any((module) => module.transitivelyContainsCss);
+                .any((module) => module.transitivelyContainsCss),
+        transitivelyContainsExtensions = !extender.isEmpty ||
+            _environment._allModules
+                .any((module) => module.transitivelyContainsExtensions);
 
   void setVariable(String name, Value value, AstNode nodeWithSpan) {
     if (!_environment._variables.first.containsKey(name)) {

--- a/lib/src/async_module.dart
+++ b/lib/src/async_module.dart
@@ -62,4 +62,7 @@ abstract class AsyncModule {
   /// Throws a [SassScriptException] if this module doesn't define a variable
   /// named [name].
   void setVariable(String name, Value value, AstNode nodeWithSpan);
+
+  /// Creates a copy of this module with new [css] and [extender].
+  AsyncModule cloneCss();
 }

--- a/lib/src/async_module.dart
+++ b/lib/src/async_module.dart
@@ -58,6 +58,10 @@ abstract class AsyncModule {
   /// Whether this module *or* any modules in [upstream] contain any CSS.
   bool get transitivelyContainsCss;
 
+  /// Whether this module *or* any modules in [upstream] contain `@extend`
+  /// rules..
+  bool get transitivelyContainsExtensions;
+
   /// Sets the variable named [name] to [value], associated with
   /// [nodeWithSpan]'s source span.
   ///

--- a/lib/src/async_module.dart
+++ b/lib/src/async_module.dart
@@ -12,6 +12,12 @@ import 'value.dart';
 
 /// The interface for a Sass module.
 abstract class AsyncModule {
+  /// The canonical URL for this module's source file.
+  ///
+  /// This may be `null` if the module was loaded from a string without a URL
+  /// provided.
+  Uri get url;
+
   /// Modules that this module uses.
   List<AsyncModule> get upstream;
 

--- a/lib/src/environment.dart
+++ b/lib/src/environment.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_environment.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 097eb94cd15103bf4bef739a61e61414db4b55b1
+// Checksum: 3210a5c0528eac456ae8ca7827b65f3976f6b29d
 //
 // ignore_for_file: unused_import
 
@@ -634,6 +634,7 @@ class _EnvironmentModule implements Module {
   final Extender extender;
   final CssStylesheet css;
   final bool transitivelyContainsCss;
+  final bool transitivelyContainsExtensions;
 
   /// The environment that defines this module's members.
   final Environment _environment;
@@ -650,7 +651,10 @@ class _EnvironmentModule implements Module {
         mixins = PublicMemberMap(_environment._mixins.first),
         transitivelyContainsCss = css.children.isNotEmpty ||
             _environment._allModules
-                .any((module) => module.transitivelyContainsCss);
+                .any((module) => module.transitivelyContainsCss),
+        transitivelyContainsExtensions = !extender.isEmpty ||
+            _environment._allModules
+                .any((module) => module.transitivelyContainsExtensions);
 
   void setVariable(String name, Value value, AstNode nodeWithSpan) {
     if (!_environment._variables.first.containsKey(name)) {

--- a/lib/src/environment.dart
+++ b/lib/src/environment.dart
@@ -5,10 +5,11 @@
 // DO NOT EDIT. This file was generated from async_environment.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 36876e7e932a30409d59d0fa256ad02d25934aab
+// Checksum: 097eb94cd15103bf4bef739a61e61414db4b55b1
 //
 // ignore_for_file: unused_import
 
+import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 
 import 'ast/css.dart';
@@ -623,6 +624,8 @@ class Environment {
 
 /// A module that represents the top-level members defined in an [Environment].
 class _EnvironmentModule implements Module {
+  Uri get url => css.span.sourceUrl;
+
   final List<Module> upstream;
   final Map<String, Value> variables;
   final Map<String, AstNode> variableNodes;
@@ -668,4 +671,6 @@ class _EnvironmentModule implements Module {
     return _EnvironmentModule(
         _environment, newCssAndExtender.item1, newCssAndExtender.item2);
   }
+
+  String toString() => p.prettyUri(css.span.sourceUrl);
 }

--- a/lib/src/environment.dart
+++ b/lib/src/environment.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_environment.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 0969eab1df3ee05f1029ebe1a5e2485580032491
+// Checksum: 36876e7e932a30409d59d0fa256ad02d25934aab
 //
 // ignore_for_file: unused_import
 
@@ -21,6 +21,7 @@ import 'functions.dart';
 import 'util/public_member_map.dart';
 import 'utils.dart';
 import 'value.dart';
+import 'visitor/clone_css.dart';
 
 /// The lexical environment in which Sass is executed.
 ///
@@ -658,5 +659,13 @@ class _EnvironmentModule implements Module {
       _environment._variableNodes.first[name] = nodeWithSpan;
     }
     return;
+  }
+
+  Module cloneCss() {
+    if (css.children.isEmpty) return this;
+
+    var newCssAndExtender = cloneCssStylesheet(css, extender);
+    return _EnvironmentModule(
+        _environment, newCssAndExtender.item1, newCssAndExtender.item2);
   }
 }

--- a/lib/src/extend/empty_extender.dart
+++ b/lib/src/extend/empty_extender.dart
@@ -42,4 +42,7 @@ class EmptyExtender implements Extender {
     throw UnsupportedError(
         "addExtensions() can't be called for a const Extender.");
   }
+
+  Tuple2<Extender, Map<CssStyleRule, ModifiableCssStyleRule>> clone() =>
+      const Tuple2(EmptyExtender(), {});
 }

--- a/lib/src/extend/extender.dart
+++ b/lib/src/extend/extender.dart
@@ -914,7 +914,13 @@ class Extender {
       newSelectors[simple] = newRules;
 
       for (var rule in rules) {
-        var newRule = rule.copyWithoutChildren();
+        // We can't use [StyleRule.copyWithoutChildren] here because it doesn't
+        // copy the [ModifiableCssValue<Selector>], which we need to do to
+        // properly isolate extensions.
+        var newRule = ModifiableCssStyleRule(
+            ModifiableCssValue(rule.selector.value, rule.selector.span),
+            rule.span,
+            originalSelector: rule.originalSelector);
         newRules.add(newRule);
         oldToNewRules[rule] = newRule;
 

--- a/lib/src/extend/extender.dart
+++ b/lib/src/extend/extender.dart
@@ -398,6 +398,7 @@ class Extender {
     Map<SimpleSelector, Map<ComplexSelector, Extension>> newExtensions;
 
     for (var extender in extenders) {
+      if (extender.isEmpty) continue;
       extender._extensions.forEach((target, newSources) {
         // Private selectors can't be extended across module boundaries.
         if (target is PlaceholderSelector && target.isPrivate) return;

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_module.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: e85903dbb32318c558ca4132a78dca55ee617280
+// Checksum: 895440529b78f1ef2830cf105af00dba0755e947
 //
 // ignore_for_file: unused_import
 
@@ -19,6 +19,12 @@ import 'value.dart';
 
 /// The interface for a Sass module.
 abstract class Module {
+  /// The canonical URL for this module's source file.
+  ///
+  /// This may be `null` if the module was loaded from a string without a URL
+  /// provided.
+  Uri get url;
+
   /// Modules that this module uses.
   List<Module> get upstream;
 

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_module.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: c8cda9eb650a827924cb601386be7d507faa7a61
+// Checksum: e85903dbb32318c558ca4132a78dca55ee617280
 //
 // ignore_for_file: unused_import
 
@@ -69,4 +69,7 @@ abstract class Module {
   /// Throws a [SassScriptException] if this module doesn't define a variable
   /// named [name].
   void setVariable(String name, Value value, AstNode nodeWithSpan);
+
+  /// Creates a copy of this module with new [css] and [extender].
+  Module cloneCss();
 }

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_module.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 895440529b78f1ef2830cf105af00dba0755e947
+// Checksum: d996840504b080c2c4e6b34136562b8152bb2e97
 //
 // ignore_for_file: unused_import
 
@@ -64,6 +64,10 @@ abstract class Module {
 
   /// Whether this module *or* any modules in [upstream] contain any CSS.
   bool get transitivelyContainsCss;
+
+  /// Whether this module *or* any modules in [upstream] contain `@extend`
+  /// rules..
+  bool get transitivelyContainsExtensions;
 
   /// Sets the variable named [name] to [value], associated with
   /// [nodeWithSpan]'s source span.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -440,3 +440,12 @@ Future<Map<String, V2>> normalizedMapMapAsync<K, V1, V2>(Map<K, V1> map,
   }
   return result;
 }
+
+/// Returns a deep copy of a map that contains maps.
+Map<K1, Map<K2, V>> copyMapOfMap<K1, K2, V>(Map<K1, Map<K2, V>> map) =>
+    mapMap<K1, Map<K2, V>, K1, Map<K2, V>>(map,
+        value: (_, innerMap) => Map.of(innerMap));
+
+/// Returns a deep copy of a map that contains lists.
+Map<K, List<E>> copyMapOfList<K, E>(Map<K, List<E>> map) =>
+    mapMap<K, List<E>, K, List<E>>(map, value: (_, list) => list.toList());

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -1033,7 +1033,12 @@ class _EvaluateVisitor
     var module = environment.toModule(
         CssStylesheet(const [], stylesheet.span), Extender.empty);
     if (module.transitivelyContainsCss) {
-      await _combineCss(module, clone: true).accept(this);
+      // If any transitively used module contains extensions, we need to clone
+      // all modules' CSS. Otherwise, it's possible that they'll be used or
+      // imported from another location that shouldn't have the same extensions
+      // applied.
+      await _combineCss(module, clone: module.transitivelyContainsExtensions)
+          .accept(this);
     }
 
     var visitor = _ImportedCssVisitor(this);

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -439,7 +439,10 @@ class _EvaluateVisitor
   /// modules transitively used by [root].
   ///
   /// This also applies each module's extensions to its upstream modules.
-  CssStylesheet _combineCss(AsyncModule root) {
+  ///
+  /// If [clone] is `true`, this will copy the modules before extending them so
+  /// that they don't modify [root] or its dependencies.
+  CssStylesheet _combineCss(AsyncModule root, {bool clone = false}) {
     // TODO(nweiz): short-circuit if no upstream modules (transitively) include
     // any CSS.
     if (root.upstream.isEmpty) {
@@ -454,6 +457,9 @@ class _EvaluateVisitor
     }
 
     var sortedModules = _topologicalModules(root);
+    if (clone) {
+      sortedModules = sortedModules.map((module) => module.cloneCss()).toList();
+    }
     _extendModules(sortedModules);
 
     // The imports (and comments between them) that should be included at the
@@ -476,11 +482,11 @@ class _EvaluateVisitor
   /// Extends the selectors in each module with the extensions defined in
   /// downstream modules.
   void _extendModules(List<AsyncModule> sortedModules) {
-    // All the extenders directly downstream of a given module. It's important
-    // that we create this in topological order, so that by the time we're
-    // processing a module we've already filled in all its downstream extenders
-    // and we can use them to extend that module.
-    var downstreamExtenders = <AsyncModule, List<Extender>>{};
+    // All the extenders directly downstream of a given module (indexed by its
+    // canonical URL). It's important that we create this in topological order,
+    // so that by the time we're processing a module we've already filled in all
+    // its downstream extenders and we can use them to extend that module.
+    var downstreamExtenders = <Uri, List<Extender>>{};
 
     /// Extensions that haven't yet been satisfied by some upstream module. This
     /// adds extensions when they're defined but not satisfied, and removes them
@@ -498,13 +504,13 @@ class _EvaluateVisitor
       unsatisfiedExtensions.addAll(module.extender.extensionsWhereTarget(
           (target) => !originalSelectors.contains(target)));
 
-      var extenders = downstreamExtenders[module];
+      var extenders = downstreamExtenders[module.url];
       if (extenders != null) module.extender.addExtensions(extenders);
       if (module.extender.isEmpty) continue;
 
       for (var upstream in module.upstream) {
         downstreamExtenders
-            .putIfAbsent(upstream, () => [])
+            .putIfAbsent(upstream.url, () => [])
             .add(module.extender);
       }
 
@@ -1026,7 +1032,9 @@ class _EvaluateVisitor
     // the CSS from modules used by [stylesheet].
     var module = environment.toModule(
         CssStylesheet(const [], stylesheet.span), Extender.empty);
-    if (module.transitivelyContainsCss) await _combineCss(module).accept(this);
+    if (module.transitivelyContainsCss) {
+      await _combineCss(module, clone: true).accept(this);
+    }
 
     var visitor = _ImportedCssVisitor(this);
     for (var child in children) {

--- a/lib/src/visitor/clone_css.dart
+++ b/lib/src/visitor/clone_css.dart
@@ -1,0 +1,86 @@
+// Copyright 2019 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:tuple/tuple.dart';
+
+import '../ast/css.dart';
+import '../ast/css/modifiable.dart';
+import '../extend/extender.dart';
+import 'interface/css.dart';
+
+/// Returns deep copies of both [stylesheet] and [extender].
+///
+/// The [extender] must be associated with [stylesheet].
+Tuple2<ModifiableCssStylesheet, Extender> cloneCssStylesheet(
+    CssStylesheet stylesheet, Extender extender) {
+  var result = extender.clone();
+  var newExtender = result.item1;
+  var oldToNewRules = result.item2;
+
+  return Tuple2(_CloneCssVisitor(oldToNewRules).visitCssStylesheet(stylesheet),
+      newExtender);
+}
+
+/// A visitor that creates a deep (and mutable) copy of a [CssStylesheet].
+class _CloneCssVisitor implements CssVisitor<ModifiableCssNode> {
+  /// A map from style rules in the original stylesheet to style rules generated
+  /// for the new stylesheet using [Extender.clone].
+  final Map<CssStyleRule, ModifiableCssStyleRule> _oldToNewRules;
+
+  _CloneCssVisitor(this._oldToNewRules);
+
+  ModifiableCssAtRule visitCssAtRule(CssAtRule node) {
+    var rule = ModifiableCssAtRule(node.name, node.span,
+        childless: node.isChildless, value: node.value);
+    return node.isChildless ? rule : _visitChildren(rule, node);
+  }
+
+  ModifiableCssComment visitCssComment(CssComment node) =>
+      ModifiableCssComment(node.text, node.span);
+
+  ModifiableCssDeclaration visitCssDeclaration(CssDeclaration node) =>
+      ModifiableCssDeclaration(node.name, node.value, node.span,
+          valueSpanForMap: node.valueSpanForMap);
+
+  ModifiableCssImport visitCssImport(CssImport node) =>
+      ModifiableCssImport(node.url, node.span,
+          supports: node.supports, media: node.media);
+
+  ModifiableCssKeyframeBlock visitCssKeyframeBlock(CssKeyframeBlock node) =>
+      _visitChildren(
+          ModifiableCssKeyframeBlock(node.selector, node.span), node);
+
+  ModifiableCssMediaRule visitCssMediaRule(CssMediaRule node) =>
+      _visitChildren(ModifiableCssMediaRule(node.queries, node.span), node);
+
+  ModifiableCssStyleRule visitCssStyleRule(CssStyleRule node) {
+    var newRule = _oldToNewRules[node];
+    if (newRule == null) {
+      throw StateError(
+          "The Extender and CssStylesheet passed to cloneCssStylesheet() must "
+          "come from the same compilation.");
+    }
+
+    return _visitChildren(newRule, node);
+  }
+
+  ModifiableCssStylesheet visitCssStylesheet(CssStylesheet node) =>
+      _visitChildren(ModifiableCssStylesheet(node.span), node);
+
+  ModifiableCssSupportsRule visitCssSupportsRule(CssSupportsRule node) =>
+      _visitChildren(
+          ModifiableCssSupportsRule(node.condition, node.span), node);
+
+  /// Visits [oldParent]'s children and adds their cloned values as children of
+  /// [newParent], then returns [newParent].
+  T _visitChildren<T extends ModifiableCssParentNode>(
+      T newParent, CssParentNode oldParent) {
+    for (var child in oldParent.children) {
+      var newChild = child.accept(this);
+      newChild.isGroupEnd = child.isGroupEnd;
+      newParent.addChild(newChild);
+    }
+    return newParent;
+  }
+}

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/synchronize.dart for details.
 //
-// Checksum: 0f4f00db38a7f2a60771d3d50652cbfdeb322e52
+// Checksum: 4de442e73c75611a675e2fd0d8962219f1ceffd7
 //
 // ignore_for_file: unused_import
 
@@ -1036,7 +1036,12 @@ class _EvaluateVisitor
     var module = environment.toModule(
         CssStylesheet(const [], stylesheet.span), Extender.empty);
     if (module.transitivelyContainsCss) {
-      _combineCss(module, clone: true).accept(this);
+      // If any transitively used module contains extensions, we need to clone
+      // all modules' CSS. Otherwise, it's possible that they'll be used or
+      // imported from another location that shouldn't have the same extensions
+      // applied.
+      _combineCss(module, clone: module.transitivelyContainsExtensions)
+          .accept(this);
     }
 
     var visitor = _ImportedCssVisitor(this);


### PR DESCRIPTION
This is necessary to ensure that @extends are properly scoped in all
cases.

See https://github.com/sass/sass-spec/pull/1368