### PR TITLE
Re-enable testing against Node stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,10 +72,9 @@ jobs:
   #
   # [this issue]: https://travis-ci.community/t/windows-instances-hanging-before-install/250/28.
   - &node-tests
-    name: Node tests | Dart stable | Node 11
+    name: Node tests | Dart stable | Node stable
     language: node_js
-    # TODO(nweiz): Make this "stable" when laverdet/node-fibers#409 is fixed.
-    node_js: 11
+    node_js: stable
     install: pub run grinder before-test
     script: tool/travis/task/node_tests.sh
   - <<: *node-tests

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "node-sass": "^4.11.0",
     "chokidar": "^2.0.0",
-    "fibers": ">=1.0.0 <4.0.0",
+    "fibers": ">=1.0.0 <5.0.0",
     "intercept-stdout": "^0.1.2"
   }
 }


### PR DESCRIPTION
laverdet/node-fibers#409 has been fixed in Fibers 4.0.0.