### PR TITLE
Don't load cli_pkg/testing on Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,9 @@ jobs:
     node_js: lts/dubnium
   - <<: *node-tests
     os: osx
-  # TODO(nweiz): Test Node tests with Dart dev when dart-lang/test#1184 is
-  # fixed.
+  - <<: *node-tests
+    name: Node tests | Dart dev | Node stable
+    env: DART_CHANNEL=dev
 
   # Miscellaneous checks.
   - name: static analysis

--- a/test/ensure_npm_package.dart
+++ b/test/ensure_npm_package.dart
@@ -4,16 +4,9 @@
 
 import 'dart:async';
 
-import 'package:cli_pkg/testing.dart' as pkg;
-import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 import 'package:sass/src/io.dart';
-
-void hybridMain(StreamChannel<Object> channel) async {
-  pkg.ensureExecutableUpToDate("sass", node: true);
-  channel.sink.close();
-}
 
 /// Ensures that the NPM package is compiled and up-to-date.
 ///
@@ -23,6 +16,14 @@ Future<void> ensureNpmPackage() async {
   // path handling in the SDK.
   if (isNode && isWindows) return;
 
-  var channel = spawnHybridUri("/test/ensure_npm_package.dart");
+  var channel = spawnHybridCode("""
+    import 'package:cli_pkg/testing.dart' as pkg;
+    import 'package:stream_channel/stream_channel.dart';
+
+    void hybridMain(StreamChannel<Object> channel) async {
+      pkg.ensureExecutableUpToDate("sass", node: true);
+      channel.sink.close();
+    }
+  """);
   await channel.stream.toList();
 }


### PR DESCRIPTION
This transitively loads dart:mirrors, which has stopped working as of
Dart 2.8.0-dev.9.0.

See dart-lang/sdk#40698