### PR TITLE
Trim extends at the compound selector level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.27.0
+## 1.27.1
+
+* Avoid going exponential on certain recursive `@extend` edge cases.
+
+## 1.27.1
 
 * Adds an overload to `map.merge()` that supports merging a nested map.
 

--- a/lib/src/extend/extender.dart
+++ b/lib/src/extend/extender.dart
@@ -684,10 +684,20 @@ class Extender {
           .toList();
     });
 
-    return unifiedPaths
-        .where((complexes) => complexes != null)
-        .expand((l) => l)
-        .toList();
+    // If we're preserving the original selector, mark the first unification as
+    // such so [_trim] doesn't get rid of it.
+    var isOriginal = (ComplexSelector _) => false;
+    if (inOriginal && _mode != ExtendMode.replace) {
+      var original = unifiedPaths.first.first;
+      isOriginal = (complex) => complex == original;
+    }
+
+    return _trim(
+        unifiedPaths
+            .where((complexes) => complexes != null)
+            .expand((l) => l)
+            .toList(),
+        isOriginal);
   }
 
   Iterable<List<Extension>> _extendSimple(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.27.0
+version: 1.27.1
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
This reverts a portion of #460 (15202c4). It turns out that trimming
compound selector extends allows us to avoid exponential behavior in
certain recursive @extend cases.

See sass/dart-sass#1109
See sass/sass-spec#1578