### PR TITLE
Remove useless dev dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,6 @@ dev_dependencies:
   node_preamble: "^1.1.0"
   pedantic: "^1.0.0"
   pub_semver: "^1.0.0"
-  source_span: "^1.5.2"
   stream_channel: ">=1.0.0 <3.0.0"
   test_descriptor: "^1.1.0"
   test_process: "^1.0.0-rc.1"


### PR DESCRIPTION
source_span is already a normal dependency of the package.

this has been reported to me by my IDE (I'm using the Dart plugin for Jetbrains IDEs).