### PR TITLE
Fix a buggy interaction between meta.load-css and the legacy JS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.52.4
+
+### JS API
+
+* Fix a bug where `meta.load-css()` would sometimes resolve relative URLs
+  incorrectly when called from a mixin using the legacy JS API.
+
 ## 1.52.3
 
 * Fix crash when trailing loud comments (`/* ... */`) appear twice in a row

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -1600,7 +1600,8 @@ class _EvaluateVisitor
           }
         }
       } else {
-        var result = await _importLikeNode(url, forImport);
+        var result = await _importLikeNode(
+            url, baseUrl ?? _stylesheet.span.sourceUrl, forImport);
         if (result != null) {
           result.stylesheet.span.sourceUrl.andThen(_loadedUrls.add);
           return result;
@@ -1633,16 +1634,14 @@ class _EvaluateVisitor
   ///
   /// Returns the [Stylesheet], or `null` if the import failed.
   Future<_LoadedStylesheet?> _importLikeNode(
-      String originalUrl, bool forImport) async {
-    var result = _nodeImporter!
-        .loadRelative(originalUrl, _stylesheet.span.sourceUrl, forImport);
+      String originalUrl, Uri? previous, bool forImport) async {
+    var result = _nodeImporter!.loadRelative(originalUrl, previous, forImport);
 
     bool isDependency;
     if (result != null) {
       isDependency = _inDependency;
     } else {
-      result = await _nodeImporter!
-          .loadAsync(originalUrl, _stylesheet.span.sourceUrl, forImport);
+      result = await _nodeImporter!.loadAsync(originalUrl, previous, forImport);
       if (result == null) return null;
       isDependency = true;
     }

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: fdd5d16c0ec34a4e0e4e2d5bdbe3d764e788a43f
+// Checksum: 62020db52400fe22132154e72fbb728f6282bf6d
 //
 // ignore_for_file: unused_import
 
@@ -1598,7 +1598,8 @@ class _EvaluateVisitor
           }
         }
       } else {
-        var result = _importLikeNode(url, forImport);
+        var result = _importLikeNode(
+            url, baseUrl ?? _stylesheet.span.sourceUrl, forImport);
         if (result != null) {
           result.stylesheet.span.sourceUrl.andThen(_loadedUrls.add);
           return result;
@@ -1630,16 +1631,15 @@ class _EvaluateVisitor
   /// Imports a stylesheet using [_nodeImporter].
   ///
   /// Returns the [Stylesheet], or `null` if the import failed.
-  _LoadedStylesheet? _importLikeNode(String originalUrl, bool forImport) {
-    var result = _nodeImporter!
-        .loadRelative(originalUrl, _stylesheet.span.sourceUrl, forImport);
+  _LoadedStylesheet? _importLikeNode(
+      String originalUrl, Uri? previous, bool forImport) {
+    var result = _nodeImporter!.loadRelative(originalUrl, previous, forImport);
 
     bool isDependency;
     if (result != null) {
       isDependency = _inDependency;
     } else {
-      result = _nodeImporter!
-          .load(originalUrl, _stylesheet.span.sourceUrl, forImport);
+      result = _nodeImporter!.load(originalUrl, previous, forImport);
       if (result == null) return null;
       isDependency = true;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.52.3
+version: 1.52.4-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Closes #1627
See https://github.com/sass/sass-spec/pull/1793