### PR TITLE
Add a SassArgumentList.keywordsWithoutMarking getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
-## 1.37.6
+## 1.38.0
 
 ### JS API
 
 * Don't crash when a Windows path is returned by a custom Node importer at the
   same time as file contents.
+
+### Dart API
+
+* Add a `SassArgumentList.keywordsWithoutMarking` getter to access the keyword
+  arguments of an argument list without marking them accessed.
 
 ## 1.37.5
 

--- a/lib/src/value/argument_list.dart
+++ b/lib/src/value/argument_list.dart
@@ -25,6 +25,13 @@ class SassArgumentList extends SassList {
 
   final Map<String, Value> _keywords;
 
+  /// Returns the same value as [keywords], but doesn't mark them accessed.
+  ///
+  /// Normally, any time [keywords] is accessed it's marked as such, which
+  /// indicates that the caller was allowed to pass keywords to a rest argument.
+  /// This avoids this marking.
+  Map<String, Value> get keywordsWithoutMarking => _keywords;
+
   /// Whether [keywords] has been accessed.
   ///
   /// This is used to determine whether to throw an exception about passing

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  sass: 1.37.6
+  sass: 1.38.0
 
 dependency_overrides:
   sass: {path: ../..}

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-dev
+version: 1.0.0-beta.3
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.37.6-dev
+version: 1.38.0-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.38.0-dev
+version: 1.38.0
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This is necessary to properly forward argument list keywords to the 
embedded compiler.

See sass/embedded-protocol#27