### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/bin/sass.dart
+++ b/bin/sass.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:isolate';
 
 import 'package:path/path.dart' as p;

--- a/lib/sass.dart
+++ b/lib/sass.dart
@@ -5,8 +5,6 @@
 /// We strongly recommend importing this library with the prefix `sass`.
 library sass;
 
-import 'dart:async';
-
 import 'package:source_maps/source_maps.dart';
 
 import 'src/async_import_cache.dart';

--- a/lib/src/async_compile.dart
+++ b/lib/src/async_compile.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;

--- a/lib/src/async_environment.dart
+++ b/lib/src/async_environment.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:collection';
 
 import 'package:meta/meta.dart';

--- a/lib/src/async_import_cache.dart
+++ b/lib/src/async_import_cache.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
-
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:tuple/tuple.dart';

--- a/lib/src/compile.dart
+++ b/lib/src/compile.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_compile.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 193c9bc1905022e881636f4d6359c906146abcb3
+// Checksum: bca3a79dd4a5c3905b07003b123172f3c876d2de
 //
 // ignore_for_file: unused_import
 

--- a/lib/src/environment.dart
+++ b/lib/src/environment.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_environment.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: d304e1c5208019bca99df0678c3fdb4d09776a2b
+// Checksum: 9f4ee98a1c9e90d8d5277e0c2b0355460cda8788
 //
 // ignore_for_file: unused_import
 

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;

--- a/lib/src/executable/repl.dart
+++ b/lib/src/executable/repl.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:cli_repl/cli_repl.dart';

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_import_cache.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 8f54034c56e0d38fc8c90ad4d5f017628cab6190
+// Checksum: 5293a11e290c86829547ddd982ee3b1b1536dc73
 //
 // ignore_for_file: unused_import
 

--- a/lib/src/importer/node/interface.dart
+++ b/lib/src/importer/node/interface.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
-
 import 'package:tuple/tuple.dart';
 
 class NodeImporter {

--- a/lib/src/io/interface.dart
+++ b/lib/src/io/interface.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
-
 import 'package:watcher/watcher.dart';
 
 /// An output sink that writes to this process's standard error.

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -1581,8 +1581,7 @@ relase. For details, see http://bit.ly/moz-document.
           break;
         }
       } else if (named.isNotEmpty) {
-        error(
-            "Positional arguments must come before keyword arguments.",
+        error("Positional arguments must come before keyword arguments.",
             expression.span);
       } else {
         positional.add(expression);

--- a/lib/src/sync_package_resolver/node.dart
+++ b/lib/src/sync_package_resolver/node.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 class SyncPackageResolver {
   static final _error =
       UnsupportedError('SyncPackageResolver is not supported in JS.');

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:charcode/charcode.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core