### PR TITLE
Fix equality checks for CalculationOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.43.5
 
+* Fix a bug where calculations with different operators were incorrectly
+  considered equal.
+
 ### JS API
 
 * Print more detailed JS stack traces. This is mostly useful for the Sass team's

--- a/lib/src/value/calculation.dart
+++ b/lib/src/value/calculation.dart
@@ -337,6 +337,7 @@ class CalculationOperation {
 
   bool operator ==(Object other) =>
       other is CalculationOperation &&
+      operator == other.operator &&
       left == other.left &&
       right == other.right;
 


### PR DESCRIPTION
Fixes #1548

I haven't covered it in sass-spec for now, as sass-spec does not contain equality specs for values yet.