### PR TITLE
Don't compile .css files in directories to themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.23.2
+
+### Command-Line Interface
+
+* Fix a bug when compiling all Sass files in a directory where a CSS file could
+  be compiled to its own location, creating an infinite loop in `--watch` mode.
+
+* Properly compile CSS entrypoints in directories outside of `--watch` mode.
+
 ## 1.23.1
 
 * Fix a bug preventing built-in modules from being loaded within a configured

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -375,7 +375,7 @@ class ExecutableOptions {
       for (var path in listDir(source, recursive: true))
         if (_isEntrypoint(path) &&
             // Don't compile a CSS file to its own location.
-            (source != destination || p.extension(path) != '.css'))
+            !(source == destination && p.extension(path) == '.css'))
           path: p.join(destination,
               p.setExtension(p.relative(path, from: source), '.css'))
     };

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -373,7 +373,9 @@ class ExecutableOptions {
   Map<String, String> _listSourceDirectory(String source, String destination) {
     return {
       for (var path in listDir(source, recursive: true))
-        if (_isEntrypoint(path))
+        if (_isEntrypoint(path) &&
+            // Don't compile a CSS file to its own location.
+            (source != destination || p.extension(path) != '.css'))
           path: p.join(destination,
               p.setExtension(p.relative(path, from: source), '.css'))
     };
@@ -383,7 +385,7 @@ class ExecutableOptions {
   bool _isEntrypoint(String path) {
     if (p.basename(path).startsWith("_")) return false;
     var extension = p.extension(path);
-    return extension == ".scss" || extension == ".sass";
+    return extension == ".scss" || extension == ".sass" || extension == ".css";
   }
 
   /// Whether to emit a source map file.

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -267,10 +267,14 @@ class _Watcher {
     if (p.basename(source).startsWith('_')) return null;
 
     for (var sourceDir in _options.sourceDirectoriesToDestinations.keys) {
-      if (p.isWithin(sourceDir, source)) {
-        return p.join(_options.sourceDirectoriesToDestinations[sourceDir],
-            p.setExtension(p.relative(source, from: sourceDir), '.css'));
-      }
+      if (!p.isWithin(sourceDir, source)) continue;
+
+      var destination = p.join(
+          _options.sourceDirectoriesToDestinations[sourceDir],
+          p.setExtension(p.relative(source, from: sourceDir), '.css'));
+
+      // Don't compile ".css" files to their own locations.
+      if (destination != source) return destination;
     }
 
     return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.23.1
+version: 1.23.2
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass

--- a/test/cli/shared/colon_args.dart
+++ b/test/cli/shared/colon_args.dart
@@ -106,7 +106,8 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
     test("compiles all the stylesheets in the directory", () async {
       await d.dir("in", [
         d.file("test1.scss", "a {b: c}"),
-        d.file("test2.sass", "x\n  y: z")
+        d.file("test2.sass", "x\n  y: z"),
+        d.file("test3.css", "q {r: s}")
       ]).create();
 
       var sass = await runSass(["--no-source-map", "in:out"]);
@@ -115,7 +116,8 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
 
       await d.dir("out", [
         d.file("test1.css", equalsIgnoringWhitespace("a { b: c; }")),
-        d.file("test2.css", equalsIgnoringWhitespace("x { y: z; }"))
+        d.file("test2.css", equalsIgnoringWhitespace("x { y: z; }")),
+        d.file("test3.css", equalsIgnoringWhitespace("q { r: s; }"))
       ]).validate();
     });
 
@@ -182,6 +184,16 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
         d.file("real.css", equalsIgnoringWhitespace("x { y: z; }")),
         d.nothing("fake.css")
       ]).validate();
+    });
+
+    test("ignores a CSS file that would compile to itself", () async {
+      await d.dir("dir", [d.file("test.css", "a {b: c}")]).create();
+
+      var sass = await runSass(["dir:dir"]);
+      expect(sass.stdout, emitsDone);
+      await sass.shouldExit(0);
+
+      await d.file("dir/test.css", "a {b: c}").validate();
     });
   });
 

--- a/test/cli/shared/update.dart
+++ b/test/cli/shared/update.dart
@@ -175,6 +175,16 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
 
       await d.file("out.css", contains(message)).validate();
     });
+
+    test("from itself", () async {
+      await d.dir("dir", [d.file("test.css", "a {b: c}")]).create();
+
+      var sass = await update(["dir:dir"]);
+      expect(sass.stdout, emitsDone);
+      await sass.shouldExit(0);
+
+      await d.file("dir/test.css", "a {b: c}").validate();
+    });
   });
 
   group("updates a CSS file", () {


### PR DESCRIPTION
This also adds support for compiling .css files in directories *at
all*, which had previously only worked in --watch mode.

Closes #853