### PR TITLE
Upgrade to analyzer 2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   http: ^0.13.3
 
 dev_dependencies:
-  analyzer: ^1.1.0
+  analyzer: ^2.2.0
   archive: ^3.1.2
   cli_pkg: ^1.3.0
   crypto: ^3.0.0


### PR DESCRIPTION
This package is reported by `pub outdated`.

However, I'm not sure whether this package is actually useful. AFAICT, it is not used anywhere as the CI is using the `dart analyze` CLI instead of running the analyzer manually.