### PR TITLE
Fix publishing errors for sass_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.37.2
+
+* No user-visible changes.
+
 ## 1.37.1
 
 * No user-visible changes.

--- a/pkg/sass_api/LICENSE
+++ b/pkg/sass_api/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2021, Google Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -4,14 +4,13 @@ name: sass_api
 # visitor interface(s).
 version: 1.0.0-beta.1
 description: Additional APIs for Dart Sass.
-author: Sass Team
 homepage: https://github.com/sass/dart-sass
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  sass: 1.37.1
+  sass: 1.37.2
 
 dependency_overrides:
   sass: {path: ../..}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: sass
-version: 1.37.1
+version: 1.37.2
 description: A Sass implementation in Dart.
-author: Sass Team
 homepage: https://github.com/sass/dart-sass
 
 executables:


### PR DESCRIPTION
This needs a LICENSE of its own and it can't have dependency_overrides
when publishing.