### PR TITLE
Ensure onStdinClose only completes for non-tty streams

### DIFF
--- a/lib/src/io/interface.dart
+++ b/lib/src/io/interface.dart
@@ -95,10 +95,12 @@ String? getEnvironmentVariable(String name) => throw '';
 int get exitCode => throw '';
 set exitCode(int value) => throw '';
 
-/// If stdin is a TTY, returns a [CancelableOperation] that completes once it
-/// closes.
+/// Returns a [CancelableOperation] that completes when stdin closes.
 ///
-/// Otherwise, returns a [CancelableOperation] that never completes.
+/// Note that if stdin is a TTY, the operation never completes. This is to
+/// avoid interfering with background job systems where reading from stdin
+/// and then moving the process to the background would incorrectly cause
+/// the job to stop.
 ///
 /// As long as this is uncanceled, it will monopolize stdin so that nothing else
 /// can read from it.

--- a/lib/src/io/node.dart
+++ b/lib/src/io/node.dart
@@ -218,7 +218,7 @@ set exitCode(int code) => process.exitCode = code;
 
 CancelableOperation<void> onStdinClose() {
   var completer = CancelableCompleter<void>();
-  if (isStdinTTY == true) {
+  if (isStdinTTY != true) {
     process.stdin.on('end', allowInterop(() => completer.complete()));
   }
   return completer.operation;

--- a/lib/src/io/vm.dart
+++ b/lib/src/io/vm.dart
@@ -91,8 +91,8 @@ DateTime modificationTime(String path) {
 String? getEnvironmentVariable(String name) => io.Platform.environment[name];
 
 CancelableOperation<void> onStdinClose() => io.stdin.hasTerminal
-    ? CancelableOperation.fromSubscription(io.stdin.listen(null))
-    : CancelableCompleter<void>().operation;
+    ? CancelableCompleter<void>().operation
+    : CancelableOperation.fromSubscription(io.stdin.listen(null));
 
 Future<Stream<WatchEvent>> watchDir(String path, {bool poll = false}) async {
   var watcher = poll ? PollingDirectoryWatcher(path) : DirectoryWatcher(path);


### PR DESCRIPTION
First, thank you so much for all the work to get #1411 merged! I realized only too late that there was a small typo in my initial version that has led to a bit of a gnarly bug. 😳 

The initial stdin commit 144cd35 inverted the TTY conditional
b/w the `io/node` and `io/vm` implementations of `onStdinClose`.
The node implementation incorrectly checked for the presence
of TTY to complete the stream, while the vm implementation
correctly checked for its _absence_. The commit that landed
upstream c7ab426 normalized the incorrect behaviour, which
means that sass was still not closing when stdin was closed,
unless stdin was a TTY.

Unfortunately that created a "worst of both worlds" situation
because programs that start sass and then close unexpectedly
will still leave zombie sass processes running in the
background, and wrapper scripts designed to mitigate this
exact problem will stop working because moving the process to
the background now incorrectly causes the job to stop.

This change ensures we only complete the CancelableOperation
onStdinClose for non-tty standard input streams.