### PR TITLE
Add `--fatal-deprecation` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.35.0
+
+* Add a `--fatal-deprecation` flag, which errors when the given deprecated
+  behavior is encountered.
+
 ## 1.34.1
 
 * Fix a bug where `--update` would always compile any file that depends on a

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -14,6 +14,7 @@ import 'package:tuple/tuple.dart';
 import '../../sass.dart';
 import '../io.dart';
 import '../util/character.dart';
+import '../warn.dart';
 
 /// The parsed and processed command-line options for the Sass executable.
 ///
@@ -105,6 +106,9 @@ class ExecutableOptions {
       ..addFlag('verbose',
           help: "Print all deprecation warnings even when they're repetitive.")
       ..addFlag('trace', help: 'Print full Dart stack traces for exceptions.')
+      ..addMultiOption('fatal-deprecation',
+          help: 'Error when the specified deprecated behavior is encountered.',
+          allowed: Deprecation.byId.keys)
       ..addFlag('help',
           abbr: 'h', help: 'Print this usage information.', negatable: false)
       ..addFlag('version',
@@ -211,10 +215,17 @@ class ExecutableOptions {
   /// error.
   bool get stopOnError => _options['stop-on-error'] as bool;
 
-  /// Whether to emit error messages as CSS stylesheets
+  /// Whether to emit error messages as CSS stylesheets.
   bool get emitErrorCss =>
       _options['error-css'] as bool? ??
       sourcesToDestinations.values.any((destination) => destination != null);
+
+  /// The deprecations that should be treated as fatal.
+  Set<Deprecation> get fatalDeprecations => _fatalDeprecations ??= {
+        for (var id in _options['fatal-deprecation'] as List<String>)
+          Deprecation.byId[id] ?? _fail('Invalid deprecation "$id"')
+      };
+  Set<Deprecation>? _fatalDeprecations;
 
   /// A map from source paths to the destination paths where the compiled CSS
   /// should be written.

--- a/lib/src/functions/color.dart
+++ b/lib/src/functions/color.dart
@@ -233,12 +233,10 @@ final module = BuiltInModule("color", functions: [
       }
 
       var result = _functionString("invert", arguments.take(1));
-      warn(
-          "Passing a number (${arguments[0]}) to color.invert() is "
-          "deprecated.\n"
-          "\n"
-          "Recommendation: $result",
-          deprecation: true);
+      Deprecation.colorNumber.warnOrError(
+          argument: arguments[0],
+          function: 'invert',
+          recommendation: '$result');
       return result;
     }
 
@@ -260,12 +258,10 @@ final module = BuiltInModule("color", functions: [
   _function("grayscale", r"$color", (arguments) {
     if (arguments[0] is SassNumber) {
       var result = _functionString("grayscale", arguments.take(1));
-      warn(
-          "Passing a number (${arguments[0]}) to color.grayscale() is "
-          "deprecated.\n"
-          "\n"
-          "Recommendation: $result",
-          deprecation: true);
+      Deprecation.colorNumber.warnOrError(
+          argument: arguments[0],
+          function: 'grayscale',
+          recommendation: '$result');
       return result;
     }
 
@@ -314,11 +310,7 @@ final module = BuiltInModule("color", functions: [
           !argument.hasQuotes &&
           argument.text.contains(_microsoftFilterStart)) {
         var result = _functionString("alpha", arguments);
-        warn(
-            "Using color.alpha() for a Microsoft filter is deprecated.\n"
-            "\n"
-            "Recommendation: $result",
-            deprecation: true);
+        Deprecation.alphaFilter.warnOrError(recommendation: '$result');
         return result;
       }
 
@@ -332,11 +324,7 @@ final module = BuiltInModule("color", functions: [
           argument.text.contains(_microsoftFilterStart))) {
         // Support the proprietary Microsoft alpha() function.
         var result = _functionString("alpha", arguments);
-        warn(
-            "Using color.alpha() for a Microsoft filter is deprecated.\n"
-            "\n"
-            "Recommendation: $result",
-            deprecation: true);
+        Deprecation.alphaFilter.warnOrError(recommendation: '$result');
         return result;
       }
 
@@ -349,12 +337,10 @@ final module = BuiltInModule("color", functions: [
   _function("opacity", r"$color", (arguments) {
     if (arguments[0] is SassNumber) {
       var result = _functionString("opacity", arguments);
-      warn(
-          "Passing a number (${arguments[0]} to color.opacity() is "
-          "deprecated.\n"
-          "\n"
-          "Recommendation: $result",
-          deprecation: true);
+      Deprecation.colorNumber.warnOrError(
+          argument: arguments[0],
+          function: 'opacity',
+          recommendation: '$result');
       return result;
     }
 
@@ -636,43 +622,33 @@ Value _hsl(String name, List<Value> arguments) {
 void _checkAngle(SassNumber angle, [String? name]) {
   if (!angle.hasUnits || angle.hasUnit('deg')) return;
 
-  var message = StringBuffer()
-    ..writeln("\$$name: Passing a unit other than deg ($angle) is deprecated.")
-    ..writeln();
+  String? context;
+  String? currentBehavior;
+  String? newBehavior;
 
   if (angle.compatibleWithUnit('deg')) {
-    message
-      ..writeln(
-          "You're passing $angle, which is currently (incorrectly) converted "
-          "to ${SassNumber(angle.value, 'deg')}.")
-      ..writeln("Soon, it will instead be correctly converted to "
-          "${angle.coerce(['deg'], [])}.")
-      ..writeln();
-
-    var actualUnit = angle.numeratorUnits.first;
-    message
-      ..writeln("To preserve current behavior: \$$name * 1deg/1$actualUnit")
-      ..writeln("To migrate to new behavior: 0deg + \$$name")
-      ..writeln();
+    context = "You're passing $angle, which is currently (incorrectly) "
+        'converted to ${SassNumber(angle.value, 'deg')}.\n'
+        'Soon, it will instead be correctly converted to '
+        '${angle.coerce(['deg'], [])}.';
+    currentBehavior = '\$$name * 1deg/1${angle.numeratorUnits.first}';
+    newBehavior = '0deg + \$$name';
   } else {
-    message
-      ..writeln("To preserve current behavior: \$$name${_removeUnits(angle)}")
-      ..writeln();
+    currentBehavior = '\$$name${_removeUnits(angle)}';
   }
-
-  message.write("See https://sass-lang.com/d/color-units");
-  warn(message.toString(), deprecation: true);
+  Deprecation.hueUnits.warnOrError(
+      argument: angle,
+      context: context,
+      currentBehavior: currentBehavior,
+      newBehavior: newBehavior);
 }
 
 /// Prints a deprecation warning if [number] doesn't have unit `%`.
 void _checkPercent(SassNumber number, String name) {
   if (number.hasUnit('%')) return;
 
-  warn(
-      "\$$name: Passing a number without unit % ($number) is deprecated.\n"
-      "\n"
-      "To preserve current behavior: \$$name${_removeUnits(number)} * 1%",
-      deprecation: true);
+  Deprecation.hslPercent.warnOrError(
+      argument: number, currentBehavior: '\$$name${_removeUnits(number)} * 1%');
 }
 
 /// Returns the right-hand side of an expression that would remove all units

--- a/lib/src/parse/scss.dart
+++ b/lib/src/parse/scss.dart
@@ -8,6 +8,7 @@ import '../ast/sass.dart';
 import '../interpolation_buffer.dart';
 import '../logger.dart';
 import '../util/character.dart';
+import '../warn.dart';
 import 'stylesheet.dart';
 
 /// A parser for the CSS-compatible syntax.
@@ -45,13 +46,7 @@ class ScssParser extends StylesheetParser {
     if (scanner.scanChar($at)) {
       if (scanIdentifier('else', caseSensitive: true)) return true;
       if (scanIdentifier('elseif', caseSensitive: true)) {
-        logger.warn(
-            '@elseif is deprecated and will not be supported in future Sass '
-            'versions.\n'
-            '\n'
-            'Recommendation: @else if',
-            span: scanner.spanFrom(beforeAt),
-            deprecation: true);
+        deprecationWarning(Deprecation.elseif, scanner.spanFrom(beforeAt));
         scanner.position -= 2;
         return true;
       }

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -20,6 +20,7 @@ import '../util/character.dart';
 import '../utils.dart';
 import '../util/nullable.dart';
 import '../value.dart';
+import '../warn.dart' show Deprecation;
 import 'parser.dart';
 
 /// The base class for both the SCSS and indented syntax parsers.
@@ -1334,17 +1335,20 @@ abstract class StylesheetParser extends Parser {
     var value = buffer.interpolation(scanner.spanFrom(valueStart));
     return _withChildren(_statement, start, (children, span) {
       if (needsDeprecationWarning) {
-        logger.warn(
-            "@-moz-document is deprecated and support will be removed in Dart "
-            "Sass 2.0.0.\n"
-            "\n"
-            "For details, see http://bit.ly/MozDocument.",
-            span: span,
-            deprecation: true);
+        deprecationWarning(Deprecation.mozDocument, span);
       }
 
       return AtRule(name, span, value: value, children: children);
     });
+  }
+
+  /// Warns or errors about [deprecation], depending on whether it is fatal.
+  void deprecationWarning(Deprecation deprecation, FileSpan span) {
+    if (deprecation.isFatal) {
+      error(deprecation.message(), span);
+    } else {
+      logger.warn(deprecation.message(), span: span, deprecation: true);
+    }
   }
 
   /// Consumes a `@return` rule.

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -206,6 +206,9 @@ class _EvaluateVisitor
   /// This is used to produce warnings for importers.
   FileSpan? _importSpan;
 
+  /// The span for the current deprecation warning.
+  FileSpan? _deprecationSpan;
+
   /// Whether we're currently executing a function.
   var _inFunction = false;
 
@@ -435,12 +438,8 @@ class _EvaluateVisitor
                     callableNode.span));
 
         if (function is SassString) {
-          warn(
-              "Passing a string to call() is deprecated and will be illegal in "
-              "Dart Sass 2.0.0.\n"
-              "\n"
-              "Recommendation: call(get-function($function))",
-              deprecation: true);
+          Deprecation.callString
+              .warnOrError(recommendation: 'call(get-function($function))');
 
           var callableNode = _callableNode!;
           var expression = FunctionExpression(
@@ -547,10 +546,15 @@ class _EvaluateVisitor
   /// If no other span can be found to report a warning, falls back on
   /// [nodeWithSpan]'s.
   T _withWarnCallback<T>(AstNode nodeWithSpan, T callback()) {
+    FileSpan span() =>
+        _deprecationSpan ??
+        _importSpan ??
+        _callableNode?.span ??
+        nodeWithSpan.span;
     return withWarnCallback(
-        (message, deprecation) => _warn(
-            message, _importSpan ?? _callableNode?.span ?? nodeWithSpan.span,
-            deprecation: deprecation),
+        (message, deprecation) =>
+            _warn(message, span(), deprecation: deprecation),
+        (message) => throw _exception(message, span()),
         callback);
   }
 
@@ -1972,21 +1976,16 @@ class _EvaluateVisitor
     }
 
     if (node.isGlobal && !_environment.globalVariableExists(node.name)) {
-      _warn(
-          _environment.atRoot
-              ? "As of Dart Sass 2.0.0, !global assignments won't be able to "
-                  "declare new variables.\n"
-                  "\n"
-                  "Since this assignment is at the root of the stylesheet, the "
-                  "!global flag is\n"
-                  "unnecessary and can safely be removed."
-              : "As of Dart Sass 2.0.0, !global assignments won't be able to "
-                  "declare new variables.\n"
-                  "\n"
-                  "Recommendation: add `${node.originalName}: null` at the "
-                  "stylesheet root.",
-          node.span,
-          deprecation: true);
+      _deprecationSpan = node.span;
+      Deprecation.globalDeclaration.warnOrError(
+          context: _environment.atRoot
+              ? 'Since this assignment is at the root of the stylesheet, '
+                  'the !global flag is\n'
+                  'unnecessary and can safely be removed.'
+              : null,
+          recommendation: _environment.atRoot
+              ? null
+              : 'add `${node.originalName}: null` at the stylesheet root.');
     }
 
     var value =
@@ -2111,16 +2110,9 @@ class _EvaluateVisitor
                 }
               }
 
-              _warn(
-                  "Using / for division is deprecated and will be removed in "
-                  "Dart Sass 2.0.0.\n"
-                  "\n"
-                  "Recommendation: ${recommendation(node)}\n"
-                  "\n"
-                  "More info and automated migrator: "
-                  "https://sass-lang.com/d/slash-div",
-                  node.span,
-                  deprecation: true);
+              _deprecationSpan = node.span;
+              Deprecation.slashAsDivision
+                  .warnOrError(recommendation: recommendation(node));
             }
 
             return result;
@@ -3093,16 +3085,9 @@ class _EvaluateVisitor
         }
       }
 
-      _warn(
-          "Using / for division is deprecated and will be removed in Dart Sass "
-          "2.0.0.\n"
-          "\n"
-          "Recommendation: ${recommendation(value)}\n"
-          "\n"
-          "More info and automated migrator: "
-          "https://sass-lang.com/d/slash-div",
-          nodeForSpan.span,
-          deprecation: true);
+      _deprecationSpan = nodeForSpan.span;
+      Deprecation.slashAsDivision
+          .warnOrError(recommendation: recommendation(value));
     }
 
     return value.withoutSlash();

--- a/lib/src/warn.dart
+++ b/lib/src/warn.dart
@@ -22,13 +22,230 @@ void warn(String message, {bool deprecation = false}) {
   warnDefinition(message, deprecation);
 }
 
-/// Runs [callback] with [warn] as the definition for the top-level `warn()` function.
+/// Runs [callback] with [warn] as the definition for the top-level `warn()`
+/// function and [error] as a similar function that errors.
 ///
-/// This is zone-based, so if [callback] is asynchronous [warn] is set for the
-/// duration of that callback.
-T withWarnCallback<T>(
-    void warn(String message, bool deprecation), T callback()) {
+/// This is zone-based, so if [callback] is asynchronous, [warn] and [error] are
+/// set for the duration of that callback.
+T withWarnCallback<T>(void warn(String message, bool deprecation),
+    Never error(String message), T callback()) {
   return runZoned(() {
     return callback();
-  }, zoneValues: {#_warn: warn});
+  }, zoneValues: {#_warn: warn, #_error: error});
+}
+
+/// Runs [callback] with [fatalDeprecations].
+///
+/// This is zone-based, so if [callback] is asynchronous, the given deprecations
+/// are fatal for the duration of that callback.
+T withFatalDeprecations<T>(Set<Deprecation> fatalDeprecations, T callback()) {
+  return runZoned(() {
+    return callback();
+  }, zoneValues: {#_fatalDeprecations: fatalDeprecations});
+}
+
+/// Represents a piece of deprecated functionality in the language.
+class Deprecation {
+  /// The identifier for this deprecation, which can be passed on the command
+  /// line to the `--fatal-deprecation` option.
+  ///
+  /// This must be unique among all deprecations.
+  final String id;
+
+  /// A short description of the functionality being deprecated.
+  ///
+  /// Any instance of `{argument}` or `{function}` in this string will be
+  /// replaced with the corresponding arguments to [message] or [warnOrError].
+  final String description;
+
+  /// The version the deprecated functionality will be removed in, e.g. `2.0.0`
+  /// or null if this is not yet known.
+  final String? removedIn;
+
+  /// When true, [description] should instead describe the future behavior that
+  /// will be used as of [removedIn].
+  final bool describesFutureBehavior;
+
+  /// A URL with more information about this deprecation.
+  final String? url;
+
+  /// Whether or not an automatic migrator exists for this deprecation.
+  final bool hasMigrator;
+
+  /// The recommended change that should be used when no `recommendation` is
+  /// passed to [message] or [warnOrError].
+  final String? defaultRecommendation;
+
+  Deprecation._(this.id, this.description,
+      {this.removedIn,
+      this.describesFutureBehavior = false,
+      this.url,
+      this.hasMigrator = false,
+      this.defaultRecommendation});
+
+  /// The deprecation for using `color.alpha()` in a Microsoft filter.
+  static final alphaFilter = Deprecation._(
+      'alpha-filter', 'Using color.alpha() for a Microsoft filter');
+
+  /// The deprecation for passing a string to `call` instead of using
+  /// `get-function`.
+  static final callString = Deprecation._(
+      'call-string', 'Passing a string to call()',
+      removedIn: '2.0.0');
+
+  /// The deprecation for passing a number to a function in the color module.
+  static final colorNumber = Deprecation._(
+      'color-number', 'Passing a number ({argument}) to color.{function}()');
+
+  /// The deprecation for `@elseif`.
+  static final elseif =
+      Deprecation._('elseif', '@elseif', defaultRecommendation: '@else if');
+
+  /// The deprecation for declaring new variables with `!global`.
+  static final globalDeclaration = Deprecation._('global-declaration',
+      "!global assignments won't be able to declare new variables",
+      removedIn: '2.0.0', describesFutureBehavior: true);
+
+  /// The deprecation for passing numbers without % to saturation or lightness
+  /// parameters.
+  static final hslPercent = Deprecation._(
+      'hsl-percent', 'Passing a number without unit % ({argument})',
+      url: 'https://sass-lang.com/d/color-units');
+
+  /// The deprecation for passing units other than `deg` to a hue parameter.
+  static final hueUnits = Deprecation._(
+      'hue-units', 'Passing a unit other than deg ({argument})',
+      url: 'https://sass-lang.com/d/color-units');
+
+  /// The deprecation for parsing `@-moz-document`.
+  static final mozDocument = Deprecation._('moz-document', '@-moz-document',
+      removedIn: '2.0.0', url: 'https://bit.ly/MozDocument');
+
+  /// The deprecation for treating `/` as division.
+  static final slashAsDivision = Deprecation._(
+      'slash-as-division', 'Using / for division',
+      removedIn: '2.0.0',
+      url: 'https://sass-lang.com/d/slash-div',
+      hasMigrator: true);
+
+  /// The set of all current deprecations.
+  static final all = Set.unmodifiable({
+    alphaFilter,
+    callString,
+    colorNumber,
+    elseif,
+    globalDeclaration,
+    hslPercent,
+    hueUnits,
+    mozDocument,
+    slashAsDivision
+  });
+
+  /// A map between deprecation IDs and deprecation they refer to.
+  static final byId = Map<String, Deprecation>.unmodifiable(
+      {for (var item in all) item.id: item});
+
+  /// Constructs a deprecation warning for this deprecation based on its
+  /// properties and the arguments passed here.
+  ///
+  /// [argument] is the deprecated argument passed to a built-in function.
+  /// [function] is the name of a built-in function with deprecated behavior.
+  /// [context] is additional context for the deprecation that will be included
+  ///   after the default description.
+  /// [recommendation] is the recommended change to the code in question to
+  ///   avoid the deprecated behavior. This overrides [defaultRecommendation] if
+  ///   it exists.
+  /// [currentBehavior] is a recommended change that preserves the current
+  ///   behavior, while [newBehavior] is a recommended change that migrates to
+  ///   the future behavior once the deprecation is complete.
+  String message(
+      {Object? argument,
+      String? function,
+      String? context,
+      String? recommendation,
+      String? currentBehavior,
+      String? newBehavior}) {
+    var buffer = StringBuffer();
+    if (describesFutureBehavior) {
+      buffer.write(removedIn == null
+          ? 'In a future version of Sass, '
+          : 'As of Dart Sass $removedIn, ');
+    }
+    var description = this.description;
+    if (argument != null) {
+      description = description.replaceAll('{argument}', '$argument');
+    }
+    if (function != null) {
+      description = description.replaceAll('{function}', function);
+    }
+    buffer.write(description);
+    if (!describesFutureBehavior) {
+      buffer.write(' is deprecated');
+      if (removedIn != null) {
+        buffer.write(' and will be removed in Dart Sass $removedIn');
+      }
+    }
+    buffer.writeln('.');
+
+    if (context != null) buffer..writeln()..writeln(context);
+
+    recommendation ??= defaultRecommendation;
+    if (recommendation != null ||
+        currentBehavior != null ||
+        newBehavior != null) {
+      buffer.writeln();
+    }
+    if (recommendation != null) {
+      buffer.writeln('Recommendation: $recommendation');
+    }
+    if (currentBehavior != null) {
+      buffer.writeln('To preserve current behavior: $currentBehavior');
+    }
+    if (newBehavior != null) {
+      buffer.writeln('To migrate to new behavior: $newBehavior');
+    }
+    if (url != null) {
+      buffer
+        ..writeln()
+        ..write(hasMigrator ? 'More info and automated migrator:' : 'See')
+        ..writeln(' $url');
+    }
+    return buffer.toString();
+  }
+
+  /// Returns true if this deprecation is treated as fatal.
+  ///
+  /// This will be false unless inside a [withFatalDeprecations] callback that
+  /// included this deprecation.
+  bool get isFatal {
+    var fatalDeprecations = Zone.current[#_fatalDeprecations];
+    if (fatalDeprecations is! Set<Deprecation>) return false;
+    return fatalDeprecations.contains(this);
+  }
+
+  /// Emits a warning or errors based on [isFatal].
+  ///
+  /// This will only work when inside a [withWarnCallback] callback.
+  ///
+  /// The arguments here are the same as those of [message].
+  void warnOrError(
+      {Object? argument,
+      String? function,
+      String? context,
+      String? recommendation,
+      String? currentBehavior,
+      String? newBehavior}) {
+    var msg = message(
+        argument: argument,
+        function: function,
+        context: context,
+        recommendation: recommendation,
+        currentBehavior: currentBehavior,
+        newBehavior: newBehavior);
+    if (isFatal) {
+      Zone.current[#_error](msg);
+    } else {
+      warn(msg, deprecation: true);
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.34.1
+version: 1.35.0-dev
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass

--- a/test/cli/shared.dart
+++ b/test/cli/shared.dart
@@ -529,6 +529,24 @@ void sharedTests(
     });
   });
 
+  group('with --fatal-deprecation', () {
+    test('errors on the given deprecation', () async {
+      await d.file('test.scss', r'$_: 1/2').create();
+      var sass =
+          await runSass(['--fatal-deprecation=slash-as-division', 'test.scss']);
+      expect(sass.stderr, emitsThrough(contains('math.div')));
+      await sass.shouldExit(65);
+    });
+
+    test('warns for other deprecations', () async {
+      await d.file('test.scss', r'$_: call("inspect", null)').create();
+      var sass =
+          await runSass(['--fatal-deprecation=slash-as-division', 'test.scss']);
+      expect(sass.stderr, emitsThrough(contains('call()')));
+      await sass.shouldExit(0);
+    });
+  });
+
   group("with --charset", () {
     test("doesn't emit @charset for a pure-ASCII stylesheet", () async {
       await d.file("test.scss", "a {b: c}").create();


### PR DESCRIPTION
Partial fix for #633.

This restructures deprecation warnings into a class that gives each deprecation an identifier and structures the warnings themselves primarily based on the instance variables of that Deprecation.

This supports the core use case of making a deprecation fatal from the command line, but I'd like some feedback on the general approach before finishing this PR (mainly adding support to the Dart API and updating any sass-specs with warnings that were tweaked as part of this).

My main questions are:
- Do the deprecations and their identifiers make sense here? I looked for all the deprecation warnings I could find being emitted but it's possible I missed one. I also made the [color units breaking change](https://sass-lang.com/documentation/breaking-changes/color-units) into two deprecations here (requiring deg for hue as one, and requiring % for saturation and lightness as the other) since the warnings were fairly different.
- The properties of `Deprecation` and the parameters for `Deprecation.message` were mostly just based on what was necessary to replicate the existing warnings in a structured way. Are there any that don't make sense, or additional properties that should be added? Also, are there any deprecations without a `removedIn` version that should have one?
- Does the Zone-based approach for setting fatal deprecations make sense here? What about updating `withWarnCallback` to include an `error ` function to allow `Deprecation.warnOrError` to work? I'm more confident in the former, but I'm less sure about the latter.
- Should the Dart API take in deprecation identifiers as strings (like the `--fatal-deprecation` flag), or should `Deprecation` be exposed as part of the public API?