### PR TITLE
Release 1.26.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.9
+
+* Use an updated version of `node_preamble` when compiling to JS.
+
 ## 1.26.8
 
 * Fixes an error when emitting source maps to stdout.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,5 +44,5 @@ dev_dependencies:
   stream_channel: ">=1.0.0 <3.0.0"
   test_descriptor: "^1.1.0"
   test_process: "^1.0.0-rc.1"
-  test: ">=0.12.42 <=2.0.0"
+  test: ">=0.12.42 <2.0.0"
   yaml: "^2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.26.8
+version: 1.26.9
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,5 +45,5 @@ dev_dependencies:
   test_descriptor: "^1.1.0"
   test_process: "^1.0.0-rc.1"
   # Update this constraint once dart-lang/test#1278 is resolved.
-  test: "1.14.7"
+  test: ">=0.12.42 <=1.14.7"
   yaml: "^2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,5 @@ dev_dependencies:
   stream_channel: ">=1.0.0 <3.0.0"
   test_descriptor: "^1.1.0"
   test_process: "^1.0.0-rc.1"
-  # Update this constraint once dart-lang/test#1278 is resolved.
-  test: ">=0.12.42 <=1.14.7"
+  test: ">=0.12.42 <=2.0.0"
   yaml: "^2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,5 +44,6 @@ dev_dependencies:
   stream_channel: ">=1.0.0 <3.0.0"
   test_descriptor: "^1.1.0"
   test_process: "^1.0.0-rc.1"
-  test: ">=0.12.42 <2.0.0"
+  # Update this constraint once dart-lang/test#1278 is resolved.
+  test: "1.14.7"
   yaml: "^2.0.0"


### PR DESCRIPTION
(Update to `node_preamble` is available)