### PR TITLE
Don't recursively list directories in realCasePath()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.17.5
+
+* Avoid recursively listing directories when finding the canonical name of a
+  file on case-insensitive filesystems.
+
 ## 1.17.4
 
 * Consistently parse U+000C FORM FEED, U+000D CARRIAGE RETURN, and sequences of

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -356,7 +356,7 @@ class ExecutableOptions {
   /// [destination] directories.
   Map<String, String> _listSourceDirectory(String source, String destination) {
     var map = <String, String>{};
-    for (var path in listDir(source)) {
+    for (var path in listDir(source, recursive: true)) {
       var basename = p.basename(path);
       if (basename.startsWith("_")) continue;
 

--- a/lib/src/io/interface.dart
+++ b/lib/src/io/interface.dart
@@ -79,9 +79,11 @@ bool dirExists(String path) => null;
 /// necessary.
 void ensureDir(String path) => null;
 
-/// Recursively lists the files (not sub-directories) of the directory at
-/// [path].
-Iterable<String> listDir(String path) => null;
+/// Lists the files (not sub-directories) in the directory at [path].
+///
+/// If [recursive] is `true`, this lists files in directories transitively
+/// beneath [path] as well.
+Iterable<String> listDir(String path, {bool recursive = false}) => null;
 
 /// Returns the modification time of the file at [path].
 DateTime modificationTime(String path) => null;

--- a/lib/src/io/node.dart
+++ b/lib/src/io/node.dart
@@ -191,14 +191,23 @@ void ensureDir(String path) {
   });
 }
 
-Iterable<String> listDir(String path) {
-  Iterable<String> list(String parent) =>
-      _fs.readdirSync(parent).expand((child) {
-        var path = p.join(parent, child as String);
-        return dirExists(path) ? listDir(path) : [path];
-      });
+Iterable<String> listDir(String path, {bool recursive = false}) {
+  return _systemErrorToFileSystemException(() {
+    if (!recursive) {
+      return _fs
+          .readdirSync(parent)
+          .map((child) => p.join(parent, child as String))
+          .where((path) => !dirExists(path));
+    } else {
+      Iterable<String> list(String parent) =>
+          _fs.readdirSync(parent).expand((child) {
+            var path = p.join(parent, child as String);
+            return dirExists(path) ? list(path) : [path];
+          });
 
-  return _systemErrorToFileSystemException(() => list(path));
+      return list(path);
+    }
+  });
 }
 
 DateTime modificationTime(String path) =>

--- a/lib/src/io/node.dart
+++ b/lib/src/io/node.dart
@@ -195,9 +195,9 @@ Iterable<String> listDir(String path, {bool recursive = false}) {
   return _systemErrorToFileSystemException(() {
     if (!recursive) {
       return _fs
-          .readdirSync(parent)
-          .map((child) => p.join(parent, child as String))
-          .where((path) => !dirExists(path));
+          .readdirSync(path)
+          .map((child) => p.join(path, child as String))
+          .where((child) => !dirExists(child));
     } else {
       Iterable<String> list(String parent) =>
           _fs.readdirSync(parent).expand((child) {

--- a/lib/src/io/vm.dart
+++ b/lib/src/io/vm.dart
@@ -71,10 +71,11 @@ bool dirExists(String path) => io.Directory(path).existsSync();
 
 void ensureDir(String path) => io.Directory(path).createSync(recursive: true);
 
-Iterable<String> listDir(String path) => io.Directory(path)
-    .listSync(recursive: true)
-    .where((entity) => entity is io.File)
-    .map((entity) => entity.path);
+Iterable<String> listDir(String path, {bool recursive = false}) =>
+    io.Directory(path)
+        .listSync(recursive: recursive)
+        .where((entity) => entity is io.File)
+        .map((entity) => entity.path);
 
 DateTime modificationTime(String path) {
   var stat = io.FileStat.statSync(path);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.17.4
+version: 1.17.5-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
We only need to list the path's immediate parent directory in order to
find its real case.

Closes #636 