### PR TITLE
Don't try to force custom URL schemes to file paths in the Node API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Don't crash when a Windows path is returned by a custom Node importer at the
   same time as file contents.
 
+* Don't crash when an error occurs in a stylesheet loaded via a custom importer
+  with a custom URL scheme.
+
 ## 1.37.5
 
 * No user-visible changes.

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -183,10 +183,20 @@ RenderResult _renderSync(RenderOptions options) {
 /// Converts an exception to a [JsError].
 JsError _wrapException(Object exception) {
   if (exception is SassException) {
+    String file;
+    var url = exception.span.sourceUrl;
+    if (url == null) {
+      file = 'stdin';
+  } else if (url.scheme == 'file') {
+    file = p.fromUri(url);
+  } else {
+    file = url.toString();
+  }
+
     return _newRenderError(exception.toString().replaceFirst("Error: ", ""),
         line: exception.span.start.line + 1,
         column: exception.span.start.column + 1,
-        file: exception.span.sourceUrl.andThen(p.fromUri) ?? 'stdin',
+        file: file,
         status: 1);
   } else {
     return JsError(exception.toString());

--- a/test/node_api/importer_test.dart
+++ b/test/node_api/importer_test.dart
@@ -704,6 +704,24 @@ void main() {
               "  ╵\n"
               "  stdin 1:9  root stylesheet"));
     });
+
+    test("it occurs in a file with a custom URL scheme", () {
+      var error =
+          renderSyncError(RenderOptions(
+              data: "@import 'foo:bar'",
+              importer: allowInterop(expectAsync2((String _, void __) {
+                  return NodeImporterResult(contents: '@error "oh no";');
+          }))));
+
+          expect(error,
+          toStringAndMessageEqual("\"oh no\"\n"
+              "  ╷\n"
+              "1 │ @error \"oh no\";\n"
+              "  │ ^^^^^^^^^^^^^^\n"
+              "  ╵\n"
+              "  foo:bar 1:1  @import\n"
+              "  stdin 1:9    root stylesheet"));
+    });
   });
 
   group("render()", () {


### PR DESCRIPTION
When an error occurred in a stylesheet loaded by a custom importer
with a custom URL scheme, the Node error wrapper tried to convert that
URL into a path and ended up crashing.

Closes #1138