### PR TITLE
fix serializing loud comment crash when importing the same file twice in a row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.52.3
+
+* Fix crash when trailing loud comments (`/* ... */`) appear twice in a row
+  across two different imports which themselves imported the same file each.
+
 ## 1.52.2
 
 * Preserve location of trailing loud comments (`/* ... */`) instead of pushing

--- a/lib/src/visitor/serialize.dart
+++ b/lib/src/visitor/serialize.dart
@@ -1356,6 +1356,11 @@ class _SerializeVisitor
     // simple forward search of the previous.span.text as that might contain
     // other left braces.
     var searchFrom = node.span.start.offset - previous.span.start.offset - 1;
+
+    // Imports can cause a node to be "contained" by another node when they are
+    // actually the same node twice in a row.
+    if (searchFrom < 0) return false;
+
     var endOffset = previous.span.text.lastIndexOf("{", searchFrom);
     endOffset = math.max(0, endOffset);
     var span = previous.span.file.span(

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.48
+
+* No user-visible changes.
+
 ## 1.0.0-beta.47
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,18 +2,18 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 1.0.0-beta.47
+version: 1.0.0-beta.48
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  sass: 1.52.2
+  sass: 1.52.3
 
 dev_dependencies:
   dartdoc: ^5.0.0
 
 dependency_overrides:
-  sass: {path: ../..}
+  sass: { path: ../.. }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.52.2
+version: 1.52.3
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 
@@ -8,7 +8,7 @@ executables:
   sass: sass
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   args: ^2.0.0


### PR DESCRIPTION
Fixes #1712

See https://github.com/sass/sass-spec/pull/1790