### PR TITLE
Add a map.deep-merge() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 1.27.0
+
+* Add a `map.deep-merge()` function. This works like `map.merge()`, except that
+  nested map values are *also* recursively merged. For example:
+  
+  ```
+  map.deep-merge(
+    (color: (primary: red, secondary: blue),
+    (color: (secondary: teal)
+  ) // => (color: (primary: red, secondary: teal))
+  ```
+
+  See [the Sass documentation][map-deep-merge] for more details.
+
+  [map-deep-merge]: https://sass-lang.com/documentation/modules/map#deep-merge
+
+### Dart API
+
+* Add a `Value.tryMap()` function which returns the `Value` as a `SassMap` if
+  it's a valid map, or `null` otherwise. This allows function authors to safely
+  retrieve maps even if they're internally stored as empty lists, without having
+  to catch exceptions from `Value.assertMap()`.
+
 ## 1.26.11
 
 * **Potentially breaking bug fix:** `selector.nest()` now throws an error

--- a/lib/src/value.dart
+++ b/lib/src/value.dart
@@ -98,6 +98,8 @@ abstract class Value implements ext.Value {
   SassMap assertMap([String name]) =>
       throw _exception("$this is not a map.", name);
 
+  SassMap tryMap() => null;
+
   SassNumber assertNumber([String name]) =>
       throw _exception("$this is not a number.", name);
 

--- a/lib/src/value/external/value.dart
+++ b/lib/src/value/external/value.dart
@@ -104,6 +104,10 @@ abstract class Value {
   /// (without the `$`). It's used for error reporting.
   SassMap assertMap([String name]);
 
+  /// Returns [this] as a [SassMap] if it is one (including empty lists, which
+  /// count as empty maps) or returns `null` if it's not.
+  SassMap tryMap();
+
   /// Throws a [SassScriptException] if [this] isn't a number.
   ///
   /// If this came from a function argument, [name] is the argument name

--- a/lib/src/value/list.dart
+++ b/lib/src/value/list.dart
@@ -46,6 +46,8 @@ class SassList extends Value implements ext.SassList {
   SassMap assertMap([String name]) =>
       asList.isEmpty ? const SassMap.empty() : super.assertMap(name);
 
+  SassMap tryMap() => asList.isEmpty ? const SassMap.empty() : null;
+
   bool operator ==(Object other) =>
       (other is SassList &&
           other.separator == separator &&

--- a/lib/src/value/map.dart
+++ b/lib/src/value/map.dart
@@ -32,6 +32,8 @@ class SassMap extends Value implements ext.SassMap {
 
   SassMap assertMap([String name]) => this;
 
+  SassMap tryMap() => this;
+
   bool operator ==(Object other) =>
       (other is SassMap && mapEquals(other.contents, contents)) ||
       (contents.isEmpty && other is SassList && other.asList.isEmpty);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.26.11-dev
+version: 1.27.0-dev
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass

--- a/test/dart_api/value/boolean_test.dart
+++ b/test/dart_api/value/boolean_test.dart
@@ -31,6 +31,7 @@ void main() {
       expect(value.assertColor, throwsSassScriptException);
       expect(value.assertFunction, throwsSassScriptException);
       expect(value.assertMap, throwsSassScriptException);
+      expect(value.tryMap(), isNull);
       expect(value.assertNumber, throwsSassScriptException);
       expect(value.assertString, throwsSassScriptException);
     });
@@ -56,6 +57,7 @@ void main() {
       expect(value.assertColor, throwsSassScriptException);
       expect(value.assertFunction, throwsSassScriptException);
       expect(value.assertMap, throwsSassScriptException);
+      expect(value.tryMap(), isNull);
       expect(value.assertNumber, throwsSassScriptException);
       expect(value.assertString, throwsSassScriptException);
     });

--- a/test/dart_api/value/color_test.dart
+++ b/test/dart_api/value/color_test.dart
@@ -139,6 +139,7 @@ void main() {
       expect(value.assertBoolean, throwsSassScriptException);
       expect(value.assertFunction, throwsSassScriptException);
       expect(value.assertMap, throwsSassScriptException);
+      expect(value.tryMap(), isNull);
       expect(value.assertNumber, throwsSassScriptException);
       expect(value.assertString, throwsSassScriptException);
     });

--- a/test/dart_api/value/function_test.dart
+++ b/test/dart_api/value/function_test.dart
@@ -31,6 +31,7 @@ void main() {
       expect(value.assertBoolean, throwsSassScriptException);
       expect(value.assertColor, throwsSassScriptException);
       expect(value.assertMap, throwsSassScriptException);
+      expect(value.tryMap(), isNull);
       expect(value.assertNumber, throwsSassScriptException);
       expect(value.assertString, throwsSassScriptException);
     });

--- a/test/dart_api/value/list_test.dart
+++ b/test/dart_api/value/list_test.dart
@@ -110,6 +110,7 @@ void main() {
       expect(value.assertColor, throwsSassScriptException);
       expect(value.assertFunction, throwsSassScriptException);
       expect(value.assertMap, throwsSassScriptException);
+      expect(value.tryMap(), isNull);
       expect(value.assertNumber, throwsSassScriptException);
       expect(value.assertString, throwsSassScriptException);
     });
@@ -140,6 +141,7 @@ void main() {
       expect(value.assertColor, throwsSassScriptException);
       expect(value.assertFunction, throwsSassScriptException);
       expect(value.assertMap, throwsSassScriptException);
+      expect(value.tryMap(), isNull);
       expect(value.assertNumber, throwsSassScriptException);
       expect(value.assertString, throwsSassScriptException);
     });
@@ -167,6 +169,7 @@ void main() {
 
     test("counts as an empty map", () {
       expect(value.assertMap().contents, isEmpty);
+      expect(value.tryMap().contents, isEmpty);
     });
 
     test("isn't any other type", () {

--- a/test/dart_api/value/map_test.dart
+++ b/test/dart_api/value/map_test.dart
@@ -128,6 +128,7 @@ void main() {
 
     test("is a map", () {
       expect(value.assertMap(), equals(value));
+      expect(value.tryMap(), equals(value));
     });
 
     test("isn't any other type", () {

--- a/test/dart_api/value/null_test.dart
+++ b/test/dart_api/value/null_test.dart
@@ -27,6 +27,7 @@ void main() {
     expect(value.assertColor, throwsSassScriptException);
     expect(value.assertFunction, throwsSassScriptException);
     expect(value.assertMap, throwsSassScriptException);
+    expect(value.tryMap(), isNull);
     expect(value.assertNumber, throwsSassScriptException);
     expect(value.assertString, throwsSassScriptException);
   });

--- a/test/dart_api/value/number_test.dart
+++ b/test/dart_api/value/number_test.dart
@@ -102,6 +102,7 @@ void main() {
       expect(value.assertColor, throwsSassScriptException);
       expect(value.assertFunction, throwsSassScriptException);
       expect(value.assertMap, throwsSassScriptException);
+      expect(value.tryMap(), isNull);
       expect(value.assertString, throwsSassScriptException);
     });
   });

--- a/test/dart_api/value/string_test.dart
+++ b/test/dart_api/value/string_test.dart
@@ -37,6 +37,7 @@ void main() {
       expect(value.assertColor, throwsSassScriptException);
       expect(value.assertFunction, throwsSassScriptException);
       expect(value.assertMap, throwsSassScriptException);
+      expect(value.tryMap(), isNull);
       expect(value.assertNumber, throwsSassScriptException);
     });
 


### PR DESCRIPTION
This also adds a Value.tryMap() function, which was useful for
implementing this and may be more generally useful to users as well.

Note: this is the same as #1077, but targeted at the
`feature.nested-maps` branch.

See sass/sass#2836
See sass/sass-spec#1563