### PR TITLE
Limit the Dart SDK constraint to ^2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.22.7
+
+* Restrict the supported versions of the Dart SDK to `^2.4.0`.
+
 ## 1.22.6
 
 * **Potentially breaking bug fix:** The `keywords()` function now converts

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.22.6
+version: 1.22.7
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass
@@ -9,7 +9,7 @@ executables:
   sass: sass
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
   args: ">=1.4.0 <2.0.0"


### PR DESCRIPTION
2.3.2 and earlier releases suffered from dart-lang/sdk#37027, which
causes them to fail to parse Dart Sass.

Closes #768