### PR TITLE
Temporarily disable deploying to Chocolatey

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,20 +181,6 @@ jobs:
       skip_cleanup: true
       on: {tags: true}
 
-  # Deploy to Chocolatey.
-  - name: Chocolatey
-    if: *deploy-if
-    os: windows
-    env:
-      # CHOCOLATEY_TOKEN="..."
-      - secure: "EnII3YAGESEl9g9rQDcrL1Sw9eww80VJP0qZHz8Da07GB0hUrDQBJ372Zs2A4qaH/GOm7cknszEPOnkE4w3IBwe5idj31Q+WJbcvqqAB1gex3bLYyStdHeohculqmPgpuEPD3yVT59viJIn6L9+GEKNtnCygDpgxMilXzDIXi6vtLqovJc6q09i7XCSnf2IVjzKv0VBSUV0lU9QOZui5/zLN0sCSzE8QKYj0QSoQ8Th3ZTuWn3/CtRYhIaw4/12oepHyXRvieMeNGnhv8O4d1lAOiXKn28COJWA+xvCOZSxIrBCc0k8VzanYftTcp1Zf0Lxkm0ObmFXWaoHATFWjkvW6G34kQrzRpUlWUMmxIxBukHc2ZFuGnVi6pL9ANI8BVh6m8M1ojRqtKCFvBbgDDdxD7qqBQSfdtssEL+m6O0U9A5/xnQxHPbuyL/Y9ww9p/ohEFaaF3MK/qjiWKQJR+TXspmNDBhFC+w2vQ6zetEx787V6POS8ma5MX1+WWOecDtaDuEMv4bzjkTuYk9tuBC4GR/KrdUNbFtcNXCk5To4Du4FBdOW/+yoVg+ZHtgOzSDehgMJMeFM2fTYNt55iwmjwDyS4XcqsWoHHCDMEhIcuXL5XV5VBENFgs98EGofja70Lp05oLH2W7100OuyG0H18lpECx15OXSFnHQh+91g="
-    script: skip
-    deploy:
-      provider: script
-      script: pub run grinder pkg-chocolatey-deploy
-      skip_cleanup: true
-      on: {tags: true}
-
   # Redeploy sass-lang.com.
   - name: sass-lang.com
     if: *deploy-if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,10 @@
-## 1.26.0-test.3
+## 1.26.0
 
-* No user-visible changes.
-
-## 1.26.0-test.2
-
-* `@use` rules whose URLs' basenames begin with `_` now correctly exclude that
-  `_` from the rules' namespaces.
+* **Potentially breaking bug fix:** `@use` rules whose URLs' basenames begin
+  with `_` now correctly exclude that `_` from the rules' namespaces.
 
 * Fix a bug where imported forwarded members weren't visible in mixins and
   functions that were defined before the `@import`.
-
-## 1.26.0-test.1
 
 * Don't throw errors if the exact same member is loaded or forwarded from
   multiple modules at the same time.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.26.0-test.3
+version: 1.26.0
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
The cli_pkg Chocolatey deployment is still failing for unknown
reasons, and until I have time to debug it I want to get a full
release out.