### PR TITLE
Bump to 1.32.5 (updated node_preamble.dart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.32.5
+
+* Use an updated version of `node_preamble` when compiling to JS.
+
 ## 1.32.4
 
 * No user-visible changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.32.5
 
-* Use an updated version of `node_preamble` when compiling to JS.
+* Fixes Electron support when `nodeIntegration` is disabled
 
 ## 1.32.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.32.5
+version: 1.32.5-dev
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.32.4
+version: 1.32.5
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
Similar to #1028, pulls mbullington/node_preamble.dart#21