### PR TITLE
Replace use of deprecated mapMap with map literals

### DIFF
--- a/lib/src/color_names.dart
+++ b/lib/src/color_names.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'package:collection/collection.dart';
-
 import 'value.dart';
 
 /// A map from (lowercase) color names to their color values.
@@ -162,5 +160,6 @@ final colorsByName = {
 };
 
 /// A map from Sass colors to (lowercase) color names.
-final namesByColor = mapMap<String, SassColor, SassColor, String>(colorsByName,
-    key: (_, color) => color, value: (name, _) => name);
+final namesByColor = {
+  for (var entry in colorsByName.entries) entry.value: entry.key
+};

--- a/lib/src/functions/meta.dart
+++ b/lib/src/functions/meta.dart
@@ -50,8 +50,10 @@ final global = UnmodifiableListView([
   _function("keywords", r"$args", (arguments) {
     var argumentList = arguments[0];
     if (argumentList is SassArgumentList) {
-      return SassMap(mapMap(argumentList.keywords,
-          key: (String key, Value _) => SassString(key, quotes: false)));
+      return SassMap({
+        for (var entry in argumentList.keywords.entries)
+          SassString(entry.key, quotes: false): entry.value
+      });
     } else {
       throw "\$args: $argumentList is not an argument list.";
     }

--- a/lib/src/util/source_map_buffer.dart
+++ b/lib/src/util/source_map_buffer.dart
@@ -20,8 +20,10 @@ class SourceMapBuffer implements StringBuffer {
   /// A map from source file URLs to the corresponding [SourceFile]s.
   ///
   /// This is of a form that can be passed to [Mapping.spanFor].
-  Map<String, SourceFile> get sourceFiles => UnmodifiableMapView(
-      mapMap(_sourceFiles, key: (url, _) => url.toString()));
+  Map<String, SourceFile> get sourceFiles => UnmodifiableMapView({
+        for (var entry in _sourceFiles.entries)
+          entry.key.toString(): entry.value
+      });
   final _sourceFiles = <Uri, SourceFile>{};
 
   /// The index of the current line in [_buffer].

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -396,29 +396,13 @@ Future<V> putIfAbsentAsync<K, V>(
   return value;
 }
 
-/// Like [mapMap], but for asynchronous [key] and [value].
-Future<Map<K2, V2>> mapMapAsync<K1, V1, K2, V2>(Map<K1, V1> map,
-    {Future<K2> key(K1 key, V1 value),
-    Future<V2> value(K1 key, V1 value)}) async {
-  key ??= (mapKey, _) async => mapKey as K2;
-  value ??= (_, mapValue) async => mapValue as V2;
-
-  var result = <K2, V2>{};
-  for (var mapKey in map.keys) {
-    var mapValue = map[mapKey];
-    result[await key(mapKey, mapValue)] = await value(mapKey, mapValue);
-  }
-  return result;
-}
-
 /// Returns a deep copy of a map that contains maps.
 Map<K1, Map<K2, V>> copyMapOfMap<K1, K2, V>(Map<K1, Map<K2, V>> map) =>
-    mapMap<K1, Map<K2, V>, K1, Map<K2, V>>(map,
-        value: (_, innerMap) => Map.of(innerMap));
+    {for (var entry in map.entries) entry.key: Map.of(entry.value)};
 
 /// Returns a deep copy of a map that contains lists.
 Map<K, List<E>> copyMapOfList<K, E>(Map<K, List<E>> map) =>
-    mapMap<K, List<E>, K, List<E>>(map, value: (_, list) => list.toList());
+    {for (var entry in map.entries) entry.key: entry.value.toList()};
 
 extension SpanExtensions on FileSpan {
   /// Returns this span with all whitespace trimmed from both sides.

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -387,10 +387,10 @@ class _EvaluateVisitor
             keywordRest: args.keywords.isEmpty
                 ? null
                 : ValueExpression(
-                    SassMap(mapMap(args.keywords,
-                        key: (String key, Value _) =>
-                            SassString(key, quotes: false),
-                        value: (String _, Value value) => value)),
+                    SassMap({
+                      for (var entry in args.keywords.entries)
+                        SassString(entry.key, quotes: false): entry.value
+                    }),
                     _callableNode.span));
 
         if (function is SassString) {
@@ -2328,9 +2328,10 @@ class _EvaluateVisitor
     var positional = [
       for (var expression in arguments.positional) await expression.accept(this)
     ];
-    var named = await mapMapAsync<String, Expression, String, Value>(
-        arguments.named,
-        value: (_, expression) => expression.accept(this));
+    var named = {
+      for (var entry in arguments.named.entries)
+        entry.key: await entry.value.accept(this)
+    };
 
     var positionalNodes = trackSpans
         ? [
@@ -2339,8 +2340,10 @@ class _EvaluateVisitor
           ]
         : null;
     var namedNodes = trackSpans
-        ? mapMap<String, Expression, String, AstNode>(arguments.named,
-            value: (_, expression) => _expressionNode(expression))
+        ? {
+            for (var entry in arguments.named.entries)
+              entry.key: _expressionNode(entry.value)
+          }
         : null;
 
     if (arguments.rest == null) {

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 0ad7cedc5ee1d05297c4a8d321d492854742e8ab
+// Checksum: 7f6c1eeddc48b08b4ff3f95c3af19cdf8afdfb1b
 //
 // ignore_for_file: unused_import
 
@@ -394,10 +394,10 @@ class _EvaluateVisitor
             keywordRest: args.keywords.isEmpty
                 ? null
                 : ValueExpression(
-                    SassMap(mapMap(args.keywords,
-                        key: (String key, Value _) =>
-                            SassString(key, quotes: false),
-                        value: (String _, Value value) => value)),
+                    SassMap({
+                      for (var entry in args.keywords.entries)
+                        SassString(entry.key, quotes: false): entry.value
+                    }),
                     _callableNode.span));
 
         if (function is SassString) {
@@ -2311,8 +2311,10 @@ class _EvaluateVisitor
     var positional = [
       for (var expression in arguments.positional) expression.accept(this)
     ];
-    var named = mapMap<String, Expression, String, Value>(arguments.named,
-        value: (_, expression) => expression.accept(this));
+    var named = {
+      for (var entry in arguments.named.entries)
+        entry.key: entry.value.accept(this)
+    };
 
     var positionalNodes = trackSpans
         ? [
@@ -2321,8 +2323,10 @@ class _EvaluateVisitor
           ]
         : null;
     var namedNodes = trackSpans
-        ? mapMap<String, Expression, String, AstNode>(arguments.named,
-            value: (_, expression) => _expressionNode(expression))
+        ? {
+            for (var entry in arguments.named.entries)
+              entry.key: _expressionNode(entry.value)
+          }
         : null;
 
     if (arguments.rest == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,5 +44,5 @@ dev_dependencies:
   stream_channel: ">=1.0.0 <3.0.0"
   test_descriptor: "^1.1.0"
   test_process: "^1.0.0-rc.1"
-  test: ">=0.12.42 <2.0.0"
+  test: ">=1.15.1 <2.0.0"
   yaml: "^2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,5 +44,5 @@ dev_dependencies:
   stream_channel: ">=1.0.0 <3.0.0"
   test_descriptor: "^1.1.0"
   test_process: "^1.0.0-rc.1"
-  test: ">=1.15.1 <2.0.0"
+  test: ">=0.12.42 <2.0.0"
   yaml: "^2.0.0"


### PR DESCRIPTION
The test package fixed the macOS issue in 1.15.1, so I've also bumped that version.