### PR TITLE
Revert "Run qemu in tmpfs (#1707)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,12 +315,10 @@ jobs:
             --env "GH_TOKEN=$GH_TOKEN" \
             --env "GH_USER=$GH_USER" \
             --platform ${{ matrix.platform }} \
-            --mount type=bind,source="$PWD",target="$PWD" \
-            --mount type=tmpfs,destination=/root/.pub-cache \
-            --mount type=tmpfs,destination=/tmp \
+            --volume "$PWD:$PWD" \
             --workdir "$PWD" \
             docker.io/library/dart:latest \
-            /bin/sh -c "cp -R . /tmp/workspace && cd /tmp/workspace && dart pub get && dart run grinder pkg-github-linux-${{ matrix.arch }}"
+            /bin/sh -c "dart pub get && dart run grinder pkg-github-linux-${{ matrix.arch }}"
         env:
           GH_TOKEN: "${{ secrets.GH_TOKEN }}"
           GH_USER: sassbot


### PR DESCRIPTION
This reverts commit cb74cc4c3150898a95adfe2d8ebcd50ec49c5be9.

The fix for the original issue is in https://github.com/dart-lang/sdk/commit/6b04565db2a345867e7ecf56e838321cc85a4e28 and has been included with dart-sdk `2.18.0-271.2.beta`. I have tested it locally and verified the workaround is no longer needed.