### PR TITLE
Only generate and update selectors, not rules, in Extender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 * Fix a bug preventing built-in modules from being loaded within a configured
   module.
-  
+
+* Fix a bug when `meta.load-css()` was used to load some files that included
+  media queries.
+
 * Allow `saturate()` in plain CSS files, since it can be used as a plain CSS
   filter function.
 

--- a/lib/src/ast/css/modifiable/style_rule.dart
+++ b/lib/src/ast/css/modifiable/style_rule.dart
@@ -14,10 +14,7 @@ import 'value.dart';
 class ModifiableCssStyleRule extends ModifiableCssParentNode
     implements CssStyleRule {
   final ModifiableCssValue<SelectorList> selector;
-
-  /// The selector for this rule, before any extensions are applied.
   final SelectorList originalSelector;
-
   final FileSpan span;
 
   /// Creates a new [ModifiableCssStyleRule].

--- a/lib/src/ast/css/style_rule.dart
+++ b/lib/src/ast/css/style_rule.dart
@@ -16,5 +16,8 @@ abstract class CssStyleRule extends CssParentNode {
   /// The selector for this rule.
   CssValue<SelectorList> get selector;
 
+  /// The selector for this rule, before any extensions were applied.
+  SelectorList get originalSelector;
+
   T accept<T>(CssVisitor<T> visitor) => visitor.visitCssStyleRule(this);
 }

--- a/lib/src/extend/empty_extender.dart
+++ b/lib/src/extend/empty_extender.dart
@@ -24,8 +24,8 @@ class EmptyExtender implements Extender {
           bool callback(SimpleSelector target)) =>
       const [];
 
-  ModifiableCssStyleRule addSelector(
-      SelectorList selector, FileSpan selectorSpan, FileSpan ruleSpan,
+  ModifiableCssValue<SelectorList> addSelector(
+      SelectorList selector, FileSpan span,
       [List<CssMediaQuery> mediaContext]) {
     throw UnsupportedError(
         "addSelector() can't be called for a const Extender.");
@@ -43,6 +43,7 @@ class EmptyExtender implements Extender {
         "addExtensions() can't be called for a const Extender.");
   }
 
-  Tuple2<Extender, Map<CssStyleRule, ModifiableCssStyleRule>> clone() =>
-      const Tuple2(EmptyExtender(), {});
+  Tuple2<Extender,
+          Map<CssValue<SelectorList>, ModifiableCssValue<SelectorList>>>
+      clone() => const Tuple2(EmptyExtender(), {});
 }

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -1629,8 +1629,10 @@ class _EvaluateVisitor
             _styleRule?.originalSelector,
             implicitParent: !_atRootExcludingStyleRule));
 
-    var rule = _extender.addSelector(
-        parsedSelector, node.selector.span, node.span, _mediaQueries);
+    var selector = _extender.addSelector(
+        parsedSelector, node.selector.span, _mediaQueries);
+    var rule = ModifiableCssStyleRule(selector, node.span,
+        originalSelector: parsedSelector);
     var oldAtRootExcludingStyleRule = _atRootExcludingStyleRule;
     _atRootExcludingStyleRule = false;
     await _withParent(rule, () async {
@@ -2512,12 +2514,13 @@ class _EvaluateVisitor
           "Style rules may not be used within nested declarations.", node.span);
     }
 
-    var rule = _extender.addSelector(
-        node.selector.value.resolveParentSelectors(_styleRule?.originalSelector,
-            implicitParent: !_atRootExcludingStyleRule),
-        node.selector.span,
-        node.span,
-        _mediaQueries);
+    var originalSelector = node.selector.value.resolveParentSelectors(
+        _styleRule?.originalSelector,
+        implicitParent: !_atRootExcludingStyleRule);
+    var selector = _extender.addSelector(
+        originalSelector, node.selector.span, _mediaQueries);
+    var rule = ModifiableCssStyleRule(selector, node.span,
+        originalSelector: originalSelector);
     var oldAtRootExcludingStyleRule = _atRootExcludingStyleRule;
     _atRootExcludingStyleRule = false;
     await _withParent(rule, () async {

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: f4f4c5d1cbc9894d14b6d8ce7c1a3c09146db9ba
+// Checksum: 9083313a65eb24875e7292b859202fd574daf46b
 //
 // ignore_for_file: unused_import
 
@@ -1625,8 +1625,10 @@ class _EvaluateVisitor
             _styleRule?.originalSelector,
             implicitParent: !_atRootExcludingStyleRule));
 
-    var rule = _extender.addSelector(
-        parsedSelector, node.selector.span, node.span, _mediaQueries);
+    var selector = _extender.addSelector(
+        parsedSelector, node.selector.span, _mediaQueries);
+    var rule = ModifiableCssStyleRule(selector, node.span,
+        originalSelector: parsedSelector);
     var oldAtRootExcludingStyleRule = _atRootExcludingStyleRule;
     _atRootExcludingStyleRule = false;
     _withParent(rule, () {
@@ -2496,12 +2498,13 @@ class _EvaluateVisitor
           "Style rules may not be used within nested declarations.", node.span);
     }
 
-    var rule = _extender.addSelector(
-        node.selector.value.resolveParentSelectors(_styleRule?.originalSelector,
-            implicitParent: !_atRootExcludingStyleRule),
-        node.selector.span,
-        node.span,
-        _mediaQueries);
+    var originalSelector = node.selector.value.resolveParentSelectors(
+        _styleRule?.originalSelector,
+        implicitParent: !_atRootExcludingStyleRule);
+    var selector = _extender.addSelector(
+        originalSelector, node.selector.span, _mediaQueries);
+    var rule = ModifiableCssStyleRule(selector, node.span,
+        originalSelector: originalSelector);
     var oldAtRootExcludingStyleRule = _atRootExcludingStyleRule;
     _atRootExcludingStyleRule = false;
     _withParent(rule, () {


### PR DESCRIPTION
We switched to *updating* selectors a while ago so that cloned rules
would continue to see updates in their selectors, but we were still
generating and tracking rules in the Extender. This caused skew
between what rules the extender knew about and what rules actually
existed in situations where rules were copied (such as when resolving
nested media queries).

There's no principled reason the extender needs to know about style
rules at all, so now it just tracks modifiable wrappers of selectors.
These are re-used even when style rules are cloned, so they're safe
from the skew problem.

Closes #843
See sass/sass-spec#1487