### PR TITLE
Use `|` rather than `>` in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,7 +451,7 @@ jobs:
         run: echo "::set-output name=version::${GITHUB_REF##*/}"
 
       - name: Update version
-        run: >
+        run: |
           sed -i 's/version: .*/version: ${{ steps.version.outputs.version }}/' pubspec.yaml
           dart pub remove sass
           dart pub add sass:${{ steps.version.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,4 @@
-## 1.49.1
-
-* Stop supporting non-LTS Node.js versions.
+## 1.49.2
 
 ### Embedded Sass
 
@@ -9,6 +7,10 @@
 
 * First stable release of the `sass_embedded` pub package that contains the
   Embedded Dart Sass compiler.
+
+## 1.49.1
+
+* Stop supporting non-LTS Node.js versions.
 
 ## 1.49.0
 

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.31
+
+* No user-visible changes.
+
 ## 1.0.0-beta.30
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-beta.30
+version: 1.0.0-beta.31
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  sass: 1.49.1
+  sass: 1.49.2
 
 dependency_overrides:
   sass: {path: ../..}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.49.1
+version: 1.49.2
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
The `|` character preserves newlines where `>` does not.