### PR TITLE
Drop the Git dependency on source_span

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,9 +49,3 @@ dev_dependencies:
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
   yaml: ^3.1.0
-
-dependency_overrides:
-  source_span:
-    git:
-      url: https://github.com/dart-lang/source_span
-      ref: multi-line-label


### PR DESCRIPTION
We don't need to narrow the version constraint because this release
just improves formatting, it doesn't actually change the API.