### PR TITLE
Add support for `var()` with an empty fallback argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 1.52.4
+## 1.53.0
+
+* Add support for calling `var()` with an empty second argument, such as
+  `var(--side, )`.
 
 ### Embedded Sass
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.52.4-dev
+version: 1.53.0-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Closes sass/sass#3245
See sass/sass-spec#1794