### PR TITLE
Avoid depending on `iterator.current != null`.

### DIFF
--- a/lib/src/extend/functions.dart
+++ b/lib/src/extend/functions.dart
@@ -522,15 +522,19 @@ List<List<T>> paths<T>(Iterable<List<T>> choices) => choices.fold(
 QueueList<List<ComplexSelectorComponent>> _groupSelectors(
     Iterable<ComplexSelectorComponent> complex) {
   var groups = QueueList<List<ComplexSelectorComponent>>();
-  var iterator = complex.iterator..moveNext();
-  while (iterator.current != null) {
-    var group = <ComplexSelectorComponent>[];
-    do {
-      group.add(iterator.current);
-    } while (iterator.moveNext() &&
-        (iterator.current is Combinator || group.last is Combinator));
+  var iterator = complex.iterator;
+  if (iterator.moveNext()) {
+    var group = <ComplexSelectorComponent>[iterator.current]   
     groups.add(group);
-  }
+    while (iterator.moveNext()) {
+      if (group.last is Combinator || iterator.current is Combinator) {
+        group.add(iterator.current);
+      } else {
+        group = [iterator.current];
+        groups.add(group);
+      }
+    }
+  }          
   return groups;
 }
 

--- a/lib/src/extend/functions.dart
+++ b/lib/src/extend/functions.dart
@@ -523,19 +523,17 @@ QueueList<List<ComplexSelectorComponent>> _groupSelectors(
     Iterable<ComplexSelectorComponent> complex) {
   var groups = QueueList<List<ComplexSelectorComponent>>();
   var iterator = complex.iterator;
-  if (iterator.moveNext()) {
-    var group = <ComplexSelectorComponent>[iterator.current]   
-    groups.add(group);
-    while (iterator.moveNext()) {
-      if (group.last is Combinator || iterator.current is Combinator) {
-        group.add(iterator.current);
-      } else {
-        group = [iterator.current];
-        groups.add(group);
-      }
+  if (!iterator.moveNext()) return groups;
+  var group = <ComplexSelectorComponent>[iterator.current];
+  groups.add(group);
+  while (iterator.moveNext()) {
+    if (group.last is Combinator || iterator.current is Combinator) {
+      group.add(iterator.current);
+    } else {
+      group = [iterator.current];
+      groups.add(group);
     }
-  }          
-  return groups;
+  }
 }
 
 /// Returns whether or not [compound] contains a `::root` selector.

--- a/lib/src/extend/functions.dart
+++ b/lib/src/extend/functions.dart
@@ -534,6 +534,7 @@ QueueList<List<ComplexSelectorComponent>> _groupSelectors(
       groups.add(group);
     }
   }
+  return groups;
 }
 
 /// Returns whether or not [compound] contains a `::root` selector.


### PR DESCRIPTION
With the NNBD change to Dart, it's no longer safe to rely on an iterator returning `null` when it has hit the end (or before calling `moveNext` the first time). For non-nullable element types, it will have to throw instead.

This PR rewrites code that currently rely on a `null` value to recognize the end of an iterator.