### PR TITLE
Set RangeError.start and .end for color range checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.32.6
+
+### Dart API
+
+* All range checks for `SassColor` constructors now throw `RangeError`s with
+  `start` and `end` set.
+
 ## 1.32.5
 
 * **Potentially breaking bug fix:** When using `@for` with numbers that have

--- a/lib/src/util/number.dart
+++ b/lib/src/util/number.dart
@@ -89,5 +89,6 @@ num fuzzyCheckRange(num number, num min, num max) {
 num fuzzyAssertRange(num number, num min, num max, [String name]) {
   var result = fuzzyCheckRange(number, min, max);
   if (result != null) return result;
-  throw RangeError.value(number, name, "must be between $min and $max.");
+  throw RangeError.range(
+      number, min, max, name, "must be between $min and $max");
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.32.5
+version: 1.32.6-dev
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
This is useful for sass/dart-sass-embedded#32 because it makes the
range checks easier to deconstruct and reconstruct into useful
embedded error messages.