### PR TITLE
Release 1.43.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.43.1
+
+* No user-visible changes.
+
 ## 1.43.0
 
 ### JS API

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.15
+
+* No user-visible changes.
+
 ## 1.0.0-beta.14
 
 * Fix a bug where `RecursiveAstVisitor.visitAtRootRule` wouldn't visit any nodes

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-beta.14
+version: 1.0.0-beta.15
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  sass: 1.43.0
+  sass: 1.43.1
 
 dependency_overrides:
   sass: {path: ../..}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.43.0
+version: 1.43.1
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This brings in google/dart_cli_pkg#92 to fix releasing on npm.