### PR TITLE
Fix extending selectors across multiple modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.32.12
+
+* Fix a bug that disallowed more than one module from extending the same
+  selector from a module if that selector itself extended a selector from
+  another upstream module.
+
 ## 1.32.11
 
 * Fix a bug where bogus indented syntax errors were reported for lines that

--- a/lib/src/extend/extension_store.dart
+++ b/lib/src/extend/extension_store.dart
@@ -328,7 +328,7 @@ class ExtensionStore {
       }
 
       var containsExtension = selectors.first == extension.extender.selector;
-      var first = false;
+      var first = true;
       for (var complex in selectors) {
         // If the output contains the original complex selector, there's no
         // need to recreate it.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.32.11
+version: 1.32.12-dev
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.32.12-dev
+version: 1.32.12
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
Allows more than one module to extend the same upstream selector that,
in turn, extends a selector from its upstream module.

Properly skips creating an extra extension that was being counted as
unresolved when evaluating @extends.

See https://github.com/sass/sass-spec/pull/1635
Fixes https://github.com/sass/dart-sass/issues/1295