### PR TITLE
Error for Unicode ranges that have too many `?`s after digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.35.2
 
+* **Potentially breaking bug fix**: Properly throw an error for Unicode ranges
+  that have too many `?`s after hexadecimal digits, such as `U+12345??`.
+
 * **Potentially breaking bug fix:** Fixed a bug where certain local variable
   declarations nested within multiple `@if` statements would incorrectly
   override a global variable. It's unlikely that any real stylesheets were

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -2491,27 +2491,38 @@ abstract class StylesheetParser extends Parser {
     expectIdentChar($u);
     scanner.expectChar($plus);
 
-    var i = 0;
-    for (; i < 6; i++) {
-      if (!scanCharIf((char) => char != null && isHex(char))) break;
+    var firstRangeLength = 0;
+    while (scanCharIf((char) => char != null && isHex(char))) {
+      firstRangeLength++;
     }
 
-    if (scanner.scanChar($question)) {
-      i++;
-      for (; i < 6; i++) {
-        if (!scanner.scanChar($question)) break;
-      }
+    var hasQuestionMark = false;
+    while (scanner.scanChar($question)) {
+      hasQuestionMark = true;
+      firstRangeLength++;
+    }
+
+    if (firstRangeLength == 0) {
+      scanner.error('Expected hex digit or "?".');
+    } else if (firstRangeLength > 6) {
+      error("Expected at most 6 digits.", scanner.spanFrom(start));
+    } else if (hasQuestionMark) {
       return StringExpression.plain(
           scanner.substring(start.position), scanner.spanFrom(start));
     }
-    if (i == 0) scanner.error('Expected hex digit or "?".');
 
     if (scanner.scanChar($minus)) {
-      var j = 0;
-      for (; j < 6; j++) {
-        if (!scanCharIf((char) => char != null && isHex(char))) break;
+      var secondRangeStart = scanner.state;
+      var secondRangeLength = 0;
+      while (scanCharIf((char) => char != null && isHex(char))) {
+        secondRangeLength++;
       }
-      if (j == 0) scanner.error("Expected hex digit.");
+
+      if (secondRangeLength == 0) {
+        scanner.error("Expected hex digit.");
+      } else if (secondRangeLength > 6) {
+        error("Expected at most 6 digits.", scanner.spanFrom(secondRangeStart));
+      }
     }
 
     if (_lookingAtInterpolatedIdentifierBody()) {


### PR DESCRIPTION
Closes #1280
See https://github.com/sass/sass-spec/pull/1670