### PR TITLE
Remove @types/node from dependencies

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -17,7 +17,6 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@types/node": "^18.0.0",
     "chokidar": ">=3.0.0 <4.0.0",
     "immutable": "^4.0.0",
     "source-map-js": ">=0.6.2 <2.0.0"


### PR DESCRIPTION
Based on comments from https://github.com/sass/dart-sass/pull/1736.

It seems to be common to use `"@types/node": "*"` when `@types/node` is required.