### PR TITLE
Fix the parsing of scientific notation in keyframe selectors

### DIFF
--- a/lib/src/parse/keyframe_selector.dart
+++ b/lib/src/parse/keyframe_selector.dart
@@ -57,10 +57,10 @@ class KeyframeSelectorParser extends Parser {
       }
     }
 
-    if (scanIdentifier("e")) {
-      buffer.write(scanner.readChar());
+    if (scanIdentChar($e)) {
+      buffer.writeCharCode($e);
       var next = scanner.peekChar();
-      if (next == $plus || next == $minus) buffer.write(scanner.readChar());
+      if (next == $plus || next == $minus) buffer.writeCharCode(scanner.readChar());
       if (!isDigit(scanner.peekChar())) scanner.error("Expected digit.");
 
       while (isDigit(scanner.peekChar())) {


### PR DESCRIPTION
Closes #1509

https://github.com/sass/sass-spec/pull/1720