### PR TITLE
Another implicit dependency fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.34.2
 
-* Fix a bug that could prevent some members from being found in certain files
-  that use a mix of imports and the module system.
+* Fix a couple bugs that could prevent some members from being found in certain
+  files that use a mix of imports and the module system.
 
 ## 1.34.1
 

--- a/lib/src/async_environment.dart
+++ b/lib/src/async_environment.dart
@@ -4,6 +4,7 @@
 
 import 'dart:collection';
 
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 
@@ -809,7 +810,7 @@ class AsyncEnvironment {
   Module toModule(CssStylesheet css, ExtensionStore extensionStore) {
     assert(atRoot);
     return _EnvironmentModule(this, css, extensionStore,
-        forwarded: _forwardedModules?.keys.toSet());
+        forwarded: _forwardedModules.andThen((modules) => MapKeySet(modules)));
   }
 
   /// Returns a module with the same members and upstream modules as [this], but
@@ -824,7 +825,7 @@ class AsyncEnvironment {
         CssStylesheet(const [],
             SourceFile.decoded(const [], url: "<dummy module>").span(0)),
         ExtensionStore.empty,
-        forwarded: _forwardedModules?.keys.toSet());
+        forwarded: _forwardedModules.andThen((modules) => MapKeySet(modules)));
   }
 
   /// Returns the module with the given [namespace], or throws a

--- a/lib/src/environment.dart
+++ b/lib/src/environment.dart
@@ -5,12 +5,13 @@
 // DO NOT EDIT. This file was generated from async_environment.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: c7e97403e3c0a31ea064572622b8305357d29dc3
+// Checksum: d5a12dbc383245a91d1e2fee0e2c4aa38939a3d8
 //
 // ignore_for_file: unused_import
 
 import 'dart:collection';
 
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 
@@ -815,7 +816,7 @@ class Environment {
   Module<Callable> toModule(CssStylesheet css, ExtensionStore extensionStore) {
     assert(atRoot);
     return _EnvironmentModule(this, css, extensionStore,
-        forwarded: _forwardedModules?.keys.toSet());
+        forwarded: _forwardedModules.andThen((modules) => MapKeySet(modules)));
   }
 
   /// Returns a module with the same members and upstream modules as [this], but
@@ -830,7 +831,7 @@ class Environment {
         CssStylesheet(const [],
             SourceFile.decoded(const [], url: "<dummy module>").span(0)),
         ExtensionStore.empty,
-        forwarded: _forwardedModules?.keys.toSet());
+        forwarded: _forwardedModules.andThen((modules) => MapKeySet(modules)));
   }
 
   /// Returns the module with the given [namespace], or throws a


### PR DESCRIPTION
I haven't yet worked out a fix for the at-root issue, but this fix is actually necessary for the internal division migration.

This splits out `_globalModules` into two fields: one that contains `@use as *` global modules and one that contains modules that come from `@import`-ing a `@forward`. 

See https://github.com/sass/sass-spec/pull/1667.