### PR TITLE
Avoid adding duplicate modules when importing forwarded stylesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.4
+
+* Be more memory-efficient when handling `@forward`s through `@import`s.
+
 ## 1.26.3
 
 * Fix a bug where `--watch` mode could go into an infinite loop compiling CSS

--- a/lib/src/ast/sass/statement/forward_rule.dart
+++ b/lib/src/ast/sass/statement/forward_rule.dart
@@ -116,7 +116,8 @@ class ForwardRule implements Statement {
       buffer
         ..write(" show ")
         ..write(_memberList(shownMixinsAndFunctions, shownVariables));
-    } else if (hiddenMixinsAndFunctions != null) {
+    } else if (hiddenMixinsAndFunctions != null &&
+        hiddenMixinsAndFunctions.isNotEmpty) {
       buffer
         ..write(" hide ")
         ..write(_memberList(hiddenMixinsAndFunctions, hiddenVariables));
@@ -135,7 +136,8 @@ class ForwardRule implements Statement {
   /// Returns a combined list of names of the given members.
   String _memberList(
           Iterable<String> mixinsAndFunctions, Iterable<String> variables) =>
-      shownMixinsAndFunctions
-          .followedBy(shownVariables.map((name) => "\$$name"))
-          .join(", ");
+      [
+        if (shownMixinsAndFunctions != null) ...shownMixinsAndFunctions,
+        if (shownVariables != null) for (var name in shownVariables) "\$$name"
+      ].join(", ");
 }

--- a/lib/src/module/forwarded_view.dart
+++ b/lib/src/module/forwarded_view.dart
@@ -34,6 +34,22 @@ class ForwardedModuleView<T extends AsyncCallable> implements Module<T> {
   final Map<String, T> functions;
   final Map<String, T> mixins;
 
+  /// Like [ForwardedModuleView], but returns `inner` as-is if it doesn't need
+  /// any modification.
+  static Module<T> ifNecessary<T extends AsyncCallable>(
+      Module<T> inner, ForwardRule rule) {
+    if (rule.prefix == null &&
+        rule.shownMixinsAndFunctions == null &&
+        rule.shownVariables == null &&
+        (rule.hiddenMixinsAndFunctions == null ||
+            rule.hiddenMixinsAndFunctions.isEmpty) &&
+        (rule.hiddenVariables == null || rule.hiddenVariables.isEmpty)) {
+      return inner;
+    } else {
+      return ForwardedModuleView(inner, rule);
+    }
+  }
+
   ForwardedModuleView(this._inner, this._rule)
       : variables = _forwardedMap(_inner.variables, _rule.prefix,
             _rule.shownVariables, _rule.hiddenVariables),
@@ -102,5 +118,14 @@ class ForwardedModuleView<T extends AsyncCallable> implements Module<T> {
     return _inner.variableIdentity(name);
   }
 
+  bool operator ==(Object other) =>
+      other is ForwardedModuleView &&
+      _inner == other._inner &&
+      _rule == other._rule;
+
+  int get hashCode => _inner.hashCode ^ _rule.hashCode;
+
   Module<T> cloneCss() => ForwardedModuleView(_inner.cloneCss(), _rule);
+
+  String toString() => "forwarded $_inner";
 }

--- a/lib/src/module/shadowed_view.dart
+++ b/lib/src/module/shadowed_view.dart
@@ -9,6 +9,7 @@ import '../exception.dart';
 import '../extend/extender.dart';
 import '../module.dart';
 import '../util/limited_map_view.dart';
+import '../utils.dart';
 import '../value.dart';
 
 /// A [Module] that only exposes members that aren't shadowed by a given
@@ -29,6 +30,13 @@ class ShadowedModuleView<T extends AsyncCallable> implements Module<T> {
   final Map<String, AstNode> variableNodes;
   final Map<String, T> functions;
   final Map<String, T> mixins;
+
+  /// Returns whether this module exposes no members or CSS.
+  bool get isEmpty =>
+      variables.isEmpty &&
+      functions.isEmpty &&
+      mixins.isEmpty &&
+      css.children.isEmpty;
 
   /// Like [ShadowedModuleView], but returns `null` if [inner] would be unchanged.
   static ShadowedModuleView<T> ifNecessary<T extends AsyncCallable>(
@@ -79,6 +87,17 @@ class ShadowedModuleView<T extends AsyncCallable> implements Module<T> {
     return _inner.variableIdentity(name);
   }
 
+  bool operator ==(Object other) =>
+      other is ShadowedModuleView &&
+      _inner == other._inner &&
+      iterableEquals(variables.keys, other.variables.keys) &&
+      iterableEquals(functions.keys, other.functions.keys) &&
+      iterableEquals(mixins.keys, other.mixins.keys);
+
+  int get hashCode => _inner.hashCode;
+
   Module<T> cloneCss() => ShadowedModuleView._(
       _inner.cloneCss(), variables, variableNodes, functions, mixins);
+
+  String toString() => "shadowed $_inner";
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -173,6 +173,14 @@ int codeUnitIndexToCodepointIndex(String string, int codeUnitIndex) {
   return codepointIndex;
 }
 
+/// Returns whether [iterable1] and [iterable2] have the same contents.
+bool iterableEquals(Iterable<Object> iterable1, Iterable<Object> iterable2) =>
+    const IterableEquality<Object>().equals(iterable1, iterable2);
+
+/// Returns a hash code for [iterable] that matches [iterableEquals].
+int iterableHash(Iterable<Object> iterable) =>
+    const IterableEquality<Object>().hash(iterable);
+
 /// Returns whether [list1] and [list2] have the same contents.
 bool listEquals(List<Object> list1, List<Object> list2) =>
     const ListEquality<Object>().equals(list1, list2);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.26.3
+version: 1.26.4
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
In Google stylesheets that imported import-only stylesheets with many
forwards many of times, we were seeing Environment._globalModules grow
large enough that variable accesses were a problem. This addresses
that in several ways:

* Forwarded modules are now ignored if the module is already being
  forwarded.

* Module equality is more intelligent, so that shadowed and forwarded
  modules can be effectively de-duplicated.

* If a module would be fully shadowed by a later import *and* that
  module has no CSS, we no longer add an empty ShadowedModule to the
  module list.