### PR TITLE
Expose getters indicating which color fields a color has calculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.38.2
+
+* No user-visible changes
+
 ## 1.38.1
 
 * No user-visible changes

--- a/lib/sass.dart
+++ b/lib/sass.dart
@@ -26,7 +26,7 @@ export 'src/exception.dart' show SassException;
 export 'src/importer.dart';
 export 'src/logger.dart';
 export 'src/syntax.dart';
-export 'src/value.dart';
+export 'src/value.dart' hide SassApiColor;
 export 'src/visitor/serialize.dart' show OutputStyle;
 export 'src/warn.dart' show warn;
 

--- a/lib/src/value/color.dart
+++ b/lib/src/value/color.dart
@@ -305,3 +305,25 @@ class SassColor extends Value {
     return buffer.toString();
   }
 }
+
+/// Extension methods that are only visible through the `sass_api` package.
+///
+/// These methods are considered less general-purpose and more liable to change
+/// than the main [SassColor] interface.
+extension SassApiColor on SassColor {
+  /// Whether the [red], [green], and [blue] fields have already been computed
+  /// for this value.
+  ///
+  /// Note that these fields can always be safely computed after the fact; this
+  /// just allows users such as the Sass embedded compiler to access whichever
+  /// representation is readily available.
+  bool get hasCalculatedRgb => _red != null;
+
+  /// Whether the [hue], [saturation], and [lightness] fields have already been
+  /// computed for this value.
+  ///
+  /// Note that these fields can always be safely computed after the fact; this
+  /// just allows users such as the Sass embedded compiler to access whichever
+  /// representation is readily available.
+  bool get hasCalculatedHsl => _saturation != null;
+}

--- a/lib/src/value/color.dart
+++ b/lib/src/value/color.dart
@@ -311,16 +311,16 @@ class SassColor extends Value {
 /// These methods are considered less general-purpose and more liable to change
 /// than the main [SassColor] interface.
 extension SassApiColor on SassColor {
-  /// Whether the [SassColor.red], [SassColor.green], and [SassColor.blue]
-  /// fields have already been computed for this value.
+  /// Whether the `red`, `green`, and `blue` fields have already been computed
+  /// for this value.
   ///
   /// Note that these fields can always be safely computed after the fact; this
   /// just allows users such as the Sass embedded compiler to access whichever
   /// representation is readily available.
   bool get hasCalculatedRgb => _red != null;
 
-  /// Whether the [SassColor.hue], [SassColor.saturation], and
-  /// [SassColor.lightness] fields have already been computed for this value.
+  /// Whether the `hue`, `saturation`, and `lightness` fields have already been
+  /// computed for this value.
   ///
   /// Note that these fields can always be safely computed after the fact; this
   /// just allows users such as the Sass embedded compiler to access whichever

--- a/lib/src/value/color.dart
+++ b/lib/src/value/color.dart
@@ -311,16 +311,16 @@ class SassColor extends Value {
 /// These methods are considered less general-purpose and more liable to change
 /// than the main [SassColor] interface.
 extension SassApiColor on SassColor {
-  /// Whether the [red], [green], and [blue] fields have already been computed
-  /// for this value.
+  /// Whether the [SassColor.red], [SassColor.green], and [SassColor.blue]
+  /// fields have already been computed for this value.
   ///
   /// Note that these fields can always be safely computed after the fact; this
   /// just allows users such as the Sass embedded compiler to access whichever
   /// representation is readily available.
   bool get hasCalculatedRgb => _red != null;
 
-  /// Whether the [hue], [saturation], and [lightness] fields have already been
-  /// computed for this value.
+  /// Whether the [SassColor.hue], [SassColor.saturation], and
+  /// [SassColor.lightness] fields have already been computed for this value.
   ///
   /// Note that these fields can always be safely computed after the fact; this
   /// just allows users such as the Sass embedded compiler to access whichever

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.5
+
+* Add `SassColor.hasCalculatedRgb` and `.hasCalculatedHsl` extension getters.
+
 ## 1.0.0-beta.4
 
 * `UseRule`, `ForwardRule`, and `DynamicImport` now share a common `Dependency`

--- a/pkg/sass_api/lib/sass_api.dart
+++ b/pkg/sass_api/lib/sass_api.dart
@@ -14,6 +14,7 @@ export 'package:sass/src/ast/sass.dart' hide AtRootQuery;
 export 'package:sass/src/async_import_cache.dart';
 export 'package:sass/src/exception.dart' show SassFormatException;
 export 'package:sass/src/import_cache.dart';
+export 'package:sass/src/value/color.dart';
 export 'package:sass/src/visitor/find_dependencies.dart';
 export 'package:sass/src/visitor/interface/expression.dart';
 export 'package:sass/src/visitor/interface/statement.dart';

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-beta.4
+version: 1.0.0-beta.5
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  sass: 1.38.1
+  sass: 1.38.2
 
 dependency_overrides:
   sass: {path: ../..}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.38.1
+version: 1.38.2
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
These getters are only available through the sass_api package. This
will allow the Sass embedded compiler to more explicitly send the
color information it has on hand.