### PR TITLE
Avoid throw/catch in Number.==

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.32.3
+
+* Optimize `==` for numbers that have different units.
+
 ## 1.32.2
 
 * Print the actual number that was received in unit deprecation warnings for

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.32.2
+version: 1.32.3
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
Throwing and catching exceptions is expensive. Testing this on one
user's number-heavy codebase resulted in a 2x speed improvement.