### PR TITLE
Migrate deprecation warnings to sass-lang short links

### DIFF
--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -1393,7 +1393,7 @@ abstract class StylesheetParser extends Parser {
             "@-moz-document is deprecated and support will be removed in Dart "
             "Sass 2.0.0.\n"
             "\n"
-            "For details, see http://bit.ly/MozDocument.",
+            "For details, see https://sass-lang.com/d/moz-document.",
             span: span,
             deprecation: true);
       }

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -1243,7 +1243,7 @@ class _EvaluateVisitor
         throw SassFormatException(
             "compound selectors may no longer be extended.\n"
             "Consider `@extend ${compound.components.join(', ')}` instead.\n"
-            "See http://bit.ly/ExtendCompound for details.\n",
+            "See https://sass-lang.com/d/extend-compound for details.\n",
             targetText.span);
       }
 

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 1481489206d9df595860ec2e1c44729bd8928b90
+// Checksum: c70a4193cc291f298f601a5cc371be9eac71fb74
 //
 // ignore_for_file: unused_import
 
@@ -1245,7 +1245,7 @@ class _EvaluateVisitor
         throw SassFormatException(
             "compound selectors may no longer be extended.\n"
             "Consider `@extend ${compound.components.join(', ')}` instead.\n"
-            "See http://bit.ly/ExtendCompound for details.\n",
+            "See https://sass-lang.com/d/extend-compound for details.\n",
             targetText.span);
       }
 


### PR DESCRIPTION
https://github.com/sass/sass-spec/pull/1820

Requires https://github.com/sass/sass-site/pull/667