### PR TITLE
Re-enable formatter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,10 +98,9 @@ jobs:
     language: dart
     dart_task: {dartanalyzer: --fatal-warnings --fatal-infos lib tool test}
 
-  # TODO(jathak): Re-enable this once dart-lang/dart_style#940 is fixed.
-  # - name: code formatting
-  #   language: dart
-  #   dart_task: dartfmt
+  - name: code formatting
+    language: dart
+    dart_task: dartfmt
 
   ## Deployment
 


### PR DESCRIPTION
It looks like Travis worked around dart-lang/sdk#42989 on their end. The error is still happening, but the task doesn't fail (and it properly uses the package version of the formatter), so I think we can re-enable this