### PR TITLE
Remove unused methods

### DIFF
--- a/lib/src/ast/sass/statement/mixin_rule.dart
+++ b/lib/src/ast/sass/statement/mixin_rule.dart
@@ -54,7 +54,4 @@ class _HasContentVisitor extends StatementSearchVisitor<bool> {
   const _HasContentVisitor();
 
   bool visitContentRule(_) => true;
-  bool? visitArgumentInvocation(_) => null;
-  bool? visitSupportsCondition(_) => null;
-  bool? visitInterpolation(_) => null;
 }


### PR DESCRIPTION
Those protected methods have been removed from the StatementSearchVisitor in https://github.com/sass/dart-sass/commit/632a041e1eef28baaaa47cc4f21b01ffaef3260b