### PR TITLE
Disable Node.js tests on Dart dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,9 +90,12 @@ jobs:
     os: windows
   - <<: *node-tests
     os: osx
-  - <<: *node-tests
-    name: Node tests | Dart dev | Node 14
-    env: DART_CHANNEL=dev
+
+  # TODO(nweiz): Re-enable these when dart-lang/sdk#44181 or dart-lang/test#1363
+  # is fixed.
+  # - <<: *node-tests
+  #   name: Node tests | Dart dev | Node 14
+  #   env: DART_CHANNEL=dev
 
   # Miscellaneous checks.
   - name: static analysis

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,5 +45,7 @@ dev_dependencies:
   stream_channel: ">=1.0.0 <3.0.0"
   test_descriptor: "^1.1.0"
   test_process: "^1.0.0-rc.1"
-  test: ">=0.12.42 <2.0.0"
+  # TODO(nweiz): Allow higher versions of test once dart-lang/test#1382 is
+  # fixed.
+  test: ">=0.12.42 <1.15.5"
   yaml: "^2.0.0"


### PR DESCRIPTION
These are broken by a combination of dart-lang/sdk#44181 and
dart-lang/test#1363.