### PR TITLE
Throw a proper error when the same built-in module is @used twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Improve some error messages for edge-case parse failures.
 
+* Throw a proper error when the same built-in module is `@use`d twice.
+
 ## 1.26.10
 
 * Fixes a bug where two adjacent combinators could cause an error.

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -549,7 +549,7 @@ class _EvaluateVisitor
             nodeWithSpan.span);
       }
 
-      callback(builtInModule);
+      _addExceptionSpan(nodeWithSpan, () => callback(builtInModule));
       return;
     }
 

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 7f6c1eeddc48b08b4ff3f95c3af19cdf8afdfb1b
+// Checksum: f6fe6645ccec58216ef623851bd2594de291a360
 //
 // ignore_for_file: unused_import
 
@@ -552,7 +552,7 @@ class _EvaluateVisitor
             nodeWithSpan.span);
       }
 
-      callback(builtInModule);
+      _addExceptionSpan(nodeWithSpan, () => callback(builtInModule));
       return;
     }
 


### PR DESCRIPTION
Closes #1047
See sass/sass-spec#1553