### PR TITLE
Allow extra whitespace in min, max, and calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   to be within the current shadow DOM. The `@extend` logic has been updated
   accordingly as well.
 
+* Fix a bug where extra whitespace in `min()`, `max()`, `clamp()`, and `calc()`
+  expressions could cause bogus parse errors.
+
 ## 1.40.1
 
 * **Potentially breaking bug fix:** `min()` and `max()` expressions outside of

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -2802,6 +2802,8 @@ abstract class StylesheetParser extends Parser {
   /// productions separated by commas.
   bool _tryMinMaxContents(InterpolationBuffer buffer,
       {bool allowComma = true}) {
+    whitespace();
+
     // The number of open parentheses that need to be closed.
     while (true) {
       var next = scanner.peekChar();
@@ -3013,7 +3015,13 @@ abstract class StylesheetParser extends Parser {
     } else if (next == $lparen) {
       var start = scanner.state;
       scanner.readChar();
-      var value = _tryCalculationInterpolation() ?? _calculationSum();
+
+      Expression? value = _tryCalculationInterpolation();
+      if (value == null) {
+        whitespace();
+        value = _calculationSum();
+      }
+
       whitespace();
       scanner.expectChar($rparen);
       return ParenthesizedExpression(value, scanner.spanFrom(start));


### PR DESCRIPTION
Closes sass/dart-sass#1444
See sass/sass-spec#1707