### PR TITLE
Fix a selector parsing bug in indented syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,9 +99,11 @@ jobs:
   - name: static analysis
     language: dart
     dart_task: {dartanalyzer: --fatal-warnings --fatal-infos lib tool test}
-  - name: code formatting
-    language: dart
-    dart_task: dartfmt
+
+  # TODO(jathak): Re-enable this once dart-lang/dart_style#940 is fixed.
+  # - name: code formatting
+  #   language: dart
+  #   dart_task: dartfmt
 
   ## Deployment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.11-dev
+
+* Fixes a parsing bug with inline comments in selectors.
+
 ## 1.26.10
 
 * Fixes a bug where two adjacent combinators could cause an error.

--- a/lib/src/parse/sass.dart
+++ b/lib/src/parse/sass.dart
@@ -46,23 +46,12 @@ class SassParser extends StylesheetParser {
 
     var buffer = InterpolationBuffer();
     do {
-      buffer.addInterpolation(almostAnyValue());
+      buffer.addInterpolation(almostAnyValue(omitComments: true));
       buffer.writeCharCode($lf);
-    } while (_endsWithComma(buffer.trailingString) && scanCharIf(isNewline));
+    } while (buffer.trailingString.trimRight().endsWith(',') &&
+        scanCharIf(isNewline));
 
     return buffer.interpolation(scanner.spanFrom(start));
-  }
-
-  // Returns true if [text] ends with a comma, ignoring whitespace and comments.
-  bool _endsWithComma(String text) {
-    var line = text.trimRight().split('\n').last;
-    var silentComment = line.lastIndexOf('//');
-    if (silentComment != -1) line = line.substring(0, silentComment);
-    line = line.trimRight();
-    while (line.endsWith('*/')) {
-      line = line.substring(0, line.lastIndexOf('/*')).trimRight();
-    }
-    return line.endsWith(',');
   }
 
   void expectStatementSeparator([String name]) {

--- a/lib/src/parse/sass.dart
+++ b/lib/src/parse/sass.dart
@@ -48,10 +48,21 @@ class SassParser extends StylesheetParser {
     do {
       buffer.addInterpolation(almostAnyValue());
       buffer.writeCharCode($lf);
-    } while (buffer.trailingString.trimRight().endsWith(",") &&
-        scanCharIf(isNewline));
+    } while (_endsWithComma(buffer.trailingString) && scanCharIf(isNewline));
 
     return buffer.interpolation(scanner.spanFrom(start));
+  }
+
+  // Returns true if [text] ends with a comma, ignoring whitespace and comments.
+  bool _endsWithComma(String text) {
+    var line = text.trimRight().split('\n').last;
+    var silentComment = line.lastIndexOf('//');
+    if (silentComment != -1) line = line.substring(0, silentComment);
+    line = line.trimRight();
+    while (line.endsWith('*/')) {
+      line = line.substring(0, line.lastIndexOf('/*')).trimRight();
+    }
+    return line.endsWith(',');
   }
 
   void expectStatementSeparator([String name]) {

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -2881,6 +2881,9 @@ relase. For details, see http://bit.ly/moz-document.
   /// This respects string and comment boundaries and supports interpolation.
   /// Once this interpolation is evaluated, it's expected to be re-parsed.
   ///
+  /// If [omitComments] is true, comments will still be consumed, but they will
+  /// not be included in the returned interpolation.
+  ///
   /// Differences from [_interpolatedDeclarationValue] include:
   ///
   /// * This does not balance brackets.
@@ -2892,7 +2895,7 @@ relase. For details, see http://bit.ly/moz-document.
   ///
   /// * This does not compress adjacent whitespace characters.
   @protected
-  Interpolation almostAnyValue() {
+  Interpolation almostAnyValue({bool omitComments = false}) {
     var start = scanner.state;
     var buffer = InterpolationBuffer();
 
@@ -2914,7 +2917,7 @@ relase. For details, see http://bit.ly/moz-document.
         case $slash:
           var commentStart = scanner.position;
           if (scanComment()) {
-            buffer.write(scanner.substring(commentStart));
+            if (!omitComments) buffer.write(scanner.substring(commentStart));
           } else {
             buffer.writeCharCode(scanner.readChar());
           }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.26.10
+version: 1.26.11-dev
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
Fixes #1002.

In the indented syntax, a selector list may continue onto another line if the previous line ends with a comma. Previously, if there was a comment after the comma, it wouldn't be recognized and the selector would be broken in two (with the first selector having no properties).

This fixes the parser to ignore comments when looking for the comma at the end of a line.

See sass/sass-spec#1532.