### PR TITLE
Update the contribution guidelines regarding behaviors not supported by libsass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ To create a new spec:
 
   ```yaml
   ---
-  :todo:
+  :ignore_for:
   - libsass
   ```
 


### PR DESCRIPTION
As libsass is deprecated, specs should not use `ignore_for` rather than `todo` but the contribution guide was still using the old behavior.