### PR TITLE
Improve error messages for color functions that aren't in sass:color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Fix a bug preventing built-in modules from being loaded within a configured
   module.
 
+* Improve the error messages for trying to access functions like `lighten()`
+  from the `sass:color` module.
+
 ## 1.23.0
 
 * **Launch the new Sass module system!** This adds:

--- a/lib/src/functions/color.dart
+++ b/lib/src/functions/color.dart
@@ -557,7 +557,7 @@ BuiltInCallable _removedColorFunction(String name, String argument,
         {bool negative = false}) =>
     BuiltInCallable(name, r"$color, $amount", (arguments) {
       throw SassScriptException(
-          "The function $name() isn't in the new module system.\n"
+          "The function $name() isn't in the sass:color module.\n"
           "\n"
           "Recommendation: color.adjust(${arguments[0]}, \$$argument: "
           "${negative ? '-' : ''}${arguments[1]})\n"


### PR DESCRIPTION
See https://github.com/sass/sass-spec/pull/1482