### PR TITLE
Use HTTPS links in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,7 +259,7 @@
   module system. You can also use the new [Sass migrator][] to automatically
   migrate your stylesheets to the new module system!
 
-  [migrator blog]: http://sass-lang.com/blog/posts/7858341-the-module-system-is-launched
+  [migrator blog]: https://sass-lang.com/blog/the-module-system-is-launched
   [Sass migrator]: https://sass-lang.com/documentation/cli/migrator
 
 ## 1.22.12


### PR DESCRIPTION
This also update the URL to the canonical one rather than relying on the redirection.