### PR TITLE
Release 1.26.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.5
+
+* No user-visible changes.
+
 ## 1.26.4
 
 * Be more memory-efficient when handling `@forward`s through `@import`s.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.26.4
+version: 1.26.5
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
This needs a release because the release process for 1.26.4 was broken
by dart-lang/sdk#41259.