### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.32.6
+
+### Node JS API
+
+* Fix Electron support when `nodeIntegration` is disabled.
+
 ## 1.32.5
 
 * **Potentially breaking bug fix:** When using `@for` with numbers that have

--- a/lib/src/util/number.dart
+++ b/lib/src/util/number.dart
@@ -86,7 +86,7 @@ num fuzzyCheckRange(num number, num min, num max) {
 ///
 /// If [number] is [fuzzyEquals] to [min] or [max], it's clamped to the
 /// appropriate value. [name] is used in error reporting.
-num fuzzyAssertRange(num number, num min, num max, [String name]) {
+num fuzzyAssertRange(num number, int min, int max, [String name]) {
   var result = fuzzyCheckRange(number, min, max);
   if (result != null) return result;
   throw RangeError.range(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.32.5
+version: 1.32.6
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
Same as  #1028, this time the relevant [node_preamble.dart version](https://pub.dev/packages/node_preamble/versions/1.4.13) has actually been published... Whoops!