### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:collection';
 
 import 'package:path/path.dart' as p;

--- a/lib/src/util/multi_dir_watcher.dart
+++ b/lib/src/util/multi_dir_watcher.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
-
 import 'package:async/async.dart';
 import 'package:path/path.dart' as p;
 import 'package:watcher/watcher.dart';

--- a/test/cli/dart_test.dart
+++ b/test/cli/dart_test.dart
@@ -4,8 +4,6 @@
 
 @TestOn('vm')
 
-import 'dart:async';
-
 import 'package:cli_pkg/testing.dart' as pkg;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;

--- a/test/cli/node_test.dart
+++ b/test/cli/node_test.dart
@@ -5,8 +5,6 @@
 @TestOn('vm')
 @Tags(['node'])
 
-import 'dart:async';
-
 import 'package:cli_pkg/testing.dart' as pkg;
 import 'package:test_process/test_process.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;

--- a/test/cli/shared.dart
+++ b/test/cli/shared.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/cli/shared/colon_args.dart
+++ b/test/cli/shared/colon_args.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
-
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;

--- a/test/cli/shared/errors.dart
+++ b/test/cli/shared/errors.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
-
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';

--- a/test/cli/shared/repl.dart
+++ b/test/cli/shared/repl.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
-
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';

--- a/test/cli/shared/source_maps.dart
+++ b/test/cli/shared/source_maps.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;

--- a/test/cli/shared/update.dart
+++ b/test/cli/shared/update.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
-
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';

--- a/test/cli/shared/watch.dart
+++ b/test/cli/shared/watch.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
-
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;

--- a/test/ensure_npm_package.dart
+++ b/test/ensure_npm_package.dart
@@ -2,8 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
-
 import 'package:test/test.dart';
 
 import 'package:sass/src/io.dart';

--- a/test/hybrid.dart
+++ b/test/hybrid.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:test/test.dart';

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.