### PR TITLE
Limit the version of source_span

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   package_resolver: "^1.0.0"
   path: "^1.6.0"
   source_maps: "^0.10.5"
-  source_span: "^1.6.0"
+  source_span: ">=1.6.0 <1.8.0" # dart-lang/source_span#72
   stack_trace: ">=0.9.0 <2.0.0"
   stream_transform: ">=0.0.20 <2.0.0"
   string_scanner: ">=0.1.5 <2.0.0"


### PR DESCRIPTION
This is a workaround to get the build working again until
dart-lang/source_span#72 lands.