### PR TITLE
Fix the leftover-configuration check for `@forward ... with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.39.2
+
+* Fix a bug where configuring with `@use ... with` would throw an error when
+  that variable was defined in a module that also contained `@forward ... with`.
+
 ## 1.39.1
 
 * Partial fix for a bug where `@at-root` does not work properly in nested

--- a/lib/src/configured_value.dart
+++ b/lib/src/configured_value.dart
@@ -28,4 +28,6 @@ class ConfiguredValue {
   /// variable prior to an `@import` of a file that contains a `@forward`.
   ConfiguredValue.implicit(this.value, this.assignmentNode)
       : configurationSpan = null;
+
+  String toString() => value.toString();
 }

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -1326,12 +1326,21 @@ class _EvaluateVisitor
       }, configuration: newConfiguration);
 
       _removeUsedConfiguration(adjustedConfiguration, newConfiguration,
-          except: node.configuration.isEmpty
-              ? const {}
-              : {
-                  for (var variable in node.configuration)
-                    if (!variable.isGuarded) variable.name
-                });
+          except: {
+            for (var variable in node.configuration)
+              if (!variable.isGuarded) variable.name
+          });
+
+      // Remove all the variables that weren't configured by this particular
+      // `@forward` before checking that the configuration is empty. Errors for
+      // outer `with` clauses will be thrown once those clauses finish
+      // executing.
+      var configuredVariables = {
+        for (var variable in node.configuration) variable.name
+      };
+      for (var name in newConfiguration.values.keys.toList()) {
+        if (!configuredVariables.contains(name)) newConfiguration.remove(name);
+      }
 
       _assertConfigurationIsEmpty(newConfiguration);
     } else {

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 99e7cdfc43a20e2c0827753081db6dcbd914ec75
+// Checksum: b73635829d711b9344e10836e865afe70ca55e77
 //
 // ignore_for_file: unused_import
 
@@ -1327,12 +1327,21 @@ class _EvaluateVisitor
       }, configuration: newConfiguration);
 
       _removeUsedConfiguration(adjustedConfiguration, newConfiguration,
-          except: node.configuration.isEmpty
-              ? const {}
-              : {
-                  for (var variable in node.configuration)
-                    if (!variable.isGuarded) variable.name
-                });
+          except: {
+            for (var variable in node.configuration)
+              if (!variable.isGuarded) variable.name
+          });
+
+      // Remove all the variables that weren't configured by this particular
+      // `@forward` before checking that the configuration is empty. Errors for
+      // outer `with` clauses will be thrown once those clauses finish
+      // executing.
+      var configuredVariables = {
+        for (var variable in node.configuration) variable.name
+      };
+      for (var name in newConfiguration.values.keys.toList()) {
+        if (!configuredVariables.contains(name)) newConfiguration.remove(name);
+      }
 
       _assertConfigurationIsEmpty(newConfiguration);
     } else {

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.8
+
+* No user-visible changes.
+
 ## 1.0.0-beta.7
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-beta.7
+version: 1.0.0-beta.8
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  sass: 1.39.1
+  sass: 1.39.2
 
 dependency_overrides:
   sass: {path: ../..}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.39.1
+version: 1.39.2
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This check was previously checking whether *any* variables were left
in this configuration, which could include variables that were adopted
from outer configurations. This threw invalid errors when that outer
configuration would have been satisfied by another variable (or
forward) later in the file.

Closes sass/sass#1460
See sass/sass-spec#1701