### PR TITLE
Add a deprecation warning for strict unary operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.54.10
+
+* Emit a deprecation warning for `$a -$b` and `$a +$b`, since these look like
+  they could be unary operations but they're actually parsed as binary
+  operations. Either explicitly write `$a - $b` or `$a (-$b)`. See
+  https://sass-lang.com/d/strict-unary for more details.
+
 ## 1.54.9
 
 * Fix an incorrect span in certain `@media` query deprecation warnings.

--- a/lib/src/callable/built_in.dart
+++ b/lib/src/callable/built_in.dart
@@ -72,8 +72,7 @@ class BuiltInCallable implements Callable, AsyncBuiltInCallable {
   ///
   /// If passed, [url] is the URL of the module in which the function is
   /// defined.
-  BuiltInCallable.overloadedFunction(
-      this.name, Map<String, Callback> overloads,
+  BuiltInCallable.overloadedFunction(this.name, Map<String, Callback> overloads,
       {Object? url})
       : _overloads = [
           for (var entry in overloads.entries)

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -1788,6 +1788,34 @@ abstract class StylesheetParser extends Parser {
       } else {
         singleExpression_ = BinaryOperationExpression(operator, left, right);
         allowSlash = false;
+
+        if (operator == BinaryOperator.plus ||
+            operator == BinaryOperator.minus) {
+          if (scanner.string.substring(
+                      right.span.start.offset - 1, right.span.start.offset) ==
+                  operator.operator &&
+              isWhitespace(scanner.string.codeUnitAt(left.span.end.offset))) {
+            logger.warn(
+                "This operation is parsed as:\n"
+                "\n"
+                "    $left ${operator.operator} $right\n"
+                "\n"
+                "but you may have intended it to mean:\n"
+                "\n"
+                "    $left (${operator.operator}$right)\n"
+                "\n"
+                "Add a space after ${operator.operator} to clarify that it's "
+                "meant to be a binary operation, or wrap\n"
+                "it in parentheses to make it a unary operation. This will be "
+                "an error in future\n"
+                "versions of Sass.\n"
+                "\n"
+                "More info and automated migrator: "
+                "https://sass-lang.com/d/strict-unary",
+                span: singleExpression_!.span,
+                deprecation: true);
+          }
+        }
       }
     }
 

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.5
+
+* No user-visible changes.
+
 ## 3.0.4
 
 * `UnaryOperationExpression`s with operator `not` now include a correct span,

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 3.0.4
+version: 3.0.5-dev
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  sass: 1.54.9
+  sass: 1.54.10
 
 dev_dependencies:
   dartdoc: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.54.9
+version: 1.54.10-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Closes #1721
See sass/sass-spec#1823