### PR TITLE
Escape the source map URL before using it in a CSS comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Fix an issue where source locations tracked through variable references could
   potentially become incorrect.
+* Fix a bug where a loud comment in the source can break the source map when
+  embedding the sources, when using the command-line interface or the legacy JS
+  API.
 
 ## 1.51.0
 

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -174,6 +174,8 @@ String _writeSourceMap(
     url = p.toUri(p.relative(sourceMapPath, from: p.dirname(destination)));
   }
 
+  var escapedUrl = url.toString().replaceAll("*/", '%2A/');
+
   return (options.style == OutputStyle.compressed ? '' : '\n\n') +
-      '/*# sourceMappingURL=$url */';
+      '/*# sourceMappingURL=$escapedUrl */';
 }

--- a/lib/src/node/legacy.dart
+++ b/lib/src/node/legacy.dart
@@ -405,7 +405,8 @@ RenderResult _newRenderResult(
           : p.toUri(outFile == null
               ? sourceMapPath
               : p.relative(sourceMapPath, from: p.dirname(outFile)));
-      css += "\n\n/*# sourceMappingURL=$url */";
+      var escapedUrl = url.toString().replaceAll("*/", '%2A/');
+      css += "\n\n/*# sourceMappingURL=$escapedUrl */";
     }
   }
 


### PR DESCRIPTION
The URL must not be allowed to terminate the comment.

Closes #1351