### PR TITLE
Fix RecursiveAstVisitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.43.1
+
+* No user-visible changes.
+
 ## 1.43.0
 
 ### JS API
@@ -111,7 +115,7 @@
 
 * Partial fix for a bug where `@at-root` does not work properly in nested
   imports that contain `@use` rules. If the only `@use` rules in the nested
-  import are for built-in modules, `@at-root` should now work properly. 
+  import are for built-in modules, `@at-root` should now work properly.
 
 ## 1.39.0
 

--- a/lib/src/visitor/recursive_ast.dart
+++ b/lib/src/visitor/recursive_ast.dart
@@ -35,6 +35,12 @@ abstract class RecursiveAstVisitor extends RecursiveStatementVisitor
     super.visitAtRule(node);
   }
 
+  void visitCalculationExpression(CalculationExpression node) {
+    for (var argument in node.arguments) {
+      argument.accept(this);
+    }
+  }
+
   void visitContentRule(ContentRule node) {
     visitArgumentInvocation(node.arguments);
   }

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-beta.15
+
+* Fix an issue where `RecursiveAstVisitor` was not implementing
+  `visitCalculationExpression`.
+
 ## 1.0.0-beta.14
 
 * Fix a bug where `RecursiveAstVisitor.visitAtRootRule` wouldn't visit any nodes

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-beta.14
+version: 1.0.0-beta.15
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  sass: 1.43.0
+  sass: 1.43.1
 
 dependency_overrides:
   sass: {path: ../..}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.43.0
+version: 1.43.1
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/test/dart_api/visitor_test.dart
+++ b/test/dart_api/visitor_test.dart
@@ -1,0 +1,14 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:sass/src/visitor/recursive_ast.dart';
+import 'package:sass/src/visitor/recursive_statement.dart';
+
+/// Test that `RecursiveAstVisitor` is not missing any implementations.
+class TestAstVisitor extends RecursiveAstVisitor {}
+
+/// Test that `RecursiveStatementVisitor` is not missing any implementations.
+class TestStatementVisitor extends RecursiveStatementVisitor {}
+
+void main() {}


### PR DESCRIPTION
`visitCalculationExpression` is now properly implemented.

This also adds concrete test classes that extend `RecursiveAstVisitor`
and `RecursiveStatementVisitor` to ensure similar issues are avoided in
the future whenever new AST nodes are added.