### PR TITLE
Fix a check that prevents compiling .css files to themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.26.3
+
+* Fix a bug where `--watch` mode could go into an infinite loop compiling CSS
+  files to themselves.
+
 ## 1.26.2
 
 * More aggressively eliminate redundant selectors in the `selector.extend()` and

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -267,7 +267,7 @@ class _Watcher {
           p.setExtension(p.relative(source, from: sourceDir), '.css'));
 
       // Don't compile ".css" files to their own locations.
-      if (destination != source) return destination;
+      if (p.relative(destination) != p.relative(source)) return destination;
     }
 
     return null;

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -267,7 +267,7 @@ class _Watcher {
           p.setExtension(p.relative(source, from: sourceDir), '.css'));
 
       // Don't compile ".css" files to their own locations.
-      if (p.relative(destination) != p.relative(source)) return destination;
+      if (!p.equals(destination, source)) return destination;
     }
 
     return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.26.2
+version: 1.26.3
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass

--- a/test/cli/shared/watch.dart
+++ b/test/cli/shared/watch.dart
@@ -173,30 +173,32 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
           ]).validate();
         });
 
-        test("when it's modified twice when watched from a directory that is also a destination", () async {
+        test(
+            "when it's modified twice when watched from a directory that is "
+            "also a destination", () async {
           await d.file("test.scss", "a {b: c}").create();
 
           var sass = await watch(["."]);
           await expectLater(
-            sass.stdout, emits('Compiled test.scss to test.css.'));
+              sass.stdout, emits('Compiled test.scss to test.css.'));
           await expectLater(sass.stdout, _watchingForChanges);
           await tickIfPoll();
 
           await d.file("test.scss", "r {o: g}").create();
           await expectLater(
-            sass.stdout, emits('Compiled test.scss to test.css.'));
+              sass.stdout, emits('Compiled test.scss to test.css.'));
 
           await tickIfPoll();
 
           await d.file("test.scss", "x {y: z}").create();
           await expectLater(
-            sass.stdout, emits('Compiled test.scss to test.css.'));
+              sass.stdout, emits('Compiled test.scss to test.css.'));
 
           await sass.kill();
 
           await d
-            .file("test.css", equalsIgnoringWhitespace("x { y: z; }"))
-            .validate();
+              .file("test.css", equalsIgnoringWhitespace("x { y: z; }"))
+              .validate();
         });
 
         group("when its dependency is modified", () {


### PR DESCRIPTION
* fixes the infinite loop issue in --watch mode  (#904, #853)
* previously it compared relative destination to absolute source
* p.relative(destination) is used to replace backslashes