### PR TITLE
Use nvm's "lts/*" alias for the latest stable Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,7 @@ jobs:
   - &node-tests
     name: Node tests | Dart stable | Node stable
     language: node_js
-    # TODO(nweiz): Make this "stable" when laverdet/node-fibers#420 is fixed.
-    node_js: 12
+    node_js: lts/*
     install: pub run grinder before-test
     script: tool/travis/task/node_tests.sh
   - <<: *node-tests
@@ -154,8 +153,7 @@ jobs:
       - secure: "Iv6UKB6mH0GLkRQtaLeZnoW0QMmXbzGVX/QO+vvT26yWvqlW/ik+YeHB+4VLZFz/4xezukkztVENdxNDCnrQA/NX7fVhjqj4Px2JQau0V0ljYN64H+o0oxlBeMQqnsVOJcsU7DuPFPErYixkE3yuN6DqIYE+DYe3fVQg/1RBCs2z1nejg4udbZG7D0yfrxZSCckhsyBH1Ej72FhMGMaFq7k7IMC7f/sGYZZYsOe2WKmsYF35hyL/twIXKBNxjPat1HmsVT/3VOUIF+doO26BxthEc68Tmp3SHucEXHWPEjk9N87DxLClGkHvvZ2PUK9nYB9/KqxvJqf/AcDO34vS0lAU809Eov7dK/19WE1GtgA/gL0B/nh2QYbWpbO/HPzxFqOYwfzLtAXvwUr45eMNxmh1yupbAtxRvst7ZO/UTC+awW55AXnVd4jiTzZ/jqV52aGbClN+escPZCYXgYosvJLK3G4xLYCY4TTC99riBQZ0MDLfCt35+RivjNLVf8vecGT8WTmVQySzq0Cthy/9SCp1OzWT5roY2rzkwvR4R0+42f48qyDU/buUgPBsw9zwCabWVoB0p4hflalEhc9EwbRn5oDI0NHwXE0r83movx+JHHPBau1zwX53DJSpSFXnDPi6KaNpg52wyuIIzO90zA7FZTRR9My38AzYgVaKkdE="
     script: skip
     language: node_js
-    # TODO(nweiz): Make this "stable" when laverdet/node-fibers#420 is fixed.
-    node_js: 12
+    node_js: lts/*
     deploy:
       provider: script
       script: tool/travis/deploy/npm.sh
@@ -225,8 +223,7 @@ jobs:
     env: *github-env
     script: skip
     language: node_js
-    # TODO(nweiz): Make this "stable" when laverdet/node-fibers#420 is fixed.
-    node_js: 12
+    node_js: lts/*
     deploy:
       provider: script
       script: pub run grinder update-bazel


### PR DESCRIPTION
Follow-up from #859. It turns out that nvm's "stable" alias is
deprecated, Node itself doesn't consider odd-numbered releases
"stable" in any real sense, and pertinently the fibers package doesn't
guarantee support for them. By only building on LTS releases we avoid
all these shenanigans.