### PR TITLE
Fix #417 preserve location of trailing loud comments

### DIFF
--- a/lib/src/util/span.dart
+++ b/lib/src/util/span.dart
@@ -81,11 +81,11 @@ extension SpanExtensions on FileSpan {
   /// Whether [this] FileSpan contains the [target] FileSpan.
   ///
   /// Validates the FileSpans to be in the same file and for the [target] to be
-  /// within [this] FileSpan non-inclusive range (start, end).
+  /// within [this] FileSpan inclusive range [start,end].
   bool contains(FileSpan target) =>
       file.url == target.file.url &&
-      start.offset < target.start.offset &&
-      end.offset > target.end.offset;
+      start.offset <= target.start.offset &&
+      end.offset >= target.end.offset;
 }
 
 /// Consumes an identifier from [scanner].

--- a/lib/src/util/span.dart
+++ b/lib/src/util/span.dart
@@ -77,6 +77,15 @@ extension SpanExtensions on FileSpan {
     _scanIdentifier(scanner);
     return subspan(scanner.position).trimLeft();
   }
+
+  /// Whether [this] FileSpan contains the [target] FileSpan.
+  ///
+  /// Validates the FileSpans to be in the same file and for the [target] to be
+  /// within [this] FileSpan non-inclusive range (start, end).
+  bool contains(FileSpan target) =>
+      file.url == target.file.url &&
+      start.offset < target.start.offset &&
+      end.offset > target.end.offset;
 }
 
 /// Consumes an identifier from [scanner].

--- a/lib/src/visitor/serialize.dart
+++ b/lib/src/visitor/serialize.dart
@@ -1319,7 +1319,8 @@ class _SerializeVisitor
         _buffer.writeCharCode($semicolon);
       }
 
-      if (prePrevious_ == parent && _isTrailingComment(previous, prePrevious_)) {
+      if (prePrevious_ == parent &&
+          _isTrailingComment(previous, prePrevious_!)) {
         _writeOptionalSpace();
       } else {
         _writeLineFeed();

--- a/test/dart_api_test.dart
+++ b/test/dart_api_test.dart
@@ -304,7 +304,7 @@ a {
     expect(compileStringAsync("""
       @use 'sass:meta';
       @include meta.load-css("other.scss");
-    """, loadPaths: [d.sandbox]), completion(equals("/**/\n/**/")));
+    """, loadPaths: [d.sandbox]), completion(equals("/**/ /**/")));
 
     // Give the race condition time to appear.
     await pumpEventQueue();

--- a/test/output_test.dart
+++ b/test/output_test.dart
@@ -213,6 +213,7 @@ selector[href*="{"] { /* please don't move me */ }
 
 @rule3;"""));
     });
+
     group("loud comments in mixin", () {
       test("empty", () {
         expect(compileString("""
@@ -225,7 +226,7 @@ selector {
 }"""), "selector {\n  /* ... */\n}");
       });
 
-      test("with stylerule", () {
+      test("with style rule", () {
         expect(compileString("""
 @mixin loudComment {
   margin: 1px; /* mixin */

--- a/test/output_test.dart
+++ b/test/output_test.dart
@@ -164,6 +164,24 @@ selector { /* please don't move me */ }"""), equals("""
 selector { /* please don't move me */ }"""));
     });
 
+    test("double trailing empty block", () {
+      expect(compileString("""
+selector { /* please don't move me */ /* please don't move me */ }"""),
+          equals("""
+selector { /* please don't move me */ /* please don't move me */
+}"""));
+    });
+
+    test("double trailing style rule", () {
+      expect(compileString("""
+selector {
+  margin: 1px; /* please don't move me */ /* please don't move me */
+}"""), equals("""
+selector {
+  margin: 1px; /* please don't move me */ /* please don't move me */
+}"""));
+    });
+
     test("after property in block", () {
       expect(compileString("""
 selector {
@@ -215,7 +233,7 @@ selector[href*="{"] { /* please don't move me */ }
     });
 
     group("loud comments in mixin", () {
-      test("empty", () {
+      test("empty with spacing", () {
         expect(compileString("""
 @mixin loudComment {
   /* ... */
@@ -223,7 +241,19 @@ selector[href*="{"] { /* please don't move me */ }
 
 selector {
   @include loudComment;
-}"""), "selector {\n  /* ... */\n}");
+}"""), """
+selector {
+  /* ... */
+}""");
+      });
+
+      test("empty no spacing", () {
+        expect(compileString("""
+@mixin loudComment{/* ... */}
+selector {@include loudComment;}"""), """
+selector {
+  /* ... */
+}""");
       });
 
       test("with style rule", () {

--- a/test/output_test.dart
+++ b/test/output_test.dart
@@ -204,12 +204,12 @@ selector {
     test("selector contains left brace", () {
       expect(compileString("""@rule1;
 @rule2;
-selector[href*=\"{\"]
+selector[href*="{"]
 { /* please don't move me */ }
 
 @rule3;"""), equals("""@rule1;
 @rule2;
-selector[href*=\"{\"] { /* please don't move me */ }
+selector[href*="{"] { /* please don't move me */ }
 
 @rule3;"""));
     });

--- a/test/output_test.dart
+++ b/test/output_test.dart
@@ -213,9 +213,9 @@ selector[href*="{"] { /* please don't move me */ }
 
 @rule3;"""));
     });
-
-    test("loud comments in mixin", () {
-      expect(compileString("""
+    group("loud comments in mixin", () {
+      test("empty", () {
+        expect(compileString("""
 @mixin loudComment {
   /* ... */
 }
@@ -223,6 +223,97 @@ selector[href*="{"] { /* please don't move me */ }
 selector {
   @include loudComment;
 }"""), "selector {\n  /* ... */\n}");
+      });
+
+      test("with stylerule", () {
+        expect(compileString("""
+@mixin loudComment {
+  margin: 1px; /* mixin */
+} /* mixin-out */
+
+selector {
+  @include loudComment; /* selector */
+}"""), """
+/* mixin-out */
+selector {
+  margin: 1px; /* mixin */
+  /* selector */
+}""");
+      });
+    });
+
+    group("loud comments in nested blocks", () {
+      test("with styles", () {
+        expect(
+          compileString("""
+foo { /* foo */
+  padding: 1px; /* foo padding */
+  bar { /* bar */
+    padding: 2px; /* bar padding */
+    baz { /* baz */
+      padding: 3px; /* baz padding */
+      margin: 3px; /* baz margin */
+    } /* baz end */
+    biz { /* biz */
+      padding: 3px; /* biz padding */
+      margin: 3px; /* biz margin */
+    } /* biz end */
+    margin: 2px; /* bar margin */
+  } /* bar end */
+  margin: 1px; /* foo margin */
+} /* foo end */
+"""),
+          """
+foo { /* foo */
+  padding: 1px; /* foo padding */
+  /* bar end */
+  margin: 1px; /* foo margin */
+}
+foo bar { /* bar */
+  padding: 2px; /* bar padding */
+  /* baz end */
+  /* biz end */
+  margin: 2px; /* bar margin */
+}
+foo bar baz { /* baz */
+  padding: 3px; /* baz padding */
+  margin: 3px; /* baz margin */
+}
+foo bar biz { /* biz */
+  padding: 3px; /* biz padding */
+  margin: 3px; /* biz margin */
+}
+
+/* foo end */""",
+        );
+      });
+
+      test("empty", () {
+        expect(
+          compileString("""
+foo { /* foo */
+  bar { /* bar */
+    baz { /* baz */
+    } /* baz end */
+    biz { /* biz */
+    } /* biz end */
+  } /* bar end */
+} /* foo end */
+"""),
+          """
+foo { /* foo */
+  /* bar end */
+}
+foo bar { /* bar */
+  /* baz end */
+  /* biz end */
+}
+foo bar baz { /* baz */ }
+foo bar biz { /* biz */ }
+
+/* foo end */""",
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
Fix #417 by preserving the location of trailing loud comments.

Loud comment AST nodes now have the notion of whether they're "trailing".  During parsing, we look for loud comments at the end of lines and if found, tag them as trailing.  This information is then plumbed through and made available during serialization.  

During serialization, where we would previously unconditionally insert newlines between nodes, we now check to see if the next node is a trailing loud comment.  If so, we instead write out a space followed by the trailing loud comment.

Ran the following locally, all tests passing:
$ pub run grinder && dartanalyzer lib test && pub run test -x node

See https://github.com/sass/sass-spec/pull/1485