### PR TITLE
Migrate to stream_transform extension methods

### DIFF
--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -201,9 +201,7 @@ class _Watcher {
   /// Otherwise, if a file is erased and then rewritten, we can end up reading
   /// the intermediate erased version.
   Stream<WatchEvent> _debounceEvents(Stream<WatchEvent> events) {
-    return events
-        .transform(debounceBuffer(Duration(milliseconds: 25)))
-        .expand((buffer) {
+    return events.debounceBuffer(Duration(milliseconds: 25)).expand((buffer) {
       var typeForPath = p.PathMap<ChangeType>();
       for (var event in buffer) {
         var oldType = typeForPath[event.path];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ executables:
   sass: sass
 
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   args: ">=1.4.0 <2.0.0"
@@ -23,7 +23,7 @@ dependencies:
   source_maps: "^0.10.5"
   source_span: "^1.4.0"
   stack_trace: ">=0.9.0 <2.0.0"
-  stream_transform: "^0.0.1"
+  stream_transform: "^0.0.20"
   string_scanner: ">=0.1.5 <2.0.0"
   term_glyph: "^1.0.0"
   tuple: "^1.0.0"


### PR DESCRIPTION
The non-extension implementation will be removed in the next version.

Bump the min SDK to 2.6.0 to reflect the fact that extension methods are
used.