### PR TITLE
Refactor Extender._extendOrReplace()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.26.2
+
+* More aggressively eliminate redundant selectors in the `selector.extend()` and
+  `selector.replace()` functions.
+
 ## 1.26.1
 
 ### Command Line Interface

--- a/lib/src/extend/extender.dart
+++ b/lib/src/extend/extender.dart
@@ -90,25 +90,28 @@ class Extender {
   /// A helper function for [extend] and [replace].
   static SelectorList _extendOrReplace(SelectorList selector,
       SelectorList source, SelectorList targets, ExtendMode mode) {
-    var extenders = Map<ComplexSelector, Extension>.fromIterable(
-        source.components,
-        value: (complex) => Extension.oneOff(complex as ComplexSelector));
-    for (var complex in targets.components) {
-      if (complex.components.length != 1) {
-        throw SassScriptException("Can't extend complex selector $complex.");
-      }
+    var extenders = {
+      for (var complex in source.components) complex: Extension.oneOff(complex)
+    };
 
-      var compound = complex.components.first as CompoundSelector;
-      var extensions = {
+    var compoundTargets = [
+      for (var complex in targets.components)
+        if (complex.components.length != 1)
+          throw SassScriptException("Can't extend complex selector $complex.")
+        else
+          complex.components.first as CompoundSelector
+    ];
+
+    var extensions = {
+      for (var compound in compoundTargets)
         for (var simple in compound.components) simple: extenders
-      };
+    };
 
-      var extender = Extender._mode(mode);
-      if (!selector.isInvisible) {
-        extender._originals.addAll(selector.components);
-      }
-      selector = extender._extendList(selector, extensions, null);
+    var extender = Extender._mode(mode);
+    if (!selector.isInvisible) {
+      extender._originals.addAll(selector.components);
     }
+    selector = extender._extendList(selector, extensions, null);
 
     return selector;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.26.1
+version: 1.26.2
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
This combines all targets into a single extender invocation, which is
more efficient and allows it to more aggressively do redundant
selector elimination.

See sass/sass#1518