### PR TITLE
Make sass compiler compatible with bazel persistent worker.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ environment:
 dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.10.0 <3.0.0"
+  bazel_worker: ">0.1.0"
   charcode: "^1.1.0"
   cli_repl: ">=0.1.3 <0.3.0"
   collection: "^1.8.0"


### PR DESCRIPTION
This is required before we can turn on persistent worker support in [sass_binary bazel rule](https://github.com/bazelbuild/rules_sass).

Tested that `dartanalyzer lib test` and `pub run test -x node` all pass.