### PR TITLE
Print call-site for @errors in mixins and functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.23.5
+
+* When `@error` is used in a function or mixin, print the call site rather than
+  the location of the `@error` itself to better match the behavior of calling a
+  built-in function that throws an error.
+
 ## 1.23.4
 
 ### Command-Line Interface

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -81,14 +81,8 @@ body::before {
 class SassRuntimeException extends SassException {
   final Trace trace;
 
-  SassRuntimeExceptionType type;
-
-  SassRuntimeException(String message, FileSpan span, this.trace, [this.type])
+  SassRuntimeException(String message, FileSpan span, this.trace)
       : super(message, span);
-}
-
-enum SassRuntimeExceptionType {
-  error,
 }
 
 /// An exception thrown when Sass parsing has failed.

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -81,8 +81,14 @@ body::before {
 class SassRuntimeException extends SassException {
   final Trace trace;
 
-  SassRuntimeException(String message, FileSpan span, this.trace)
+  SassRuntimeExceptionType type;
+
+  SassRuntimeException(String message, FileSpan span, this.trace, [this.type])
       : super(message, span);
+}
+
+enum SassRuntimeExceptionType {
+  error,
 }
 
 /// An exception thrown when Sass parsing has failed.

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -1469,7 +1469,7 @@ class _EvaluateVisitor
         await _environment.withContent(contentCallable, () async {
           await _environment.asMixin(() async {
             for (var statement in mixin.declaration.children) {
-              await _addErrorSpanAsync(node, () => statement.accept(this));
+              await _addErrorSpan(node, () => statement.accept(this));
             }
           });
           return null;
@@ -1983,7 +1983,7 @@ class _EvaluateVisitor
 
     var oldInFunction = _inFunction;
     _inFunction = true;
-    var result = await _addErrorSpanAsync(
+    var result = await _addErrorSpan(
         node, () => _runFunctionCallable(node.arguments, function, node));
     _inFunction = oldInFunction;
     return result;
@@ -2858,19 +2858,7 @@ class _EvaluateVisitor
   /// Runs [callback], and converts any [SassRuntimeException]s containing an
   /// @error to throw a more relevant [SassRuntimeException] with [nodeWithSpan]'s
   /// source span.
-  T _addErrorSpan<T>(AstNode nodeWithSpan, T callback()) {
-    try {
-      return callback();
-    } on SassRuntimeException catch (error) {
-      if (!error.span.text.startsWith("@error")) rethrow;
-      throw SassRuntimeException(
-          error.message, nodeWithSpan.span, _stackTrace());
-    }
-  }
-
-  /// Like [_addErrorSpan], but for an asynchronous [callback].
-  Future<T> _addErrorSpanAsync<T>(
-      AstNode nodeWithSpan, Future<T> callback()) async {
+  Future<T> _addErrorSpan<T>(AstNode nodeWithSpan, Future<T> callback()) async {
     try {
       return await callback();
     } on SassRuntimeException catch (error) {

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -2864,7 +2864,7 @@ class _EvaluateVisitor
     } on SassRuntimeException catch (error) {
       if (!error.span.text.startsWith("@error")) rethrow;
       throw SassRuntimeException(
-          error.message, nodeWithSpan.span, _stackTrace(nodeWithSpan.span));
+          error.message, nodeWithSpan.span, _stackTrace());
     }
   }
 
@@ -2876,7 +2876,7 @@ class _EvaluateVisitor
     } on SassRuntimeException catch (error) {
       if (!error.span.text.startsWith("@error")) rethrow;
       throw SassRuntimeException(
-          error.message, nodeWithSpan.span, _stackTrace(nodeWithSpan.span));
+          error.message, nodeWithSpan.span, _stackTrace());
     }
   }
 }

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 4d00afa45e1a405a53159888e7912d9ab6e9c178
+// Checksum: 14dca11ccb77211c498bd38737edd63956700aba
 //
 // ignore_for_file: unused_import
 
@@ -2829,7 +2829,7 @@ class _EvaluateVisitor
     } on SassRuntimeException catch (error) {
       if (!error.span.text.startsWith("@error")) rethrow;
       throw SassRuntimeException(
-          error.message, nodeWithSpan.span, _stackTrace(nodeWithSpan.span));
+          error.message, nodeWithSpan.span, _stackTrace());
     }
   }
 }

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 14dca11ccb77211c498bd38737edd63956700aba
+// Checksum: 9617d2d08b71858db9228b0858f2f27f87a35bf7
 //
 // ignore_for_file: unused_import
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.23.4
+version: 1.23.5-dev
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass

--- a/test/cli/shared/errors.dart
+++ b/test/cli/shared/errors.dart
@@ -72,6 +72,58 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
     await sass.shouldExit(65);
   });
 
+  test("from an error encountered within a function", () async {
+    await d.file("test.scss", """
+@function a() {
+  @error "Within A.";
+}
+
+.b {
+  c: a();
+}
+""").create();
+
+    var sass = await runSass(["--no-unicode", "test.scss"]);
+    expect(
+        sass.stderr,
+        emitsInOrder([
+          "Error: \"Within A.\"",
+          "  ,",
+          "6 |   c: a();",
+          "  |      ^^^",
+          "  '",
+          "  test.scss 2:3  a()",
+          "  test.scss 6:6  root stylesheet",
+        ]));
+    await sass.shouldExit(65);
+  });
+
+  test("from an error encountered within a mixin", () async {
+    await d.file("test.scss", """
+@mixin a() {
+  @error "Within A.";
+}
+
+.b {
+  @include a();
+}
+""").create();
+
+    var sass = await runSass(["--no-unicode", "test.scss"]);
+    expect(
+        sass.stderr,
+        emitsInOrder([
+          "Error: \"Within A.\"",
+          "  ,",
+          "6 |   @include a();",
+          "  |   ^^^^^^^^^^^^",
+          "  '",
+          "  test.scss 2:3  a()",
+          "  test.scss 6:3  root stylesheet",
+        ]));
+    await sass.shouldExit(65);
+  });
+
   test("with colors with --color", () async {
     await d.file("test.scss", "a {b: }").create();
 

--- a/test/cli/shared/errors.dart
+++ b/test/cli/shared/errors.dart
@@ -92,7 +92,6 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
           "6 |   c: a();",
           "  |      ^^^",
           "  '",
-          "  test.scss 6:6  a()",
           "  test.scss 6:6  root stylesheet",
         ]));
     await sass.shouldExit(65);
@@ -118,7 +117,6 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
           "6 |   @include a();",
           "  |   ^^^^^^^^^^^^",
           "  '",
-          "  test.scss 6:3  a()",
           "  test.scss 6:3  root stylesheet",
         ]));
     await sass.shouldExit(65);

--- a/test/cli/shared/errors.dart
+++ b/test/cli/shared/errors.dart
@@ -92,7 +92,7 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
           "6 |   c: a();",
           "  |      ^^^",
           "  '",
-          "  test.scss 2:3  a()",
+          "  test.scss 6:6  a()",
           "  test.scss 6:6  root stylesheet",
         ]));
     await sass.shouldExit(65);
@@ -118,7 +118,7 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
           "6 |   @include a();",
           "  |   ^^^^^^^^^^^^",
           "  '",
-          "  test.scss 2:3  a()",
+          "  test.scss 6:3  a()",
           "  test.scss 6:3  root stylesheet",
         ]));
     await sass.shouldExit(65);


### PR DESCRIPTION
For any @errors encountered in mixins or functions, use the call-site
(instead of the @error rule) as the span printed in the error message.

Closes #474
sass/sass-spec#1494