### PR TITLE
Remove some dead code

### DIFF
--- a/lib/src/ast/sass/statement/if_rule.dart
+++ b/lib/src/ast/sass/statement/if_rule.dart
@@ -41,10 +41,9 @@ class IfRule implements Statement {
   T accept<T>(StatementVisitor<T> visitor) => visitor.visitIfRule(this);
 
   String toString() {
-    var first = true;
     var result = clauses
         .map((clause) =>
-            "@${first ? 'if' : 'else if'} {${clause.children.join(' ')}}")
+            "@if {${clause.children.join(' ')}}")
         .join(' ');
 
     var lastClause = this.lastClause;

--- a/lib/src/ast/sass/statement/if_rule.dart
+++ b/lib/src/ast/sass/statement/if_rule.dart
@@ -2,6 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
 
@@ -42,8 +43,8 @@ class IfRule implements Statement {
 
   String toString() {
     var result = clauses
-        .map((clause) =>
-            "@if {${clause.children.join(' ')}}")
+        .mapIndexed((index, clause) =>
+            "@${index == 0 ? 'if' : 'else if'} {${clause.children.join(' ')}}")
         .join(' ');
 
     var lastClause = this.lastClause;


### PR DESCRIPTION
Remove the unchanging `first` variable. Use `mapIndexed` to
differentiate the first clause.

When building internally the analyzer is surfacing a `dead_code`
diagnostic which needs to be ignored. Fixing the code will allow us to
remove the ignore.

I don't know why the diagnostic does not show up when analyzing using
the external analyzer.
https://github.com/dart-lang/sdk/issues/47837