### PR TITLE
Track stack traces through rethrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.43.5
+
+### JS API
+
+* Print more detailed JS stack traces. This is mostly useful for the Sass team's
+  own debugging purposes.
+
 ## 1.43.4
 
 ### JS API

--- a/bin/sass.dart
+++ b/bin/sass.dart
@@ -16,6 +16,7 @@ import 'package:sass/src/executable/watch.dart';
 import 'package:sass/src/import_cache.dart';
 import 'package:sass/src/io.dart';
 import 'package:sass/src/stylesheet_graph.dart';
+import 'package:sass/src/utils.dart';
 
 Future<void> main(List<String> args) async {
   var printedError = false;
@@ -79,7 +80,7 @@ Future<void> main(List<String> args) async {
         }();
 
         printError(error.toString(color: options.color),
-            options.trace ? stackTrace : null);
+            options.trace ? getTrace(error) ?? stackTrace : null);
 
         // Exit code 65 indicates invalid data per
         // http://www.freebsd.org/cgi/man.cgi?query=sysexits.
@@ -93,7 +94,7 @@ Future<void> main(List<String> args) async {
             path == null
                 ? error.message
                 : "Error reading ${p.relative(path)}: ${error.message}.",
-            options.trace ? stackTrace : null);
+            options.trace ? getTrace(error) ?? stackTrace : null);
 
         // Error 66 indicates no input.
         exitCode = 66;
@@ -114,7 +115,7 @@ Future<void> main(List<String> args) async {
     buffer.writeln();
     buffer.writeln(error);
 
-    printError(buffer.toString(), stackTrace);
+    printError(buffer.toString(), getTrace(error) ?? stackTrace);
     exitCode = 255;
   }
 }

--- a/lib/src/executable/repl.dart
+++ b/lib/src/executable/repl.dart
@@ -14,6 +14,7 @@ import '../import_cache.dart';
 import '../importer/filesystem.dart';
 import '../logger/tracking.dart';
 import '../parse/parser.dart';
+import '../utils.dart';
 import '../visitor/evaluate.dart';
 
 /// Runs an interactive SassScript shell according to [options].
@@ -42,7 +43,8 @@ Future<void> repl(ExecutableOptions options) async {
         print(evaluator.evaluate(Expression.parse(line, logger: logger)));
       }
     } on SassException catch (error, stackTrace) {
-      _logError(error, stackTrace, line, repl, options, logger);
+      _logError(
+          error, getTrace(error) ?? stackTrace, line, repl, options, logger);
     }
   }
 }

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -14,6 +14,7 @@ import '../importer/filesystem.dart';
 import '../io.dart';
 import '../stylesheet_graph.dart';
 import '../util/multi_dir_watcher.dart';
+import '../utils.dart';
 import 'compile_stylesheet.dart';
 import 'options.dart';
 
@@ -78,7 +79,8 @@ class _Watcher {
       return true;
     } on SassException catch (error, stackTrace) {
       if (!_options.emitErrorCss) _delete(destination);
-      _printError(error.toString(color: _options.color), stackTrace);
+      _printError(
+          error.toString(color: _options.color), getTrace(error) ?? stackTrace);
       exitCode = 65;
       return false;
     } on FileSystemException catch (error, stackTrace) {
@@ -87,7 +89,7 @@ class _Watcher {
           path == null
               ? error.message
               : "Error reading ${p.relative(path)}: ${error.message}.",
-          stackTrace);
+          getTrace(error) ?? stackTrace);
       exitCode = 66;
       return false;
     }

--- a/lib/src/extend/extension_store.dart
+++ b/lib/src/extend/extension_store.dart
@@ -187,11 +187,13 @@ class ExtensionStore {
       try {
         selector = _extendList(
             originalSelector, selectorSpan, _extensions, mediaContext);
-      } on SassException catch (error) {
-        throw SassException(
-            "From ${error.span.message('')}\n"
-            "${error.message}",
-            error.span);
+      } on SassException catch (error, stackTrace) {
+        throwWithTrace(
+            SassException(
+                "From ${error.span.message('')}\n"
+                "${error.message}",
+                error.span),
+            stackTrace);
       }
     }
 
@@ -330,11 +332,13 @@ class ExtensionStore {
         selectors = _extendComplex(extension.extender.selector,
             extension.extender.span, newExtensions, extension.mediaContext);
         if (selectors == null) continue;
-      } on SassException catch (error) {
-        throw SassException(
-            "From ${extension.extender.span.message('')}\n"
-            "${error.message}",
-            error.span);
+      } on SassException catch (error, stackTrace) {
+        throwWithTrace(
+            SassException(
+                "From ${extension.extender.span.message('')}\n"
+                "${error.message}",
+                error.span),
+            stackTrace);
       }
 
       var containsExtension = selectors.first == extension.extender.selector;
@@ -391,12 +395,14 @@ class ExtensionStore {
       try {
         selector.value = _extendList(selector.value, selector.span,
             newExtensions, _mediaContexts[selector]);
-      } on SassException catch (error) {
+      } on SassException catch (error, stackTrace) {
         // TODO(nweiz): Make this a MultiSpanSassException.
-        throw SassException(
-            "From ${selector.span.message('')}\n"
-            "${error.message}",
-            error.span);
+        throwWithTrace(
+            SassException(
+                "From ${selector.span.message('')}\n"
+                "${error.message}",
+                error.span),
+            stackTrace);
       }
 
       // If no extends actually happened (for example because unification

--- a/lib/src/io/vm.dart
+++ b/lib/src/io/vm.dart
@@ -12,6 +12,7 @@ import 'package:source_span/source_span.dart';
 import 'package:watcher/watcher.dart';
 
 import '../exception.dart';
+import '../utils.dart';
 
 export 'dart:io' show exitCode, FileSystemException;
 
@@ -41,7 +42,7 @@ String readFile(String path) {
 
   try {
     return utf8.decode(bytes);
-  } on FormatException catch (error) {
+  } on FormatException catch (error, stackTrace) {
     var decodedUntilError =
         utf8.decode(bytes.sublist(0, error.offset), allowMalformed: true);
     var stringOffset = decodedUntilError.length;
@@ -49,8 +50,10 @@ String readFile(String path) {
 
     var decoded = utf8.decode(bytes, allowMalformed: true);
     var sourceFile = SourceFile.fromString(decoded, url: p.toUri(path));
-    throw SassException(
-        "Invalid UTF-8.", sourceFile.location(stringOffset).pointSpan());
+    throwWithTrace(
+        SassException(
+            "Invalid UTF-8.", sourceFile.location(stringOffset).pointSpan()),
+        stackTrace);
   }
 }
 

--- a/lib/src/node/compile.dart
+++ b/lib/src/node/compile.dart
@@ -4,7 +4,7 @@
 
 import 'package:js/js.dart';
 import 'package:node_interop/js.dart';
-import 'package:node_interop/util.dart';
+import 'package:node_interop/util.dart' hide futureToPromise;
 import 'package:term_glyph/term_glyph.dart' as glyph;
 
 import '../../sass.dart';
@@ -42,8 +42,8 @@ NodeCompileResult compile(String path, [CompileOptions? options]) {
             ascii: ascii),
         importers: options?.importers?.map(_parseImporter));
     return _convertResult(result);
-  } on SassException catch (error) {
-    throwNodeException(error, color: color, ascii: ascii);
+  } on SassException catch (error, stackTrace) {
+    throwNodeException(error, color: color, ascii: ascii, trace: stackTrace);
   }
 }
 
@@ -70,8 +70,8 @@ NodeCompileResult compileString(String text, [CompileStringOptions? options]) {
         importer: options?.importer.andThen(_parseImporter) ??
             (options?.url == null ? NoOpImporter() : null));
     return _convertResult(result);
-  } on SassException catch (error) {
-    throwNodeException(error, color: color, ascii: ascii);
+  } on SassException catch (error, stackTrace) {
+    throwNodeException(error, color: color, ascii: ascii, trace: stackTrace);
   }
 }
 

--- a/lib/src/parse/keyframe_selector.dart
+++ b/lib/src/parse/keyframe_selector.dart
@@ -60,7 +60,9 @@ class KeyframeSelectorParser extends Parser {
     if (scanIdentChar($e)) {
       buffer.writeCharCode($e);
       var next = scanner.peekChar();
-      if (next == $plus || next == $minus) buffer.writeCharCode(scanner.readChar());
+      if (next == $plus || next == $minus) {
+        buffer.writeCharCode(scanner.readChar());
+      }
       if (!isDigit(scanner.peekChar())) scanner.error("Expected digit.");
 
       while (isDigit(scanner.peekChar())) {

--- a/lib/src/parse/sass.dart
+++ b/lib/src/parse/sass.dart
@@ -110,8 +110,8 @@ class SassParser extends StylesheetParser {
     } else {
       try {
         return DynamicImport(parseImportUrl(url), span);
-      } on FormatException catch (innerError) {
-        error("Invalid URL: ${innerError.message}", span);
+      } on FormatException catch (innerError, stackTrace) {
+        error("Invalid URL: ${innerError.message}", span, stackTrace);
       }
     }
   }

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -696,7 +696,7 @@ abstract class StylesheetParser extends Parser {
       var state = scanner.state;
       try {
         return _variableDeclarationWithNamespace();
-      } on SourceSpanFormatException catch (variableDeclarationError) {
+      } on SourceSpanFormatException catch (variableDeclarationError, stackTrace) {
         scanner.state = state;
 
         // If a variable declaration failed to parse, it's possible the user
@@ -712,7 +712,8 @@ abstract class StylesheetParser extends Parser {
         error(
             "@function rules may not contain "
             "${statement is StyleRule ? "style rules" : "declarations"}.",
-            statement.span);
+            statement.span,
+            stackTrace);
       }
     }
 
@@ -1103,8 +1104,8 @@ abstract class StylesheetParser extends Parser {
     } else {
       try {
         return DynamicImport(parseImportUrl(url), urlSpan);
-      } on FormatException catch (innerError) {
-        error("Invalid URL: ${innerError.message}", urlSpan);
+      } on FormatException catch (innerError, stackTrace) {
+        error("Invalid URL: ${innerError.message}", urlSpan, stackTrace);
       }
     }
   }
@@ -3733,8 +3734,9 @@ abstract class StylesheetParser extends Parser {
     var url = string();
     try {
       return Uri.parse(url);
-    } on FormatException catch (innerError) {
-      error("Invalid URL: ${innerError.message}", scanner.spanFrom(start));
+    } on FormatException catch (innerError, stackTrace) {
+      error("Invalid URL: ${innerError.message}", scanner.spanFrom(start),
+          stackTrace);
     }
   }
 

--- a/lib/src/value.dart
+++ b/lib/src/value.dart
@@ -6,6 +6,7 @@ import 'package:meta/meta.dart';
 
 import 'ast/selector.dart';
 import 'exception.dart';
+import 'utils.dart';
 import 'value/boolean.dart';
 import 'value/calculation.dart';
 import 'value/color.dart';
@@ -202,10 +203,12 @@ abstract class Value {
     var string = _selectorString(name);
     try {
       return SelectorList.parse(string, allowParent: allowParent);
-    } on SassFormatException catch (error) {
+    } on SassFormatException catch (error, stackTrace) {
       // TODO(nweiz): colorize this if we're running in an environment where
       // that works.
-      throw _exception(error.toString().replaceFirst("Error: ", ""), name);
+      throwWithTrace(
+          _exception(error.toString().replaceFirst("Error: ", ""), name),
+          stackTrace);
     }
   }
 
@@ -226,10 +229,12 @@ abstract class Value {
     var string = _selectorString(name);
     try {
       return SimpleSelector.parse(string, allowParent: allowParent);
-    } on SassFormatException catch (error) {
+    } on SassFormatException catch (error, stackTrace) {
       // TODO(nweiz): colorize this if we're running in an environment where
       // that works.
-      throw _exception(error.toString().replaceFirst("Error: ", ""), name);
+      throwWithTrace(
+          _exception(error.toString().replaceFirst("Error: ", ""), name),
+          stackTrace);
     }
   }
 
@@ -250,10 +255,12 @@ abstract class Value {
     var string = _selectorString(name);
     try {
       return CompoundSelector.parse(string, allowParent: allowParent);
-    } on SassFormatException catch (error) {
+    } on SassFormatException catch (error, stackTrace) {
       // TODO(nweiz): colorize this if we're running in an environment where
       // that works.
-      throw _exception(error.toString().replaceFirst("Error: ", ""), name);
+      throwWithTrace(
+          _exception(error.toString().replaceFirst("Error: ", ""), name),
+          stackTrace);
     }
   }
 

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 5cdb3467b517bf381d525a1a4bc4f9b6a0eeefad
+// Checksum: 75f2c75c86bcf5397b054a6e88d94e44e59512cf
 //
 // ignore_for_file: unused_import
 
@@ -627,16 +627,24 @@ class _EvaluateVisitor
         callback(module);
       } on SassRuntimeException {
         rethrow;
-      } on MultiSpanSassException catch (error) {
-        throw MultiSpanSassRuntimeException(error.message, error.span,
-            error.primaryLabel, error.secondarySpans, _stackTrace(error.span));
-      } on SassException catch (error) {
-        throw _exception(error.message, error.span);
-      } on MultiSpanSassScriptException catch (error) {
-        throw _multiSpanException(
-            error.message, error.primaryLabel, error.secondarySpans);
-      } on SassScriptException catch (error) {
-        throw _exception(error.message);
+      } on MultiSpanSassException catch (error, stackTrace) {
+        throwWithTrace(
+            MultiSpanSassRuntimeException(
+                error.message,
+                error.span,
+                error.primaryLabel,
+                error.secondarySpans,
+                _stackTrace(error.span)),
+            stackTrace);
+      } on SassException catch (error, stackTrace) {
+        throwWithTrace(_exception(error.message, error.span), stackTrace);
+      } on MultiSpanSassScriptException catch (error, stackTrace) {
+        throwWithTrace(
+            _multiSpanException(
+                error.message, error.primaryLabel, error.secondarySpans),
+            stackTrace);
+      } on SassScriptException catch (error, stackTrace) {
+        throwWithTrace(_exception(error.message), stackTrace);
       }
     });
   }
@@ -1594,16 +1602,16 @@ class _EvaluateVisitor
       } else {
         throw "Can't find stylesheet to import.";
       }
-    } on SassException catch (error) {
-      throw _exception(error.message, error.span);
-    } catch (error) {
+    } on SassException catch (error, stackTrace) {
+      throwWithTrace(_exception(error.message, error.span), stackTrace);
+    } catch (error, stackTrace) {
       String? message;
       try {
         message = (error as dynamic).message as String;
       } catch (_) {
         message = error.toString();
       }
-      throw _exception(message);
+      throwWithTrace(_exception(message), stackTrace);
     } finally {
       _importSpan = null;
     }
@@ -2215,12 +2223,12 @@ class _EvaluateVisitor
         default:
           throw UnsupportedError('Unknown calculation name "${node.name}".');
       }
-    } on SassScriptException catch (error) {
+    } on SassScriptException catch (error, stackTrace) {
       // The simplification logic in the [SassCalculation] static methods will
       // throw an error if the arguments aren't compatible, but we have access
       // to the original spans so we can throw a more informative error.
       _verifyCompatibleNumbers(arguments, node.arguments);
-      throw _exception(error.message, node.span);
+      throwWithTrace(_exception(error.message, node.span), stackTrace);
     }
   }
 
@@ -2564,24 +2572,32 @@ class _EvaluateVisitor
       result = callback(evaluated.positional);
     } on SassRuntimeException {
       rethrow;
-    } on MultiSpanSassScriptException catch (error) {
-      throw MultiSpanSassRuntimeException(
-          error.message,
-          nodeWithSpan.span,
-          error.primaryLabel,
-          error.secondarySpans,
-          _stackTrace(nodeWithSpan.span));
-    } on MultiSpanSassException catch (error) {
-      throw MultiSpanSassRuntimeException(error.message, error.span,
-          error.primaryLabel, error.secondarySpans, _stackTrace(error.span));
-    } catch (error) {
+    } on MultiSpanSassScriptException catch (error, stackTrace) {
+      throwWithTrace(
+          MultiSpanSassRuntimeException(
+              error.message,
+              nodeWithSpan.span,
+              error.primaryLabel,
+              error.secondarySpans,
+              _stackTrace(nodeWithSpan.span)),
+          stackTrace);
+    } on MultiSpanSassException catch (error, stackTrace) {
+      throwWithTrace(
+          MultiSpanSassRuntimeException(
+              error.message,
+              error.span,
+              error.primaryLabel,
+              error.secondarySpans,
+              _stackTrace(error.span)),
+          stackTrace);
+    } catch (error, stackTrace) {
       String? message;
       try {
         message = (error as dynamic).message as String;
       } catch (_) {
         message = error.toString();
       }
-      throw _exception(message, nodeWithSpan.span);
+      throwWithTrace(_exception(message, nodeWithSpan.span), stackTrace);
     }
     _callableNode = oldCallableNode;
 
@@ -3272,7 +3288,7 @@ class _EvaluateVisitor
   T _adjustParseError<T>(AstNode nodeWithSpan, T callback()) {
     try {
       return callback();
-    } on SassFormatException catch (error) {
+    } on SassFormatException catch (error, stackTrace) {
       var errorText = error.span.file.getText(0);
       var span = nodeWithSpan.span;
       var syntheticFile = span.file
@@ -3282,7 +3298,7 @@ class _EvaluateVisitor
           SourceFile.fromString(syntheticFile, url: span.file.url).span(
               span.start.offset + error.span.start.offset,
               span.start.offset + error.span.end.offset);
-      throw _exception(error.message, syntheticSpan);
+      throwWithTrace(_exception(error.message, syntheticSpan), stackTrace);
     }
   }
 
@@ -3295,15 +3311,17 @@ class _EvaluateVisitor
   T _addExceptionSpan<T>(AstNode nodeWithSpan, T callback()) {
     try {
       return callback();
-    } on MultiSpanSassScriptException catch (error) {
-      throw MultiSpanSassRuntimeException(
-          error.message,
-          nodeWithSpan.span,
-          error.primaryLabel,
-          error.secondarySpans,
-          _stackTrace(nodeWithSpan.span));
-    } on SassScriptException catch (error) {
-      throw _exception(error.message, nodeWithSpan.span);
+    } on MultiSpanSassScriptException catch (error, stackTrace) {
+      throwWithTrace(
+          MultiSpanSassRuntimeException(
+              error.message,
+              nodeWithSpan.span,
+              error.primaryLabel,
+              error.secondarySpans,
+              _stackTrace(nodeWithSpan.span)),
+          stackTrace);
+    } on SassScriptException catch (error, stackTrace) {
+      throwWithTrace(_exception(error.message, nodeWithSpan.span), stackTrace);
     }
   }
 
@@ -3313,10 +3331,11 @@ class _EvaluateVisitor
   T _addErrorSpan<T>(AstNode nodeWithSpan, T callback()) {
     try {
       return callback();
-    } on SassRuntimeException catch (error) {
+    } on SassRuntimeException catch (error, stackTrace) {
       if (!error.span.text.startsWith("@error")) rethrow;
-      throw SassRuntimeException(
-          error.message, nodeWithSpan.span, _stackTrace());
+      throwWithTrace(
+          SassRuntimeException(error.message, nodeWithSpan.span, _stackTrace()),
+          stackTrace);
     }
   }
 }

--- a/lib/src/visitor/serialize.dart
+++ b/lib/src/visitor/serialize.dart
@@ -346,11 +346,14 @@ class _SerializeVisitor
       try {
         _buffer.forSpan(
             node.valueSpanForMap, () => node.value.value.accept(this));
-      } on MultiSpanSassScriptException catch (error) {
-        throw MultiSpanSassException(error.message, node.value.span,
-            error.primaryLabel, error.secondarySpans);
-      } on SassScriptException catch (error) {
-        throw SassException(error.message, node.value.span);
+      } on MultiSpanSassScriptException catch (error, stackTrace) {
+        throwWithTrace(
+            MultiSpanSassException(error.message, node.value.span,
+                error.primaryLabel, error.secondarySpans),
+            stackTrace);
+      } on SassScriptException catch (error, stackTrace) {
+        throwWithTrace(
+            SassException(error.message, node.value.span), stackTrace);
       }
     }
   }

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.19
+
+* No user-visible changes.
+
 ## 1.0.0-beta.18
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-beta.18
+version: 1.0.0-beta.19
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  sass: 1.43.4
+  sass: 1.43.5
 
 dependency_overrides:
   sass: {path: ../..}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.43.4
+version: 1.43.5-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This requires a lot of manual machinery when displaying stack traces
to the user, but it should make debugging errors (especially in JS)
much easier.

Works around dart-lang/sdk#10297 using expandos.