### PR TITLE
fix(importer/node):  skip exception in tryPath

### DIFF
--- a/lib/src/importer/node/implementation.dart
+++ b/lib/src/importer/node/implementation.dart
@@ -169,9 +169,12 @@ class NodeImporter {
     var resolved = forImport
         ? inImportRule(() => resolveImportPath(path))
         : resolveImportPath(path);
-    return resolved == null
-        ? null
-        : Tuple2(readFile(resolved), p.toUri(resolved).toString());
+    if (resolved == null) return null;
+    try {
+      return Tuple2(readFile(resolved), p.toUri(resolved).toString());
+    } catch (e) {
+      return null;
+    }
   }
 
   /// Converts an importer's return [value] to a tuple that can be returned by

--- a/test/node_api/importer_test.dart
+++ b/test/node_api/importer_test.dart
@@ -139,6 +139,43 @@ void main() {
           }))));
       expect(result.stats.includedFiles, equals(['bar']));
     });
+
+    test("uses relative files within subdirectories by contents", () {
+      expect(
+          renderSync(RenderOptions(
+              data:
+                  "@use './button/rules' as button; @use './input/rules' as input",
+              importer: [
+                allowInterop((Object url, void _) {
+                  if (url != "button/rules") return null;
+                  return NodeImporterResult(
+                      contents: '@use "./styles"',
+                      file: '/__virtual__/button/rules');
+                }),
+                allowInterop((Object url, void _) {
+                  if (url != "input/rules") return null;
+                  return NodeImporterResult(
+                      contents: '@use "./styles"',
+                      file: '/__virtual__/input/rules');
+                }),
+                allowInterop((Object url, Object prev) {
+                  if (prev != "/__virtual__/button/rules") return null;
+                  if (url != "styles") return null;
+                  return NodeImporterResult(
+                      contents: 'button {color: red}',
+                      file: '/__virtual__/button/rules/styles');
+                }),
+                allowInterop((Object url, Object prev) {
+                  if (prev != "/__virtual__/input/rules") return null;
+                  if (url != "styles") return null;
+                  return NodeImporterResult(
+                      contents: 'input {color: green}',
+                      file: '/__virtual__/input/rules/styles');
+                })
+              ])),
+          equalsIgnoringWhitespace(
+              'button { color: red; } input { color: green; }'));
+    });
   });
 
   group("with a file redirect", () {


### PR DESCRIPTION
Fixes #1121:

* Add try/catch around readFile in case file is not found.
* Return null on failure, as documented