### PR TITLE
Allow configuring a module that contains multiple configured `@forward`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 * Fix a race condition where `meta.load-css()` could trigger an internal error
   when running in asynchronous mode.
 
+* Allow configuring a module that contains multiple configured `@forward`s.
+
 ### Dart API
 
 * Use the `@internal` annotation to indicate which `Value` APIs are available

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -1344,7 +1344,9 @@ class _EvaluateVisitor
                     if (!variable.isGuarded) variable.name
                 });
 
-      _assertConfigurationIsEmpty(newConfiguration);
+      if (node == _stylesheet.forwards.last) {
+        _assertConfigurationIsEmpty(newConfiguration);
+      }
     } else {
       _configuration = adjustedConfiguration;
       await _loadModule(node.url, "@forward", node, (module) {

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: b2321a00031707d2df699e6888a334deba39995d
+// Checksum: 5996d128b7335be89e76401299ddd9ecfc2217cf
 //
 // ignore_for_file: unused_import
 
@@ -1345,7 +1345,9 @@ class _EvaluateVisitor
                     if (!variable.isGuarded) variable.name
                 });
 
-      _assertConfigurationIsEmpty(newConfiguration);
+      if (node == _stylesheet.forwards.last) {
+        _assertConfigurationIsEmpty(newConfiguration);
+      }
     } else {
       _configuration = adjustedConfiguration;
       _loadModule(node.url, "@forward", node, (module) {


### PR DESCRIPTION
Defers the check for valid `@use with` configs until all configured `@forward` rules have been evaluated.

Fixes https://github.com/sass/dart-sass/issues/1343

See https://github.com/sass/sass-spec/pull/1675