### PR TITLE
Add quietDeps and verbose to the JS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
-## 1.34.2
+## 1.35.0
 
 * Fix a bug that could prevent some members from being found in certain files
   that use a mix of imports and the module system.
+
+### JS API
+
+* Add a `quietDeps` option which silences compiler warnings from stylesheets
+  loaded through importers and load paths.
+
+* Add a `verbose` option which causes the compiler to emit all deprecation
+  warnings, not just 5 per feature.
 
 ## 1.34.1
 

--- a/lib/src/async_import_cache.dart
+++ b/lib/src/async_import_cache.dart
@@ -102,8 +102,8 @@ class AsyncImportCache {
   /// canonicalize [url] (resolved relative to [baseUrl] if it's passed).
   ///
   /// If any importers understand [url], returns that importer as well as the
-  /// canonicalized URL and the original URL resolved relative to [baseUrl] if
-  /// applicable. Otherwise, returns `null`.
+  /// canonicalized URL and the original URL (resolved relative to [baseUrl] if
+  /// applicable). Otherwise, returns `null`.
   Future<Tuple3<AsyncImporter, Uri, Uri>?> canonicalize(Uri url,
       {AsyncImporter? baseImporter,
       Uri? baseUrl,

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_import_cache.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 6821c9a63333c3c99b0c9515aa04e73a14e0f141
+// Checksum: 27d8582c2ab318a52d433390ec256497b6af5dec
 //
 // ignore_for_file: unused_import
 
@@ -108,8 +108,8 @@ class ImportCache {
   /// canonicalize [url] (resolved relative to [baseUrl] if it's passed).
   ///
   /// If any importers understand [url], returns that importer as well as the
-  /// canonicalized URL and the original URL resolved relative to [baseUrl] if
-  /// applicable. Otherwise, returns `null`.
+  /// canonicalized URL and the original URL (resolved relative to [baseUrl] if
+  /// applicable). Otherwise, returns `null`.
   Tuple3<Importer, Uri, Uri>? canonicalize(Uri url,
       {Importer? baseImporter, Uri? baseUrl, bool forImport = false}) {
     if (baseImporter != null) {

--- a/lib/src/importer/node/interface.dart
+++ b/lib/src/importer/node/interface.dart
@@ -8,6 +8,10 @@ class NodeImporter {
   NodeImporter(Object options, Iterable<String> includePaths,
       Iterable<Object> importers);
 
+  Tuple2<String, String>? loadRelative(
+          String url, Uri? previous, bool forImport) =>
+      throw '';
+
   Tuple2<String, String>? load(String url, Uri? previous, bool forImport) =>
       throw '';
 

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -106,6 +106,8 @@ Future<RenderResult> _renderAsync(RenderOptions options) async {
         indentWidth: _parseIndentWidth(options.indentWidth),
         lineFeed: _parseLineFeed(options.linefeed),
         url: file == null ? 'stdin' : p.toUri(file).toString(),
+        quietDeps: options.quietDeps ?? false,
+        verbose: options.verbose ?? false,
         sourceMap: _enableSourceMaps(options));
   } else if (file != null) {
     result = await compileAsync(file,
@@ -116,6 +118,8 @@ Future<RenderResult> _renderAsync(RenderOptions options) async {
         useSpaces: options.indentType != 'tab',
         indentWidth: _parseIndentWidth(options.indentWidth),
         lineFeed: _parseLineFeed(options.linefeed),
+        quietDeps: options.quietDeps ?? false,
+        verbose: options.verbose ?? false,
         sourceMap: _enableSourceMaps(options));
   } else {
     throw ArgumentError("Either options.data or options.file must be set.");
@@ -147,6 +151,8 @@ RenderResult _renderSync(RenderOptions options) {
           indentWidth: _parseIndentWidth(options.indentWidth),
           lineFeed: _parseLineFeed(options.linefeed),
           url: file == null ? 'stdin' : p.toUri(file).toString(),
+          quietDeps: options.quietDeps ?? false,
+          verbose: options.verbose ?? false,
           sourceMap: _enableSourceMaps(options));
     } else if (file != null) {
       result = compile(file,
@@ -157,6 +163,8 @@ RenderResult _renderSync(RenderOptions options) {
           useSpaces: options.indentType != 'tab',
           indentWidth: _parseIndentWidth(options.indentWidth),
           lineFeed: _parseLineFeed(options.linefeed),
+          quietDeps: options.quietDeps ?? false,
+          verbose: options.verbose ?? false,
           sourceMap: _enableSourceMaps(options));
     } else {
       throw ArgumentError("Either options.data or options.file must be set.");

--- a/lib/src/node/render_options.dart
+++ b/lib/src/node/render_options.dart
@@ -26,6 +26,8 @@ class RenderOptions {
   external bool? get sourceMapContents;
   external bool? get sourceMapEmbed;
   external String? get sourceMapRoot;
+  external bool? get quietDeps;
+  external bool? get verbose;
 
   external factory RenderOptions(
       {String? file,
@@ -44,5 +46,7 @@ class RenderOptions {
       Object? sourceMap,
       bool? sourceMapContents,
       bool? sourceMapEmbed,
-      String? sourceMapRoot});
+      String? sourceMapRoot,
+      bool? quietDeps,
+      bool? verbose});
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.34.2-dev
+version: 1.35.0
 description: A Sass implementation in Dart.
 author: Sass Team
 homepage: https://github.com/sass/dart-sass


### PR DESCRIPTION
To support this, we now run Node-Sass-style relative loads outside of
the Node importer. This allows the evaluator to check whether a
relative load succeeded and use that to determine whether the
stylesheet counts as a dependency.

See sass/sass#3065
See sass/sass#3078