### PR TITLE
Build standalone Mac OS releases on Mac OS bots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,8 @@ jobs:
       (type IN (push, api)) AND (repo = sass/dart-sass) AND tag =~ ^\d+\.\d+\.\d+([+-].*)?$
     script: pub run grinder sanity-check-before-release
 
-  # Deploy to GitHub.
+  # Deploy Linux and Windows releases to GitHub. Mac OS releases are deployed in
+  # a later stage so that we can build application snapshots on Mac OS bots.
   - stage: deploy 1
     if: *deploy-if
     env: &github-env
@@ -115,7 +116,7 @@ jobs:
     script: skip # Don't run tests
     deploy:
       provider: script
-      script: pub run grinder github-release
+      script: pub run grinder github-release github-linux github-windows
       skip_cleanup: true # Don't clean up the Dart SDK.
 
       # This causes the deploy to only be build when a tag is pushed. This
@@ -193,5 +194,14 @@ jobs:
     deploy:
       provider: script
       script: pub run grinder update-bazel
+      skip_cleanup: true
+      on: {tags: true}
+
+  - if: *deploy-if
+    env: *github-env
+    script: skip
+    deploy:
+      provider: script
+      script: pub run grinder github-mac-os
       skip_cleanup: true
       on: {tags: true}

--- a/tool/grind/standalone.dart
+++ b/tool/grind/standalone.dart
@@ -47,74 +47,79 @@ void _appSnapshot({@required bool release}) {
       arguments: ['tool/app-snapshot-input.scss'], vmArgs: args, quiet: true);
 }
 
-@Task('Build standalone packages for all OSes.')
+@Task('Build standalone packages for Linux.')
 @Depends(snapshot, releaseAppSnapshot)
-package() async {
+packageLinux() => _buildPackage("linux");
+
+@Task('Build standalone packages for Mac OS.')
+@Depends(snapshot, releaseAppSnapshot)
+packageMacOs() => _buildPackage("macos");
+
+@Task('Build standalone packages for Windows.')
+@Depends(snapshot, releaseAppSnapshot)
+packageWindows() => _buildPackage("windows");
+
+/// Builds standalone 32- and 64-bit Sass packages for the given [os].
+Future _buildPackage(String os) async {
   var client = http.Client();
-  await Future.wait(["linux", "macos", "windows"].expand((os) => [
-        _buildPackage(client, os, x64: true),
-        _buildPackage(client, os, x64: false)
-      ]));
-  client.close();
-}
+  await Future.wait(["ia32", "x64"].map((architecture) async {
+    // TODO: Compile a single executable that embeds the Dart VM and the
+    // snapshot when dart-lang/sdk#27596 is fixed.
+    var channel = isDevSdk ? "dev" : "stable";
+    var url = "https://storage.googleapis.com/dart-archive/channels/$channel/"
+        "release/$dartVersion/sdk/dartsdk-$os-$architecture-release.zip";
+    log("Downloading $url...");
+    var response = await client.get(Uri.parse(url));
+    if (response.statusCode ~/ 100 != 2) {
+      throw "Failed to download package: ${response.statusCode} "
+          "${response.reasonPhrase}.";
+    }
 
-/// Builds a standalone Sass package for the given [os] and architecture.
-///
-/// The [client] is used to download the corresponding Dart SDK.
-Future _buildPackage(http.Client client, String os, {bool x64 = true}) async {
-  var architecture = x64 ? "x64" : "ia32";
+    var dartExecutable = ZipDecoder()
+        .decodeBytes(response.bodyBytes)
+        .firstWhere((file) => os == 'windows'
+            ? file.name.endsWith("/bin/dart.exe")
+            : file.name.endsWith("/bin/dart"));
+    var executable = dartExecutable.content as List<int>;
 
-  // TODO: Compile a single executable that embeds the Dart VM and the snapshot
-  // when dart-lang/sdk#27596 is fixed.
-  var channel = isDevSdk ? "dev" : "stable";
-  var url = "https://storage.googleapis.com/dart-archive/channels/$channel/"
-      "release/$dartVersion/sdk/dartsdk-$os-$architecture-release.zip";
-  log("Downloading $url...");
-  var response = await client.get(Uri.parse(url));
-  if (response.statusCode ~/ 100 != 2) {
-    throw "Failed to download package: ${response.statusCode} "
-        "${response.reasonPhrase}.";
-  }
+    // Use the app snapshot when packaging for the current operating system.
+    //
+    // TODO: Use an app snapshot everywhere when dart-lang/sdk#28617 is fixed.
+    var snapshot =
+        os == Platform.operatingSystem && (architecture == "x64") == _is64Bit
+            ? "build/sass.dart.app.snapshot"
+            : "build/sass.dart.snapshot";
 
-  var dartExecutable = ZipDecoder().decodeBytes(response.bodyBytes).firstWhere(
-      (file) => os == 'windows'
-          ? file.name.endsWith("/bin/dart.exe")
-          : file.name.endsWith("/bin/dart"));
-  var executable = dartExecutable.content as List<int>;
+    var archive = Archive()
+      ..addFile(fileFromBytes(
+          "dart-sass/src/dart${os == 'windows' ? '.exe' : ''}", executable,
+          executable: true))
+      ..addFile(
+          file("dart-sass/src/DART_LICENSE", p.join(sdkDir.path, 'LICENSE')))
+      ..addFile(file("dart-sass/src/sass.dart.snapshot", snapshot))
+      ..addFile(file("dart-sass/src/SASS_LICENSE", "LICENSE"))
+      ..addFile(fileFromString(
+          "dart-sass/dart-sass${os == 'windows' ? '.bat' : ''}",
+          readAndReplaceVersion(
+              "package/dart-sass.${os == 'windows' ? 'bat' : 'sh'}"),
+          executable: true))
+      ..addFile(fileFromString(
+          "dart-sass/sass${os == 'windows' ? '.bat' : ''}",
+          readAndReplaceVersion(
+              "package/sass.${os == 'windows' ? 'bat' : 'sh'}"),
+          executable: true));
 
-  // Use the app snapshot when packaging for the current operating system.
-  //
-  // TODO: Use an app snapshot everywhere when dart-lang/sdk#28617 is fixed.
-  var snapshot = os == Platform.operatingSystem && x64 == _is64Bit
-      ? "build/sass.dart.app.snapshot"
-      : "build/sass.dart.snapshot";
-
-  var archive = Archive()
-    ..addFile(fileFromBytes(
-        "dart-sass/src/dart${os == 'windows' ? '.exe' : ''}", executable,
-        executable: true))
-    ..addFile(
-        file("dart-sass/src/DART_LICENSE", p.join(sdkDir.path, 'LICENSE')))
-    ..addFile(file("dart-sass/src/sass.dart.snapshot", snapshot))
-    ..addFile(file("dart-sass/src/SASS_LICENSE", "LICENSE"))
-    ..addFile(fileFromString(
-        "dart-sass/dart-sass${os == 'windows' ? '.bat' : ''}",
-        readAndReplaceVersion(
-            "package/dart-sass.${os == 'windows' ? 'bat' : 'sh'}"),
-        executable: true))
-    ..addFile(fileFromString("dart-sass/sass${os == 'windows' ? '.bat' : ''}",
-        readAndReplaceVersion("package/sass.${os == 'windows' ? 'bat' : 'sh'}"),
-        executable: true));
-
-  var prefix = 'build/dart-sass-$version-$os-$architecture';
-  if (os == 'windows') {
-    var output = "$prefix.zip";
-    log("Creating $output...");
-    File(output).writeAsBytesSync(ZipEncoder().encode(archive));
-  } else {
-    var output = "$prefix.tar.gz";
-    log("Creating $output...");
-    File(output)
-        .writeAsBytesSync(GZipEncoder().encode(TarEncoder().encode(archive)));
-  }
+    var prefix = 'build/dart-sass-$version-$os-$architecture';
+    if (os == 'windows') {
+      var output = "$prefix.zip";
+      log("Creating $output...");
+      File(output).writeAsBytesSync(ZipEncoder().encode(archive));
+    } else {
+      var output = "$prefix.tar.gz";
+      log("Creating $output...");
+      File(output)
+          .writeAsBytesSync(GZipEncoder().encode(TarEncoder().encode(archive)));
+    }
+  }));
+  await client.close();
 }


### PR DESCRIPTION
This will allow us to distribute application snapshots, rather than
script snapshots, for Mac OS.