### PR TITLE
Make FilesystemImport._loadPath absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.18.1
+
+### Dart API
+
+* `FilesystemImporter` now doesn't change its effective directory if the working
+  directory changes, even if it's passed a relative argument.
+
 ## 1.18.0
 
 * Avoid recursively listing directories when finding the canonical name of a

--- a/lib/src/importer/filesystem.dart
+++ b/lib/src/importer/filesystem.dart
@@ -18,7 +18,7 @@ class FilesystemImporter extends Importer {
   final String _loadPath;
 
   /// Creates an importer that loads files relative to [loadPath].
-  FilesystemImporter(this._loadPath);
+  FilesystemImporter(String loadPath) : _loadPath = p.absolute(loadPath);
 
   Uri canonicalize(Uri url) {
     if (url.scheme != 'file' && url.scheme != '') return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.18.0
+version: 1.18.1-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
This avoids having the effective load path change when the process's
working directory changes.