### PR TITLE
Test against a matching sass-spec feature branch by default

### DIFF
--- a/tool/travis/sass-spec-ref.sh
+++ b/tool/travis/sass-spec-ref.sh
@@ -7,7 +7,11 @@
 # run. If we're running specs for a pull request which refers to a sass-spec
 # pull request, we'll run against the latter rather than sass-spec master.
 
-default=master
+if [[ "$TRAVIS_BRANCH" == feature.* ]]; then
+  default="$TRAVIS_BRANCH"
+else
+  default=master
+fi
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   >&2 echo "TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST."


### PR DESCRIPTION
Rather than always defaulting to master, if Travis is running for a
feature branch or a pull request targeting a feature branch, it will
default to using the same feature branch in sass-spec.