### PR TITLE
Allow numbers with leading `.` in plain-CSS min/max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.37.6
 
+* Properly consider numbers that begin with `.` as "plain CSS" for the purposes
+  of parsing plain-CSS `min()` and `max()` functions.
+
 ### JS API
 
 * Don't crash when a Windows path is returned by a custom Node importer at the

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -2780,6 +2780,7 @@ abstract class StylesheetParser extends Parser {
         case $7:
         case $8:
         case $9:
+        case $dot:
           try {
             buffer.write(rawText(_number));
           } on FormatException catch (_) {


### PR DESCRIPTION
Closes #1394
See sass/sass-spec#1685