### PR TITLE
Always use absolute URLs in stdout source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.8
+
+* Fixes an error when emitting source maps to stdout.
+
 ## 1.26.7
 
 * No user-visible changes.

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -388,6 +388,11 @@ class ExecutableOptions {
     return extension == ".scss" || extension == ".sass" || extension == ".css";
   }
 
+  /// Returns whether we're writing to stdout instead of a file or files.
+  bool get _writeToStdout =>
+      sourcesToDestinations.length == 1 &&
+      sourcesToDestinations.values.single == null;
+
   /// Whether to emit a source map file.
   bool get emitSourceMap {
     if (!(_options['source-map'] as bool)) {
@@ -399,10 +404,7 @@ class ExecutableOptions {
         _fail("--embed-source-map isn't allowed with --no-source-map.");
       }
     }
-
-    var writeToStdout = sourcesToDestinations.length == 1 &&
-        sourcesToDestinations.values.single == null;
-    if (!writeToStdout) return _options['source-map'] as bool;
+    if (!_writeToStdout) return _options['source-map'] as bool;
 
     if (_ifParsed('source-map-urls') == 'relative') {
       _fail(
@@ -458,7 +460,7 @@ class ExecutableOptions {
     if (url.scheme.isNotEmpty && url.scheme != 'file') return url;
 
     var path = p.fromUri(url);
-    return p.toUri(_options['source-map-urls'] == 'relative'
+    return p.toUri(_options['source-map-urls'] == 'relative' && !_writeToStdout
         ? p.relative(path, from: p.dirname(destination))
         : p.absolute(path));
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.26.7
+version: 1.26.8
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass

--- a/test/cli/shared/source_maps.dart
+++ b/test/cli/shared/source_maps.dart
@@ -342,6 +342,20 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
         expect(map, containsPair("file", "out.css"));
       });
     });
+
+    test("with stdout as the target", () async {
+      var sass = await runSass(["--embed-source-map", "test.scss"]);
+      expect(
+          sass.stdout,
+          emitsInOrder([
+            "a {",
+            "  b: 3;",
+            "}",
+            "",
+            startsWith("/*# sourceMappingURL=data:")
+          ]));
+      await sass.shouldExit(0);
+    });
   });
 }
 


### PR DESCRIPTION
Fixes #1020.