### PR TITLE
Fix invalid YAML in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -239,11 +239,6 @@ jobs:
   - name: "GitHub: Windows"
     if: *deploy-if
     env: *github-env
-      # GITHUB_AUTH="..."
-      #
-      # Note that this overrides the read-only auth token that's set for all
-      # builds.
-      - secure: "AAP74aT+8SQmwGeHrCsZ7GgppvCCkDAZXszivocMy3Fi9gfMCLABBCh67pGINJX4VlLW7ftPF3xivlvgGu+e4ncXz9m9jIPZ9Iza3cW5jCnCgyRGZD98gwabIDFWiv4X9V2xnJA2p1ZuYBf8Sh3TTipUFBKMjlnxVxYkIOTud4rUss/htFhxVA/oFTo0ThTZwXuxJ+GRGTM4PcuHPJvPf18iRPs2AHFV6ZP51xgc3AsXC6Zyom5EJeX0yGj9zWQ0XCjnuFdGsI6G9jmkrmqgAXuUipgqAn0tjxPYp9R/1HqnBLD3Zbrvyi5pCiSFclU6CS6kTDbefzPOc5+zrnlkaolVeF8tQ+EhZiZqtLnpLYUz9bgknoFUapUN4N0R36sKBStdRv54+sMeoOzpQ8ep3PeZW5nWbak12wcrDx38ToWs6hQ4ycb0SQDZZatHsASpSu2nX8HwzZSDAZmsAdB+epPmgA0CBjWVG1ycmVnT6l3OopUmbaY3pXBNzFUXq5Fcd7Q39/MfrmHpyxSc3QVf8xNtUx9ggYtK0Kwx6dgykhNMVzFGZRVyQgwpaiyDqgMGEU2GQzzcJhgKo9+y1fDtdfj/cctmvJ2Fo1fkk+DMkEPUHGOVo6uKFnartky9iLm1WiHDMruJ6SIOJzAnb+TMBWQTSwI+F4wyEiRVR8Zv4uA="
     script: skip
     deploy:
       provider: script

--- a/test/repo_test.dart
+++ b/test/repo_test.dart
@@ -13,7 +13,8 @@ import 'package:yaml/yaml.dart';
 void main() {
   group("YAML files are valid:", () {
     for (var entry in Directory.current.listSync()) {
-      if (entry is File && (entry.path.endsWith(".yaml") || entry.path.endsWith(".yml"))) {
+      if (entry is File &&
+          (entry.path.endsWith(".yaml") || entry.path.endsWith(".yml"))) {
         test(p.basename(entry.path), () {
           // Shouldn't throw an error.
           loadYaml(entry.readAsStringSync());

--- a/test/repo_test.dart
+++ b/test/repo_test.dart
@@ -1,0 +1,24 @@
+// Copyright 2019 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+@TestOn('vm')
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  group("YAML files are valid:", () {
+    for (var entry in Directory.current.listSync()) {
+      if (entry is File && (entry.path.endsWith(".yaml") || entry.path.endsWith(".yml"))) {
+        test(p.basename(entry.path), () {
+          // Shouldn't throw an error.
+          loadYaml(entry.readAsStringSync());
+        });
+      }
+    }
+  });
+}


### PR DESCRIPTION
This also adds a test to verify that all YAML files are valid. Travis
won't run tests at all if its YAML is invalid, but this way Appveyor
can warn about broken Travis config and vice versa, and a local test
run will warn about either.