### PR TITLE
Don't read `file` if Node importer returns `file` and `contents`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Add `sass.NULL`, `sass.TRUE`, and `sass.FALSE` constants to match Node Sass's
   API.
 
+* If a custom Node importer returns both `file` and `contents`, don't attempt to
+  read the `file`. Instead, use the `contents` provided by the importer, with
+  `file` as the canonical url.
+
 ## 1.26.5
 
 * No user-visible changes.

--- a/lib/src/importer/node/implementation.dart
+++ b/lib/src/importer/node/implementation.dart
@@ -182,14 +182,15 @@ class NodeImporter {
     if (value is! NodeImporterResult) return null;
 
     var result = value as NodeImporterResult;
-    if (result.file != null) {
+    if (result.file == null) {
+      return Tuple2(result.contents ?? '', url);
+    } else if (result.contents != null) {
+      return Tuple2(result.contents, result.file);
+    } else {
       var resolved = _resolveRelativePath(result.file, previous, forImport) ??
           _resolveLoadPath(result.file, previous, forImport);
       if (resolved != null) return resolved;
-
       throw "Can't find stylesheet to import.";
-    } else {
-      return Tuple2(result.contents ?? '', url);
     }
   }
 


### PR DESCRIPTION
Instead, use `contents` with `file` as the canonical url.

Closes https://github.com/sass/dart-sass/issues/975.