### PR TITLE
Add a top-level warn() function for functions and importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.21.0
+
+* Add a top-level `warn()` function for custom functions and importers to print
+  warning messages.
+
 ## 1.20.3
 
 * No user-visible changes.

--- a/lib/sass.dart
+++ b/lib/sass.dart
@@ -28,6 +28,7 @@ export 'src/syntax.dart';
 export 'src/value.dart' show ListSeparator;
 export 'src/value/external/value.dart';
 export 'src/visitor/serialize.dart' show OutputStyle;
+export 'src/warn.dart' show warn;
 
 /// Loads the Sass file at [path], compiles it to CSS, and returns the result.
 ///

--- a/lib/src/warn.dart
+++ b/lib/src/warn.dart
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. Use of this source code is governed by an
+// Copyright 2019 Google Inc. Use of this source code is governed by an
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
@@ -15,7 +15,7 @@ void warn(String message, {bool deprecation = false}) {
 
   if (warnDefinition == null) {
     throw ArgumentError(
-        "warn() may only becalled within a custom function or importer "
+        "warn() may only be called within a custom function or importer "
         "callback.");
   }
 
@@ -24,7 +24,7 @@ void warn(String message, {bool deprecation = false}) {
 
 /// Runs [callback] with [warn] as the definition for the top-level `warn()` function.
 ///
-/// This is zone-based, so if [callback] is asynchronous [warn] set for the
+/// This is zone-based, so if [callback] is asynchronous [warn] is set for the
 /// duration of that callback.
 T withWarnCallback<T>(
     void warn(String message, bool deprecation), T callback()) {

--- a/lib/src/warn.dart
+++ b/lib/src/warn.dart
@@ -1,0 +1,34 @@
+// Copyright 2017 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'dart:async';
+
+/// Prints a warning message associated with the current `@import` or function
+/// call.
+///
+/// If [deprecation] is `true`, the warning is emitted as a deprecation warning.
+///
+/// This may only be called within a custom function or importer callback.
+void warn(String message, {bool deprecation = false}) {
+  var warnDefinition = Zone.current[#_warn];
+
+  if (warnDefinition == null) {
+    throw ArgumentError(
+        "warn() may only becalled within a custom function or importer "
+        "callback.");
+  }
+
+  warnDefinition(message, deprecation);
+}
+
+/// Runs [callback] with [warn] as the definition for the top-level `warn()` function.
+///
+/// This is zone-based, so if [callback] is asynchronous [warn] set for the
+/// duration of that callback.
+T withWarnCallback<T>(
+    void warn(String message, bool deprecation), T callback()) {
+  return runZoned(() {
+    return callback();
+  }, zoneValues: {#_warn: warn});
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.20.3
+version: 1.21.0
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.21.0
+version: 1.21.0-dev
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass

--- a/test/dart_api/importer_test.dart
+++ b/test/dart_api/importer_test.dart
@@ -12,10 +12,12 @@ import 'package:test/test.dart';
 import 'package:sass/sass.dart';
 import 'package:sass/src/exception.dart';
 
+import 'test_importer.dart';
+
 main() {
   test("uses an importer to resolve an @import", () {
     var css = compileString('@import "orange";', importers: [
-      _TestImporter((url) => Uri.parse("u:$url"), (url) {
+      TestImporter((url) => Uri.parse("u:$url"), (url) {
         var color = url.path;
         return ImporterResult('.$color {color: $color}', indented: false);
       })
@@ -26,7 +28,7 @@ main() {
 
   test("passes the canonicalized URL to the importer", () {
     var css = compileString('@import "orange";', importers: [
-      _TestImporter((url) => Uri.parse('u:blue'), (url) {
+      TestImporter((url) => Uri.parse('u:blue'), (url) {
         var color = url.path;
         return ImporterResult('.$color {color: $color}', indented: false);
       })
@@ -40,7 +42,7 @@ main() {
       @import "orange";
       @import "orange";
     """, importers: [
-      _TestImporter(
+      TestImporter(
           (url) => Uri.parse('u:blue'),
           expectAsync1((url) {
             var color = url.path;
@@ -62,7 +64,7 @@ main() {
     var times = 0;
     var css = compileString('@import "foo:bar/baz";',
         importers: [
-          _TestImporter(
+          TestImporter(
               expectAsync1((url) {
                 times++;
                 if (times == 1) return Uri(path: 'first');
@@ -93,7 +95,7 @@ main() {
     SingleMapping map;
     compileString('@import "orange";',
         importers: [
-          _TestImporter((url) => Uri.parse("u:$url"), (url) {
+          TestImporter((url) => Uri.parse("u:$url"), (url) {
             var color = url.path;
             return ImporterResult('.$color {color: $color}',
                 sourceMapUrl: Uri.parse("u:blue"), indented: false);
@@ -108,7 +110,7 @@ main() {
     SingleMapping map;
     compileString('@import "orange";',
         importers: [
-          _TestImporter((url) => Uri.parse("u:$url"), (url) {
+          TestImporter((url) => Uri.parse("u:$url"), (url) {
             var color = url.path;
             return ImporterResult('.$color {color: $color}', indented: false);
           })
@@ -124,7 +126,7 @@ main() {
   test("wraps an error in canonicalize()", () {
     expect(() {
       compileString('@import "orange";', importers: [
-        _TestImporter((url) {
+        TestImporter((url) {
           throw "this import is bad actually";
         }, expectAsync1((_) => null, count: 0))
       ]);
@@ -139,7 +141,7 @@ main() {
   test("wraps an error in load()", () {
     expect(() {
       compileString('@import "orange";', importers: [
-        _TestImporter((url) => Uri.parse("u:$url"), (url) {
+        TestImporter((url) => Uri.parse("u:$url"), (url) {
           throw "this import is bad actually";
         })
       ]);
@@ -154,7 +156,7 @@ main() {
   test("prefers .message to .toString() for an importer error", () {
     expect(() {
       compileString('@import "orange";', importers: [
-        _TestImporter((url) => Uri.parse("u:$url"), (url) {
+        TestImporter((url) => Uri.parse("u:$url"), (url) {
           throw FormatException("bad format somehow");
         })
       ]);
@@ -166,17 +168,4 @@ main() {
       return true;
     })));
   });
-}
-
-/// An [Importer] whose [canonicalize] and [load] methods are provided by
-/// closures.
-class _TestImporter extends Importer {
-  final Uri Function(Uri url) _canonicalize;
-  final ImporterResult Function(Uri url) _load;
-
-  _TestImporter(this._canonicalize, this._load);
-
-  Uri canonicalize(Uri url) => _canonicalize(url);
-
-  ImporterResult load(Uri url) => _load(url);
 }

--- a/test/dart_api/test_importer.dart
+++ b/test/dart_api/test_importer.dart
@@ -1,0 +1,18 @@
+// Copyright 2017 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:sass/sass.dart';
+
+/// An [Importer] whose [canonicalize] and [load] methods are provided by
+/// closures.
+class TestImporter extends Importer {
+  final Uri Function(Uri url) _canonicalize;
+  final ImporterResult Function(Uri url) _load;
+
+  TestImporter(this._canonicalize, this._load);
+
+  Uri canonicalize(Uri url) => _canonicalize(url);
+
+  ImporterResult load(Uri url) => _load(url);
+}


### PR DESCRIPTION
In addition to being useful for users of Sass, this will make it
possible for core Sass functions to produce warnings without needing
an explicit reference to the evaluator.