### PR TITLE
Recategorize selectors as "AST" for Dartdoc

### DIFF
--- a/lib/src/ast/selector.dart
+++ b/lib/src/ast/selector.dart
@@ -37,7 +37,7 @@ export 'selector/universal.dart';
 ///
 /// Selectors have structural equality semantics.
 ///
-/// {@category Selector}
+/// {@category AST}
 abstract class Selector {
   /// Whether this selector, and complex selectors containing it, should not be
   /// emitted.

--- a/lib/src/ast/selector/attribute.dart
+++ b/lib/src/ast/selector/attribute.dart
@@ -12,7 +12,7 @@ import '../selector.dart';
 /// This selects for elements with the given attribute, and optionally with a
 /// value matching certain conditions as well.
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class AttributeSelector extends SimpleSelector {
   /// The name of the attribute being selected for.

--- a/lib/src/ast/selector/class.dart
+++ b/lib/src/ast/selector/class.dart
@@ -12,7 +12,7 @@ import '../selector.dart';
 /// This selects elements whose `class` attribute contains an identifier with
 /// the given name.
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class ClassSelector extends SimpleSelector {
   /// The class name this selects for.

--- a/lib/src/ast/selector/combinator.dart
+++ b/lib/src/ast/selector/combinator.dart
@@ -7,7 +7,7 @@ import 'package:meta/meta.dart';
 /// A combinator that defines the relationship between selectors in a
 /// [ComplexSelector].
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class Combinator {
   /// Matches the right-hand selector if it's immediately adjacent to the

--- a/lib/src/ast/selector/complex.dart
+++ b/lib/src/ast/selector/complex.dart
@@ -16,7 +16,8 @@ import '../selector.dart';
 /// A complex selector is composed of [CompoundSelector]s separated by
 /// [Combinator]s. It selects elements based on their parent selectors.
 ///
-/// {@category Selector}
+/// {@category AST}
+/// {@category Parsing}
 @sealed
 class ComplexSelector extends Selector {
   /// This selector's leading combinators.

--- a/lib/src/ast/selector/complex_component.dart
+++ b/lib/src/ast/selector/complex_component.dart
@@ -11,7 +11,7 @@ import '../selector.dart';
 ///
 /// This a [CompoundSelector] with one or more trailing [Combinator]s.
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class ComplexSelectorComponent {
   /// This component's compound selector.

--- a/lib/src/ast/selector/compound.dart
+++ b/lib/src/ast/selector/compound.dart
@@ -16,7 +16,8 @@ import '../selector.dart';
 /// A compound selector is composed of [SimpleSelector]s. It matches an element
 /// that matches all of the component simple selectors.
 ///
-/// {@category Selector}
+/// {@category AST}
+/// {@category Parsing}
 @sealed
 class CompoundSelector extends Selector {
   /// The components of this selector.

--- a/lib/src/ast/selector/id.dart
+++ b/lib/src/ast/selector/id.dart
@@ -13,7 +13,7 @@ import '../selector.dart';
 ///
 /// This selects elements whose `id` attribute exactly matches the given name.
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class IDSelector extends SimpleSelector {
   /// The ID name this selects for.

--- a/lib/src/ast/selector/list.dart
+++ b/lib/src/ast/selector/list.dart
@@ -18,7 +18,8 @@ import '../selector.dart';
 /// A selector list is composed of [ComplexSelector]s. It matches any element
 /// that matches any of the component selectors.
 ///
-/// {@category Selector}
+/// {@category AST}
+/// {@category Parsing}
 @sealed
 class SelectorList extends Selector {
   /// The components of this selector.

--- a/lib/src/ast/selector/parent.dart
+++ b/lib/src/ast/selector/parent.dart
@@ -12,7 +12,7 @@ import '../selector.dart';
 /// This is not a plain CSS selector—it should be removed before emitting a CSS
 /// document.
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class ParentSelector extends SimpleSelector {
   /// The suffix that will be added to the parent selector after it's been

--- a/lib/src/ast/selector/placeholder.dart
+++ b/lib/src/ast/selector/placeholder.dart
@@ -14,7 +14,7 @@ import '../selector.dart';
 /// `@extend`. It's not a plain CSS selector—it should be removed before
 /// emitting a CSS document.
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class PlaceholderSelector extends SimpleSelector {
   /// The name of the placeholder.

--- a/lib/src/ast/selector/pseudo.dart
+++ b/lib/src/ast/selector/pseudo.dart
@@ -18,7 +18,7 @@ import '../selector.dart';
 /// logic for each pseudo selector that takes a selector as an argument, to
 /// ensure that extension and other selector operations work properly.
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class PseudoSelector extends SimpleSelector {
   /// The name of this selector.

--- a/lib/src/ast/selector/qualified_name.dart
+++ b/lib/src/ast/selector/qualified_name.dart
@@ -8,7 +8,7 @@ import 'package:meta/meta.dart';
 ///
 /// [qualified name]: https://www.w3.org/TR/css3-namespace/#css-qnames
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class QualifiedName {
   /// The identifier name.

--- a/lib/src/ast/selector/simple.dart
+++ b/lib/src/ast/selector/simple.dart
@@ -11,7 +11,8 @@ import '../selector.dart';
 
 /// An abstract superclass for simple selectors.
 ///
-/// {@category Selector}
+/// {@category AST}
+/// {@category Parsing}
 abstract class SimpleSelector extends Selector {
   /// The minimum possible specificity that this selector can have.
   ///

--- a/lib/src/ast/selector/type.dart
+++ b/lib/src/ast/selector/type.dart
@@ -12,7 +12,7 @@ import '../selector.dart';
 ///
 /// This selects elements whose name equals the given name.
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class TypeSelector extends SimpleSelector {
   /// The element name being selected.

--- a/lib/src/ast/selector/universal.dart
+++ b/lib/src/ast/selector/universal.dart
@@ -10,7 +10,7 @@ import '../selector.dart';
 
 /// Matches any element in the given namespace.
 ///
-/// {@category Selector}
+/// {@category AST}
 @sealed
 class UniversalSelector extends SimpleSelector {
   /// The selector namespace.


### PR DESCRIPTION
This more closely matches the categorization of other AST nodes, which
aren't broken down into fine-grained categories.

This also adds the "Parsing" category to selector classes that have
`parse()` methods.