### PR TITLE
Build the Mac OS deployment on Mac OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -221,6 +221,7 @@ jobs:
     if: *deploy-if
     env: *github-env
     script: skip
+    os: osx
     deploy:
       provider: script
       script: pub run grinder github-mac-os


### PR DESCRIPTION
This allows it to build a native executable, rather than a script
snapshot. I don't know why we weren't doing this already.