### PR TITLE
Only run framework checks when deploying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,68 +194,6 @@ jobs:
           --errors ambiguous-doc-reference,broken-link,deprecated
           --errors unknown-directive,unknown-macro,unresolved-doc-reference
 
-  bootstrap:
-    name: "Bootstrap ${{ matrix.bootstrap_version }}"
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        bootstrap_version: [4, 5]
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
-      - run: dart pub get
-      - run: dart pub run grinder fetch-bootstrap${{matrix.bootstrap_version}}
-        env: {GITHUB_BEARER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"}
-      - name: Build
-        run: dart bin/sass.dart --quiet build/bootstrap/scss:build/bootstrap-output
-
-  bourbon:
-    name: Bourbon
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
-      - run: dart pub get
-      - run: dart pub run grinder fetch-bourbon
-        env: {GITHUB_BEARER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"}
-      - name: Test
-        run: |
-          dart bin/sass.dart --quiet -I build/bourbon -I build/bourbon/spec/fixtures \
-              build/bourbon/spec/fixtures:build/bourbon-output
-
-  foundation:
-    name: Foundation
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
-      - run: dart pub get
-      - run: dart pub run grinder fetch-foundation
-        env: {GITHUB_BEARER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"}
-      # TODO(nweiz): Foundation has proper Sass tests, but they're currently not
-      # compatible with Dart Sass. Once they are, we should run those rather
-      # than just building the CSS output.
-      - name: Build
-        run: dart bin/sass.dart --quiet build/foundation-sites/assets:build/foundation-output
-
-  bulma:
-    name: Bulma
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
-      - run: dart pub get
-      - run: dart pub run grinder fetch-bulma
-        env: {GITHUB_BEARER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"}
-      - name: Build
-        run: dart bin/sass.dart --quiet build/bulma/bulma.sass build/bulma-output.css
-
   double_check:
     name: Double-check
     runs-on: ubuntu-latest
@@ -275,10 +213,76 @@ jobs:
       - name: Run checks
         run: dart pub run grinder sanity-check-before-release
 
+  bootstrap:
+    name: "Bootstrap ${{ matrix.bootstrap_version }}"
+    runs-on: ubuntu-latest
+    needs: [double_check]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        bootstrap_version: [4, 5]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+      - run: dart pub get
+      - run: dart pub run grinder fetch-bootstrap${{matrix.bootstrap_version}}
+        env: {GITHUB_BEARER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"}
+      - name: Build
+        run: dart bin/sass.dart --quiet build/bootstrap/scss:build/bootstrap-output
+
+  bourbon:
+    name: Bourbon
+    runs-on: ubuntu-latest
+    needs: [double_check]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+      - run: dart pub get
+      - run: dart pub run grinder fetch-bourbon
+        env: {GITHUB_BEARER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"}
+      - name: Test
+        run: |
+          dart bin/sass.dart --quiet -I build/bourbon -I build/bourbon/spec/fixtures \
+              build/bourbon/spec/fixtures:build/bourbon-output
+
+  foundation:
+    name: Foundation
+    runs-on: ubuntu-latest
+    needs: [double_check]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+      - run: dart pub get
+      - run: dart pub run grinder fetch-foundation
+        env: {GITHUB_BEARER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"}
+      # TODO(nweiz): Foundation has proper Sass tests, but they're currently not
+      # compatible with Dart Sass. Once they are, we should run those rather
+      # than just building the CSS output.
+      - name: Build
+        run: dart bin/sass.dart --quiet build/foundation-sites/assets:build/foundation-output
+
+  bulma:
+    name: Bulma
+    runs-on: ubuntu-latest
+    needs: [double_check]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+      - run: dart pub get
+      - run: dart pub run grinder fetch-bulma
+        env: {GITHUB_BEARER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"}
+      - name: Build
+        run: dart bin/sass.dart --quiet build/bulma/bulma.sass build/bulma-output.css
+
   deploy_github_linux:
     name: "Deploy Github: Linux"
     runs-on: ubuntu-latest
-    needs: [double_check]
+    needs: [bootstrap, bourbon, foundation, bulma]
     if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/dart-sass'"
 
     steps:
@@ -326,7 +330,7 @@ jobs:
   deploy_npm:
     name: Deploy npm
     runs-on: ubuntu-latest
-    needs: [double_check]
+    needs: [bootstrap, bourbon, foundation, bulma]
     if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/dart-sass'"
 
     steps:
@@ -361,7 +365,7 @@ jobs:
   deploy_pub:
     name: "Deploy Pub"
     runs-on: ubuntu-latest
-    needs: [double_check]
+    needs: [bootstrap, bourbon, foundation, bulma]
     if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/dart-sass'"
 
     steps:
@@ -394,7 +398,7 @@ jobs:
   deploy_homebrew:
     name: "Deploy Homebrew"
     runs-on: ubuntu-latest
-    needs: [double_check]
+    needs: [bootstrap, bourbon, foundation, bulma]
     if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/dart-sass'"
 
     steps:
@@ -410,7 +414,7 @@ jobs:
   deploy_chocolatey:
     name: "Deploy Chocolatey"
     runs-on: windows-latest
-    needs: [double_check]
+    needs: [bootstrap, bourbon, foundation, bulma]
     if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/dart-sass'"
 
     steps:
@@ -424,7 +428,7 @@ jobs:
   deploy_website:
     name: "Deploy sass-lang.com"
     runs-on: ubuntu-latest
-    needs: [double_check]
+    needs: [bootstrap, bourbon, foundation, bulma]
     if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/dart-sass'"
 
     steps:


### PR DESCRIPTION
We expect these checks to succeed almost all the time, and we really
only need them as a backstop to ensure we don't deploy a change that
breaks real-world users.