### PR TITLE
Add imported URIs getter to ImportCache

### DIFF
--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -46,6 +46,9 @@ class ImportCache {
   /// The import results for each canonicalized import URL.
   final Map<Uri, ImporterResult> _resultsCache;
 
+  /// All imported canonical URIs.
+  Set<Uri> get cachedUris => _importCache.keys.toSet();
+
   /// Creates an import cache that resolves imports using [importers].
   ///
   /// Imports are resolved by trying, in order:


### PR DESCRIPTION
Hi,

I was looking to implement a feature in dart-sass-embedded, to expose all imported URIs (see https://github.com/sass/embedded-protocol/issues/62).

However, to do this using the current api's, I'd have to first setup a `StylesheetGraph` including an `ImportCache`, then use the graph to load the to-be-compiled file, and then compile the file as normal. 
I think it would be easier, to expose a getter on the `ImportCache` class to expose all imported canonical URIs. 