### PR TITLE
Let last !default value of @forward...with be commaless.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.32.8
+
+* Allow `@forward...with` to take arguments that have a `!default` flag without
+  a trailing comma.
+
 ## 1.32.7
 
 * Improve the performance of unitless and single-unit numbers.
@@ -63,7 +68,7 @@
 
 * Properly mark some warnings emitted by `sass:color` functions as deprecation
   warnings.
-  
+
 ### Dart API
 
 * Rename `SassNumber.valueInUnits()` to `SassNumber.coerceValue()`. The old name

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -1432,6 +1432,7 @@ relase. For details, see http://bit.ly/moz-document.
         var flag = identifier();
         if (flag == 'default') {
           guarded = true;
+          whitespace();
         } else {
           error("Invalid flag name.", scanner.spanFrom(flagStart));
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.32.7
+version: 1.32.8-dev
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
This advances the scanner to the next line even if the !default
identifier is not followed by a comma.

Fixes https://github.com/sass/dart-sass/issues/1222
See https://github.com/sass/sass-spec/pull/1619