### PR TITLE
Only run GitHub Actions for tags that look like semver versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
 on:
   push:
     branches: [main, feature.*]
-    tags: ['**']
+    tags: ['[0-9]+.[0-9]+.*']
   pull_request:
 
 jobs:


### PR DESCRIPTION
We had previously been running for sass_api tags, which inevitably
failed when they didn't match the pubspec version.