### PR TITLE
Improve the deprecation message for /-as-division

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.43.6
+
+* Suggest `calc()` as an alternative in `/`-as-division deprecation messages.
+
 ## 1.43.5
 
 * Fix a bug where calculations with different operators were incorrectly

--- a/lib/src/ast/sass/expression/parenthesized.dart
+++ b/lib/src/ast/sass/expression/parenthesized.dart
@@ -23,5 +23,5 @@ class ParenthesizedExpression implements Expression {
   T accept<T>(ExpressionVisitor<T> visitor) =>
       visitor.visitParenthesizedExpression(this);
 
-  String toString() => expression.toString();
+  String toString() => "($expression)";
 }

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -2125,16 +2125,18 @@ class _EvaluateVisitor
                     expression.operator == BinaryOperator.dividedBy) {
                   return "math.div(${recommendation(expression.left)}, "
                       "${recommendation(expression.right)})";
+                } else if (expression is ParenthesizedExpression) {
+                  return expression.expression.toString();
                 } else {
                   return expression.toString();
                 }
               }
 
               _warn(
-                  "Using / for division is deprecated and will be removed in "
-                  "Dart Sass 2.0.0.\n"
+                  "Using / for division outside of calc() is deprecated "
+                  "and will be removed in Dart Sass 2.0.0.\n"
                   "\n"
-                  "Recommendation: ${recommendation(node)}\n"
+                  "Recommendation: ${recommendation(node)} or calc($node)\n"
                   "\n"
                   "More info and automated migrator: "
                   "https://sass-lang.com/d/slash-div",

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 75f2c75c86bcf5397b054a6e88d94e44e59512cf
+// Checksum: 96397ede2c79b09005bbac9a013d4a6b42faf736
 //
 // ignore_for_file: unused_import
 
@@ -2115,16 +2115,18 @@ class _EvaluateVisitor
                     expression.operator == BinaryOperator.dividedBy) {
                   return "math.div(${recommendation(expression.left)}, "
                       "${recommendation(expression.right)})";
+                } else if (expression is ParenthesizedExpression) {
+                  return expression.expression.toString();
                 } else {
                   return expression.toString();
                 }
               }
 
               _warn(
-                  "Using / for division is deprecated and will be removed in "
-                  "Dart Sass 2.0.0.\n"
+                  "Using / for division outside of calc() is deprecated "
+                  "and will be removed in Dart Sass 2.0.0.\n"
                   "\n"
-                  "Recommendation: ${recommendation(node)}\n"
+                  "Recommendation: ${recommendation(node)} or calc($node)\n"
                   "\n"
                   "More info and automated migrator: "
                   "https://sass-lang.com/d/slash-div",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.20
+
+* No user-visible changes.
+
 ## 1.0.0-beta.19
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-beta.19
+version: 1.0.0-beta.20
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.43.5
+version: 1.43.6
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Fixes https://github.com/sass/dart-sass/issues/1559
See https://github.com/sass/sass-spec/pull/1745

This also changes the string representation of ParenthesizedExpression to fix the recommendations involving them (otherwise the calc recommendation would be an invalid one).