### PR TITLE
Avoid permissions errors in _realCasePath.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.32.1
+
+* Don't emit permissions errors on Windows and OS X when trying to determine the
+  real case of path names.
+
 ## 1.32.0
 
 * Deprecate passing non-`%` numbers as lightness and saturation to `hsl()`,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.32.0
+version: 1.32.1
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
This catches permissions errors and treats them as indicating that the
path component we have so far is canonical. This also improves the
efficiency of case matching by caching results for higher directories.

Closes #1182