### PR TITLE
Fix importing files relative to "package:" imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.17.5
+
+* Fix importing files relative to `package:`-imported files.
+
+### Dart API
+
+* Explicitly require that importers' `canonicalize()` methods be able to take
+  paths relative to their outputs as valid inputs. This isn't considered a
+  breaking change because the importer infrastructure already required this in
+  practice.
+
 ## 1.17.4
 
 * Consistently parse U+000C FORM FEED, U+000D CARRIAGE RETURN, and sequences of

--- a/lib/src/importer/async.dart
+++ b/lib/src/importer/async.dart
@@ -68,8 +68,10 @@ abstract class AsyncImporter {
   ///
   /// If no stylesheets are found, the importer should return `null`.
   ///
-  /// Sass assumes that calling [canonicalize] multiple times with the same URL
-  /// will return the same result.
+  /// Calling [canonicalize] multiple times with the same URL must return the
+  /// same result. Calling [canonicalize] with a URL returned by [canonicalize]
+  /// must return that URL. Calling [canonicalize] with a URL relative to one
+  /// returned by [canonicalize] must return a meaningful result.
   FutureOr<Uri> canonicalize(Uri url);
 
   /// Loads the Sass text for the given [url], or returns `null` if

--- a/lib/src/importer/package.dart
+++ b/lib/src/importer/package.dart
@@ -29,6 +29,7 @@ class PackageImporter extends Importer {
   PackageImporter(this._packageResolver);
 
   Uri canonicalize(Uri url) {
+    if (url.scheme == 'file') return _filesystemImporter.canonicalize(url);
     if (url.scheme != 'package') return null;
 
     var resolved = _packageResolver.resolveUri(url);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.17.4
+version: 1.17.5-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/test/dart_api_test.dart
+++ b/test/dart_api_test.dart
@@ -100,6 +100,22 @@ main() {
       expect(css, equals("a {\n  b: 3;\n}"));
     });
 
+    test("can resolve relative paths in a package", () async {
+      await d.dir("subdir", [
+        d.file("test.scss", "@import 'other'"),
+        d.file("_other.scss", "a {b: 1 + 2}"),
+      ]).create();
+
+      await d
+          .file("test.scss", '@import "package:fake_package/test";')
+          .create();
+      var resolver = SyncPackageResolver.config(
+          {"fake_package": p.toUri(d.path('subdir'))});
+
+      var css = compile(d.path("test.scss"), packageResolver: resolver);
+      expect(css, equals("a {\n  b: 3;\n}"));
+    });
+
     test("doesn't import a package URL from a missing package", () async {
       await d
           .file("test.scss", '@import "package:fake_package/test_aux";')


### PR DESCRIPTION
The PackageImporter wasn't accepting paths relative to its
canonicalized outputs as inputs.

Closes #631