### PR TITLE
Fix bug in RecursiveAstVisitor

### DIFF
--- a/lib/src/visitor/recursive_ast.dart
+++ b/lib/src/visitor/recursive_ast.dart
@@ -58,7 +58,9 @@ abstract class RecursiveAstVisitor extends RecursiveStatementVisitor
 
   void visitNumberExpression(NumberExpression node) {}
 
-  void visitParenthesizedExpression(ParenthesizedExpression node) {}
+  void visitParenthesizedExpression(ParenthesizedExpression node) {
+    node.expression.accept(this);
+  }
 
   void visitSelectorExpression(SelectorExpression node) {}
 


### PR DESCRIPTION
It looks like the body of `visitParenthesizedExpression` was accidentally removed when the type parameter was removed from this class.

This will fix sass/migrator#202 once it's merged and we cut a new migrator release.