### PR TITLE
Feature: Add support for multiline expressions in indented syntax

### DIFF
--- a/lib/src/parse/sass.dart
+++ b/lib/src/parse/sass.dart
@@ -314,6 +314,12 @@ class SassParser extends StylesheetParser {
     // newlines.
     while (!scanner.isDone) {
       var next = scanner.peekChar();
+      if (next == $backslash) {
+        // Use backslash to enable multiline
+        scanner.readChar();
+        _expectNewline();
+        continue;
+      }
       if (next != $tab && next != $space) break;
       scanner.readChar();
     }


### PR DESCRIPTION
backslash "\\" is used to wrap long lines, it most be followed by newline and spaces after will be ignored, example:

```
/* Mixins */
@mixin col($cols, $mleft: 0, $mright: 0, $include-margin: false, $border: 0, \
           $pleft: 0, $pright: 0, $include-padding: true, $extra: 0, $clear: false, \
           $lead: true, $container: false)
    width: $cols
    color: red
    display: block
```

fixes #280
fixes sass/sass#216

All test passed
![Captura de pantalla de 2020-09-27 10-43-37](https://user-images.githubusercontent.com/7505980/94359326-1a923b80-00af-11eb-9260-5ca2397a06ca.png)