### PR TITLE
Fix the default separator for new SassArgumentList in the JS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.45.2
+
+### JS API
+
+* **Potentially breaking bug fix:** Change the default value of the `separator`
+  parameter for `new SassArgumentList()` to `','` rather than `null`. This
+  matches the API specification.
+
 ## 1.45.1
 
 * **Potentially breaking bug fix:** Properly parse custom properties in

--- a/lib/src/node/value/argument_list.dart
+++ b/lib/src/node/value/argument_list.dart
@@ -10,7 +10,8 @@ import '../utils.dart';
 /// The JavaScript `SassArgumentList` class.
 final JSClass argumentListClass = () {
   var jsClass = createJSClass('sass.SassArgumentList',
-      (Object self, Object contents, Object keywords, [String? separator]) {
+      (Object self, Object contents, Object keywords,
+          [String? separator = ',']) {
     return SassArgumentList(
         jsToDartList(contents).cast<Value>(),
         (isImmutableMap(keywords)

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.25
+
+* No user-visible changes.
+
 ## 1.0.0-beta.24
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-beta.24
+version: 1.0.0-beta.25
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  sass: 1.45.1
+  sass: 1.45.2
 
 dependency_overrides:
   sass: {path: ../..}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.45.1
+version: 1.45.2
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
See sass/sass-spec#1753