### PR TITLE
Run app-snapshot in the before-test grinder task

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -35,5 +35,5 @@ format() {
 npmInstall() => run("npm", arguments: ["install"]);
 
 @Task('Runs the tasks that are required for running tests.')
-@Depends(format, synchronize, npmPackage, npmInstall)
+@Depends(format, synchronize, npmPackage, npmInstall, appSnapshot)
 beforeTest() {}

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -5,6 +5,7 @@
 import 'package:grinder/grinder.dart';
 
 import 'grind/npm.dart';
+import 'grind/standalone.dart';
 import 'grind/synchronize.dart';
 
 export 'grind/bazel.dart';


### PR DESCRIPTION
This matches the behavior recommended by the tests if the snapshot is
out-of-date.