### PR TITLE
Re-add support for Node Carbon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,9 @@ jobs:
     install: pub run grinder before-test
     script: tool/travis/task/node_tests.sh
   - <<: *node-tests
+    name: Node tests | Dart stable | Node Carbon
+    node_js: lts/carbon
+  - <<: *node-tests
     name: Node tests | Dart stable | Node Dubnium
     node_js: lts/dubnium
   - <<: *node-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Clarify the error message when the wrong number of positional arguments are
   passed along with a named argument.
 
+### JavaScript API
+
+* Re-add support for Node Carbon (8.x).
+
 ## 1.22.8
 
 ### JavaScript API

--- a/package/package.json
+++ b/package/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/nex3"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=8.9.0"
   },
   "dependencies": {
     "chokidar": ">=2.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.22.9-dev
+version: 1.22.9
 description: A Sass implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
Apparently npm and Yarn won't avoid installing a package version that
declares incompatibility with them, so dropping compatibility for an
old version is actually a breaking change 😭.