### PR TITLE
Fix pubspec and release 1.26.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.7
+
+* No user-visible changes.
+
 ## 1.26.6
 
 * Fix a bug where escape sequences were improperly recognized in `@else` rules.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.26.6
+version: 1.26.7
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass
@@ -18,6 +18,7 @@ dependencies:
   cli_repl: ">=0.1.3 <0.3.0"
   collection: "^1.8.0"
   meta: "^1.1.7"
+  js: "^0.6.0"
   package_resolver: "^1.0.0"
   path: "^1.6.0"
   source_maps: "^0.10.5"
@@ -36,7 +37,6 @@ dev_dependencies:
   crypto: ">=0.9.2 <3.0.0"
   dart_style: "^1.2.0"
   grinder: "^0.8.0"
-  js: "^0.6.0"
   node_preamble: "^1.1.0"
   pedantic: "^1.0.0"
   pub_semver: "^1.0.0"


### PR DESCRIPTION
Pub was failing due to the `js` dependency being declared as a dev
dependency but being referenced in `lib`.