### PR TITLE
Run formatter directly in grind.dart

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -67,8 +67,8 @@ void all() {}
 
 @Task('Run the Dart formatter.')
 void format() {
-  Pub.run('dart_style',
-      script: 'format', arguments: ['--overwrite', '--fix', '.']);
+  run('dart',
+      arguments: ['run', 'dart_style:format', '--overwrite', '--fix', '.']);
 }
 
 @Task('Installs dependencies from npm.')


### PR DESCRIPTION
grinder's Pub class is broken in 2.17 (see https://github.com/google/grinder.dart/issues/385), so we need to run the formatter directly.