### PR TITLE
Allow `if` to be used as an unquoted string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.37.6
 
+* Allow `if` to be used as an unquoted string.
+
 ### JS API
 
 * Don't crash when a Windows path is returned by a custom Node importer at the

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -2612,7 +2612,7 @@ abstract class StylesheetParser extends Parser {
     var identifier = interpolatedIdentifier();
     var plain = identifier.asPlain;
     if (plain != null) {
-      if (plain == "if") {
+      if (plain == "if" && scanner.peekChar() == $lparen) {
         var invocation = _argumentInvocation();
         return IfExpression(
             invocation, identifier.span.expand(invocation.span));


### PR DESCRIPTION
Closes #1405
See sass/sass-spec#1684