### PR TITLE
Add the verbose option in the node API

### DIFF
--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -105,6 +105,7 @@ Future<RenderResult> _renderAsync(RenderOptions options) async {
         useSpaces: options.indentType != 'tab',
         indentWidth: _parseIndentWidth(options.indentWidth),
         lineFeed: _parseLineFeed(options.linefeed),
+        verbose: isTruthy(options.verbose),
         url: file == null ? 'stdin' : p.toUri(file).toString(),
         sourceMap: _enableSourceMaps(options));
   } else if (file != null) {
@@ -116,6 +117,7 @@ Future<RenderResult> _renderAsync(RenderOptions options) async {
         useSpaces: options.indentType != 'tab',
         indentWidth: _parseIndentWidth(options.indentWidth),
         lineFeed: _parseLineFeed(options.linefeed),
+        verbose: isTruthy(options.verbose),
         sourceMap: _enableSourceMaps(options));
   } else {
     throw ArgumentError("Either options.data or options.file must be set.");
@@ -146,6 +148,7 @@ RenderResult _renderSync(RenderOptions options) {
           useSpaces: options.indentType != 'tab',
           indentWidth: _parseIndentWidth(options.indentWidth),
           lineFeed: _parseLineFeed(options.linefeed),
+          verbose: isTruthy(options.verbose),
           url: file == null ? 'stdin' : p.toUri(file).toString(),
           sourceMap: _enableSourceMaps(options));
     } else if (file != null) {
@@ -157,6 +160,7 @@ RenderResult _renderSync(RenderOptions options) {
           useSpaces: options.indentType != 'tab',
           indentWidth: _parseIndentWidth(options.indentWidth),
           lineFeed: _parseLineFeed(options.linefeed),
+          verbose: isTruthy(options.verbose),
           sourceMap: _enableSourceMaps(options));
     } else {
       throw ArgumentError("Either options.data or options.file must be set.");

--- a/lib/src/node/render_options.dart
+++ b/lib/src/node/render_options.dart
@@ -21,6 +21,7 @@ class RenderOptions {
   external String? get indentType;
   external Object? get indentWidth;
   external String? get linefeed;
+  external bool? get verbose;
   external FiberClass? get fiber;
   external Object? get sourceMap;
   external bool? get sourceMapContents;
@@ -40,6 +41,7 @@ class RenderOptions {
       String? indentType,
       Object? indentWidth,
       String? linefeed,
+      bool? verbose,
       FiberClass? fiber,
       Object? sourceMap,
       bool? sourceMapContents,


### PR DESCRIPTION
This allows getting the full list of deprecation warnings when using the npm package.