### PR TITLE
Fix #766 invert incompatible unit error message

### DIFF
--- a/lib/src/value/number.dart
+++ b/lib/src/value/number.dart
@@ -250,8 +250,8 @@ class SassNumber extends Value implements ext.SassNumber {
         return true;
       }, orElse: () {
         throw SassScriptException("Incompatible units "
-            "${_unitString(this.numeratorUnits, this.denominatorUnits)} and "
-            "${_unitString(newNumerators, newDenominators)}.");
+            "${_unitString(newNumerators, newDenominators)} and "
+            "${_unitString(this.numeratorUnits, this.denominatorUnits)}.");
       });
     }
 
@@ -264,15 +264,15 @@ class SassNumber extends Value implements ext.SassNumber {
         return true;
       }, orElse: () {
         throw SassScriptException("Incompatible units "
-            "${_unitString(this.numeratorUnits, this.denominatorUnits)} and "
-            "${_unitString(newNumerators, newDenominators)}.");
+            "${_unitString(newNumerators, newDenominators)} and "
+            "${_unitString(this.numeratorUnits, this.denominatorUnits)}.");
       });
     }
 
     if (oldNumerators.isNotEmpty || oldDenominators.isNotEmpty) {
       throw SassScriptException("Incompatible units "
-          "${_unitString(this.numeratorUnits, this.denominatorUnits)} and "
-          "${_unitString(newNumerators, newDenominators)}.");
+          "${_unitString(newNumerators, newDenominators)} and "
+          "${_unitString(this.numeratorUnits, this.denominatorUnits)}.");
     }
 
     return value;

--- a/test/cli/shared/errors.dart
+++ b/test/cli/shared/errors.dart
@@ -62,7 +62,7 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
     expect(
         sass.stderr,
         emitsInOrder([
-          "Error: Incompatible units deg and px.",
+          "Error: Incompatible units px and deg.",
           "  ,",
           "1 | a {b: 1px + 1deg}",
           "  |       ^^^^^^^^^^",

--- a/test/cli/shared/repl.dart
+++ b/test/cli/shared/repl.dart
@@ -289,7 +289,7 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
             sass.stdout,
             emitsInOrder([
               '>> @use "other"',
-              "Error: Incompatible units s and px.",
+              "Error: Incompatible units px and s.",
               "  ,",
               r"1 | $var: 1px + 1s;",
               "  |       ^^^^^^^^",


### PR DESCRIPTION
Inverting the units in the incompatible unit error message. Updated tests to pass. 