### PR TITLE
Reset the forwarded config to empty for @use and meta.load-module()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Fix a bug preventing built-in modules from being loaded within a configured
   module.
 
+* Fix a bug preventing an unconfigured module from being loaded from within two
+  different configured modules.
+
 ## 1.23.0
 
 * **Launch the new Sass module system!** This adds:

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -413,9 +413,9 @@ class _EvaluateVisitor
         var url = Uri.parse(arguments[0].assertString("module").text);
         var withMap = arguments[1].realNull?.assertMap("with")?.contents;
 
-        Map<String, _ConfiguredValue> configuration;
+        var configuration = const <String, _ConfiguredValue>{};
         if (withMap != null) {
-          configuration = <String, _ConfiguredValue>{};
+          configuration = {};
           var span = _callableNode.span;
           withMap.forEach((variable, value) {
             var name =
@@ -525,11 +525,9 @@ class _EvaluateVisitor
       {Uri baseUrl,
       Map<String, _ConfiguredValue> configuration,
       bool namesInErrors = false}) async {
-    configuration ??= const {};
-
     var builtInModule = _builtInModules[url];
     if (builtInModule != null) {
-      if (configuration.isNotEmpty) {
+      if (configuration != null && configuration.isNotEmpty) {
         throw _exception(
             namesInErrors
                 ? "Built-in module $url can't be configured."
@@ -589,12 +587,11 @@ class _EvaluateVisitor
   Future<Module> _execute(AsyncImporter importer, Stylesheet stylesheet,
       {Map<String, _ConfiguredValue> configuration,
       bool namesInErrors = false}) async {
-    configuration ??= const {};
     var url = stylesheet.span.sourceUrl;
 
     var alreadyLoaded = _modules[url];
     if (alreadyLoaded != null) {
-      if (configuration.isNotEmpty || _configuration.isNotEmpty) {
+      if ((configuration ?? _configuration).isNotEmpty) {
         throw _exception(namesInErrors
             ? "${p.prettyUri(url)} was already loaded, so it can't be "
                 "configured using \"with\"."
@@ -637,7 +634,10 @@ class _EvaluateVisitor
       _atRootExcludingStyleRule = false;
       _inKeyframes = false;
 
-      if (configuration.isNotEmpty) _configuration = Map.of(configuration);
+      if (configuration != null) {
+        _configuration =
+            configuration.isEmpty ? const {} : Map.of(configuration);
+      }
 
       await visitStylesheet(stylesheet);
       css = _outOfOrderImports == null
@@ -658,7 +658,7 @@ class _EvaluateVisitor
       _atRootExcludingStyleRule = oldAtRootExcludingStyleRule;
       _inKeyframes = oldInKeyframes;
 
-      if (configuration.isNotEmpty && _configuration.isNotEmpty) {
+      if (configuration != null && _configuration.isNotEmpty) {
         throw _exception(
             namesInErrors
                 ? "\$${_configuration.keys.first} was not declared with "
@@ -1778,7 +1778,7 @@ class _EvaluateVisitor
       _environment.addModule(module, namespace: node.namespace);
     },
         configuration: node.configuration.isEmpty
-            ? null
+            ? const {}
             : {
                 for (var entry in node.configuration.entries)
                   entry.key: _ConfiguredValue(

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: f4f4c5d1cbc9894d14b6d8ce7c1a3c09146db9ba
+// Checksum: 2492887a55fce2c50a574d55d3958d379976be31
 //
 // ignore_for_file: unused_import
 
@@ -419,9 +419,9 @@ class _EvaluateVisitor
         var url = Uri.parse(arguments[0].assertString("module").text);
         var withMap = arguments[1].realNull?.assertMap("with")?.contents;
 
-        Map<String, _ConfiguredValue> configuration;
+        var configuration = const <String, _ConfiguredValue>{};
         if (withMap != null) {
-          configuration = <String, _ConfiguredValue>{};
+          configuration = {};
           var span = _callableNode.span;
           withMap.forEach((variable, value) {
             var name =
@@ -531,11 +531,9 @@ class _EvaluateVisitor
       {Uri baseUrl,
       Map<String, _ConfiguredValue> configuration,
       bool namesInErrors = false}) {
-    configuration ??= const {};
-
     var builtInModule = _builtInModules[url];
     if (builtInModule != null) {
-      if (configuration.isNotEmpty) {
+      if (configuration != null && configuration.isNotEmpty) {
         throw _exception(
             namesInErrors
                 ? "Built-in module $url can't be configured."
@@ -595,12 +593,11 @@ class _EvaluateVisitor
   Module<Callable> _execute(Importer importer, Stylesheet stylesheet,
       {Map<String, _ConfiguredValue> configuration,
       bool namesInErrors = false}) {
-    configuration ??= const {};
     var url = stylesheet.span.sourceUrl;
 
     var alreadyLoaded = _modules[url];
     if (alreadyLoaded != null) {
-      if (configuration.isNotEmpty || _configuration.isNotEmpty) {
+      if ((configuration ?? _configuration).isNotEmpty) {
         throw _exception(namesInErrors
             ? "${p.prettyUri(url)} was already loaded, so it can't be "
                 "configured using \"with\"."
@@ -643,7 +640,10 @@ class _EvaluateVisitor
       _atRootExcludingStyleRule = false;
       _inKeyframes = false;
 
-      if (configuration.isNotEmpty) _configuration = Map.of(configuration);
+      if (configuration != null) {
+        _configuration =
+            configuration.isEmpty ? const {} : Map.of(configuration);
+      }
 
       visitStylesheet(stylesheet);
       css = _outOfOrderImports == null
@@ -664,7 +664,7 @@ class _EvaluateVisitor
       _atRootExcludingStyleRule = oldAtRootExcludingStyleRule;
       _inKeyframes = oldInKeyframes;
 
-      if (configuration.isNotEmpty && _configuration.isNotEmpty) {
+      if (configuration != null && _configuration.isNotEmpty) {
         throw _exception(
             namesInErrors
                 ? "\$${_configuration.keys.first} was not declared with "
@@ -1772,7 +1772,7 @@ class _EvaluateVisitor
       _environment.addModule(module, namespace: node.namespace);
     },
         configuration: node.configuration.isEmpty
-            ? null
+            ? const {}
             : {
                 for (var entry in node.configuration.entries)
                   entry.key: _ConfiguredValue(


### PR DESCRIPTION
In #827 I made configuration never be null, but this turns out to be
overkill: we still need a way for _loadModule() and _execute() to
distinguish between "use the existing configuration" (for @forward)
and "use no configuration" (for an unconfigured @use or
meta.load-module()). We now use null as a sentinel value there, while
still ensuring that _configuration is non-nullable.

Closes #854
See sass/sass-spec#1486