### PR TITLE
Explicitly set the JS class names for SassNull and SassBoolean

### DIFF
--- a/lib/src/node/utils.dart
+++ b/lib/src/node/utils.dart
@@ -94,6 +94,12 @@ class _PropertyDescriptor {
 @JS("Object.create")
 external Object _create(Object prototype);
 
+/// Sets the name of `object`'s class to `name`.
+void setClassName(Object object, String name) {
+  _defineProperty(getProperty(object, "constructor"), "name",
+      _PropertyDescriptor(value: name));
+}
+
 /// Injects [constructor] into the inheritance chain for [object]'s class.
 void injectSuperclass(Object object, Function constructor) {
   var prototype = _getPrototypeOf(object);

--- a/lib/src/node/value/boolean.dart
+++ b/lib/src/node/value/boolean.dart
@@ -21,6 +21,7 @@ final Function booleanConstructor = () {
         "Use sass.types.Boolean.TRUE or sass.types.Boolean.FALSE instead.";
   });
   injectSuperclass(sassTrue, constructor);
+  setClassName(sassTrue, "SassBoolean");
   forwardToString(constructor);
   setProperty(
       getProperty(constructor, "prototype"),

--- a/lib/src/node/value/null.dart
+++ b/lib/src/node/value/null.dart
@@ -21,6 +21,7 @@ final Function nullConstructor = () {
         "instead.";
   });
   injectSuperclass(sassNull, constructor);
+  setClassName(sassNull, "SassNull");
   forwardToString(constructor);
   setProperty(constructor, "NULL", sassNull);
   setToString(sassNull, () => "null");


### PR DESCRIPTION
For whatever reason the default name seems to have changed.