### PR TITLE
Allow Node 17 to pass extra args to inspect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.49.8
+
+* Fix a bug where `require('sass')` was broken on Node 17 due to Dart's JS
+  interop.
+
 ## 1.49.7
 
 ### Embedded Sass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 1.49.8
 
-* Fix a bug where `require('sass')` was broken on Node 17 due to Dart's JS
-  interop.
+### JS API
+
+* Fix a bug where inspecting the Sass module in the Node.js console crashed on
+  Node 17.
 
 ## 1.49.7
 

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -130,9 +130,8 @@ class ImportCache {
           .putIfAbsent(Tuple4(url, forImport, baseImporter, baseUrl), () {
         var resolvedUrl = baseUrl?.resolveUri(url) ?? url;
         var canonicalUrl = _canonicalize(baseImporter, resolvedUrl, forImport);
-        if (canonicalUrl != null) {
-          return Tuple3(baseImporter, canonicalUrl, resolvedUrl);
-        }
+        if (canonicalUrl == null) return null;
+        return Tuple3(baseImporter, canonicalUrl, resolvedUrl);
       });
       if (relativeResult != null) return relativeResult;
     }

--- a/lib/src/node/reflection.dart
+++ b/lib/src/node/reflection.dart
@@ -69,7 +69,7 @@ extension JSClassExtension on JSClass {
   /// Sets the custom inspect logic for this class to [body].
   void setCustomInspect(String inspect(Object self)) {
     setProperty(prototype, _inspectSymbol,
-        allowInteropCaptureThis((Object self, _, __) => inspect(self)));
+        allowInteropCaptureThis((Object self, _, __, [___]) => inspect(self)));
   }
 
   /// Defines a method with the given [name] and [body].

--- a/lib/src/visitor/statement_search.dart
+++ b/lib/src/visitor/statement_search.dart
@@ -105,5 +105,6 @@ extension _IterableExtension<E> on Iterable<E> {
       var value = callback(element);
       if (value != null) return value;
     }
+    return null;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.49.7
+version: 1.49.8-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Fixes https://github.com/sass/dart-sass/issues/1625
Fixes https://github.com/sass/dart-sass/issues/1605

See https://github.com/sass/sass-spec/pull/1777