### PR TITLE
Clone repos using https:// not git://

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -4,7 +4,8 @@ packages. To use it, add it as a Git dependency to your `pubspec.yaml`:
 ```yaml
 dev_dependencies:
   sass_analysis:
-    git: {url: git://github.com/sass/dart-sass.git, path: analysis}
+    git: {url: 
+    https://github.com/sass/dart-sass.git, path: analysis}
 ```
 
 and include it in your `analysis_options.yaml`:

--- a/pkg/sass_api/README.md
+++ b/pkg/sass_api/README.md
@@ -19,11 +19,11 @@ released yet. Because this package directly re-exports names from the main
 dependency_overrides:
   sass:
     git:
-      url: git://github.com/sass/sass
+      url: https://github.com/sass/sass
       ref: main # Replace this with a feature branch if necessary
   sass_api:
     git:
-      url: git://github.com/sass/sass
+      url: https://github.com/sass/sass
       ref: main # Make sure this is the same as above!
       path: pkg/sass_api
 ```

--- a/tool/grind/frameworks.dart
+++ b/tool/grind/frameworks.dart
@@ -31,7 +31,7 @@ Future<void> fetchBulma() => _getLatestRelease('jgthms/bulma');
 /// If [pattern] is passed, this will clone the latest release that matches that
 /// pattern.
 Future<void> _getLatestRelease(String slug, {Pattern? pattern}) async {
-  cloneOrCheckout('git://github.com/$slug',
+  cloneOrCheckout('https://github.com/$slug',
       await _findLatestRelease(slug, pattern: pattern));
 }
 


### PR DESCRIPTION
GitHub no longer supports the git:// protocol: https://github.blog/2021-09-01-improving-git-protocol-security-github/