### PR TITLE
Deprecate passing non-`deg` units to `hwb()`'s `$hue` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
   See https://sass-lang.com/d/bogus-combinators for more details.
 
+* Deprecate passing non-`deg` units to `color.hwb()`'s `$hue` argument.
+
 ### JS API
 
 * Add a `charset` option that controls whether or not Sass emits a

--- a/lib/src/functions/color.dart
+++ b/lib/src/functions/color.dart
@@ -121,7 +121,7 @@ final global = UnmodifiableListView([
   _function("adjust-hue", r"$color, $degrees", (arguments) {
     var color = arguments[0].assertColor("color");
     var degrees = arguments[1].assertNumber("degrees");
-    _checkAngle(degrees);
+    _checkAngle(degrees, "degrees");
     return color.changeHsl(hue: color.hue + degrees.value);
   }),
 
@@ -635,7 +635,7 @@ Value _hsl(String name, List<Value> arguments) {
 }
 
 /// Prints a deprecation warning if [hue] has a unit other than `deg`.
-void _checkAngle(SassNumber angle, [String? name]) {
+void _checkAngle(SassNumber angle, String name) {
   if (!angle.hasUnits || angle.hasUnit('deg')) return;
 
   var message = StringBuffer()
@@ -692,6 +692,7 @@ Value _hwb(List<Value> arguments) {
   var whiteness = arguments[1].assertNumber("whiteness");
   var blackness = arguments[2].assertNumber("blackness");
 
+  _checkAngle(hue, "hue");
   whiteness.assertUnit("%", "whiteness");
   blackness.assertUnit("%", "blackness");
 


### PR DESCRIPTION
This was overlooked in #1175, because the spec said that `hwb()`
should already be throwing an error if non-`deg` units were passed.
However, Dart Sass didn't implement the spec correctly and these units
were in fact not being checked at all.

See #1174

See https://github.com/sass/sass-spec/pull/1806