### PR TITLE
Release 1.22.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,6 @@ jobs:
     install: pub run grinder before-test
     script: tool/travis/task/node_tests.sh
   - <<: *node-tests
-    name: Node tests | Dart stable | Node Carbon
-    node_js: lts/carbon
-  - <<: *node-tests
     name: Node tests | Dart stable | Node Dubnium
     node_js: lts/dubnium
   - <<: *node-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.22.8
+
+### JavaScript API
+
+* Don't crash when running in a directory whose name contains URL-sensitive
+  characters.
+
 ## 1.22.7
 
 * Restrict the supported versions of the Dart SDK to `^2.4.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Don't crash when running in a directory whose name contains URL-sensitive
   characters.
 
+* Drop support for Node Carbon (8.x), which doesn't support `url.pathToFileURL`.
+
 ## 1.22.7
 
 * Restrict the supported versions of the Dart SDK to `^2.4.0`.

--- a/package/package.json
+++ b/package/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/nex3"
   },
   "engines": {
-    "node": ">=0.11.8"
+    "node": ">=10.0.0"
   },
   "dependencies": {
     "chokidar": ">=2.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.22.7
+version: 1.22.8
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
This doesn't contain any code changes relative to 1.22.7, but the JS
release will pick up mbullington/node_preamble.dart#16.