### PR TITLE
Fix a crash in the Node importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.37.6
+
+* Don't crash when a Windows path is returned by a custom Node importer at the
+  same time as file contents.
+
 ## 1.37.5
 
 * No user-visible changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.37.6
 
+### JS API
+
 * Don't crash when a Windows path is returned by a custom Node importer at the
   same time as file contents.
 

--- a/lib/src/importer/node/implementation.dart
+++ b/lib/src/importer/node/implementation.dart
@@ -186,7 +186,7 @@ class NodeImporter {
     if (file == null) {
       return Tuple2(contents ?? '', url);
     } else if (contents != null) {
-      return Tuple2(contents, file);
+      return Tuple2(contents, p.toUri(file).toString());
     } else {
       var resolved =
           loadRelative(p.toUri(file).toString(), previous, forImport) ??

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.3
+
+* No user-visible changes.
+
 ## 1.0.0-beta.2
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-beta.2
+version: 1.0.0-dev
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  sass: 1.37.5
+  sass: 1.37.6
 
 dependency_overrides:
   sass: {path: ../..}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.37.5
+version: 1.37.6-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/test/double_check_test.dart
+++ b/test/double_check_test.dart
@@ -50,13 +50,18 @@ void main() {
             .convert(File("$package/CHANGELOG.md").readAsStringSync())
             .first;
         expect(firstLine, startsWith("## "));
-        var changelogVersion = firstLine.substring(3);
+        var changelogVersion = Version.parse(firstLine.substring(3));
 
         var pubspec = Pubspec.parse(
             File("$package/pubspec.yaml").readAsStringSync(),
             sourceUrl: p.toUri("$package/pubspec.yaml"));
-        expect(pubspec.version!.toString(),
-            anyOf(equals(changelogVersion), equals("$changelogVersion-dev")));
+        expect(
+            pubspec.version!.toString(),
+            anyOf(
+                equals(changelogVersion.toString()),
+                changelogVersion.isPreRelease
+                    ? equals("${changelogVersion.nextPatch}-dev")
+                    : equals("$changelogVersion-dev")));
       });
     });
   }

--- a/test/node_api/importer_test.dart
+++ b/test/node_api/importer_test.dart
@@ -141,6 +141,16 @@ void main() {
           }))));
       expect(result.stats.includedFiles, equals(['bar']));
     });
+
+    // Regression test for sass/dart-sass#1410.
+    test("passes through an absolute file path", () {
+      var result = sass.renderSync(RenderOptions(
+          data: "@import 'foo'",
+          importer: allowInterop(expectAsync2((void _, void __) {
+            return NodeImporterResult(contents: '', file: p.absolute('bar'));
+          }))));
+      expect(result.stats.includedFiles, equals([p.absolute('bar')]));
+    });
   });
 
   group("with a file redirect", () {


### PR DESCRIPTION
When a path was returned at the same time as a file's contents, it was
interpreted as a URL without first being translated to one. This
crashed for absolute Windows paths.

Closes #1410