### PR TITLE
Remove dead code in the stylesheet parser

### DIFF
--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -405,9 +405,7 @@ abstract class StylesheetParser extends Parser {
     var beforeDeclaration = scanner.state;
     Expression value;
     try {
-      value = lookingAtChildren()
-          ? StringExpression(Interpolation([], scanner.emptySpan), quotes: true)
-          : expression();
+      value = expression();
 
       if (lookingAtChildren()) {
         // Properties that are ambiguous with selectors can't have additional


### PR DESCRIPTION
At that point, the scanner is still at the same position than the previous check for children returning a nested declaration, so it is
impossible for it to be looking at children.

As part of my rewrite of scssphp to a more modern and more spec-compliant codebase, I ported the dart-sass parser to PHP. This dead code was reported by our static analyzer in its updated version, and my own investigation of the code makes me agree with the tool.