### PR TITLE
Insert explicit type arguments where types could not be inferred.

### DIFF
--- a/lib/src/functions/color.dart
+++ b/lib/src/functions/color.dart
@@ -220,7 +220,7 @@ final global = UnmodifiableListView([
 ]);
 
 /// The Sass color module.
-final module = BuiltInModule("color", functions: [
+final module = BuiltInModule("color", functions: <Callable>[
   // ### RGB
   _red, _green, _blue, _mix,
 

--- a/lib/src/functions/list.dart
+++ b/lib/src/functions/list.dart
@@ -18,7 +18,7 @@ final global = UnmodifiableListView([
 ]);
 
 /// The Sass list module.
-final module = BuiltInModule("list", functions: [
+final module = BuiltInModule("list", functions: <Callable>[
   _length, _nth, _setNth, _join, _append, _zip, _index, _isBracketed, //
   _separator, _slash
 ]);

--- a/lib/src/functions/map.dart
+++ b/lib/src/functions/map.dart
@@ -23,7 +23,7 @@ final global = UnmodifiableListView([
 ]);
 
 /// The Sass map module.
-final module = BuiltInModule("map", functions: [
+final module = BuiltInModule("map", functions: <Callable>[
   _get,
   _set,
   _merge,

--- a/lib/src/functions/math.dart
+++ b/lib/src/functions/math.dart
@@ -22,7 +22,7 @@ final global = UnmodifiableListView([
 ]);
 
 /// The Sass math module.
-final module = BuiltInModule("math", functions: [
+final module = BuiltInModule("math", functions: <Callable>[
   _abs, _acos, _asin, _atan, _atan2, _ceil, _clamp, _cos, _compatible, //
   _floor, _hypot, _isUnitless, _log, _max, _min, _percentage, _pow, //
   _randomFunction, _round, _sin, _sqrt, _tan, _unit, _div

--- a/lib/src/functions/selector.dart
+++ b/lib/src/functions/selector.dart
@@ -27,7 +27,7 @@ final global = UnmodifiableListView([
 ]);
 
 /// The Sass selector module.
-final module = BuiltInModule("selector", functions: [
+final module = BuiltInModule("selector", functions: <Callable>[
   _isSuperselector,
   _simpleSelectors,
   _parse,

--- a/lib/src/functions/string.dart
+++ b/lib/src/functions/string.dart
@@ -29,7 +29,7 @@ final global = UnmodifiableListView([
 ]);
 
 /// The Sass string module.
-final module = BuiltInModule("string", functions: [
+final module = BuiltInModule("string", functions: <Callable>[
   _unquote, _quote, _toUpperCase, _toLowerCase, _length, _insert, _index, //
   _slice, _uniqueId,
 ]);


### PR DESCRIPTION
This change is a no-op.

The Dart compiler front-end (“CFE”) and static analyzer (“analyzer”) intend to fix [a bug](https://github.com/dart-lang/sdk/issues/49308) in which “could not infer” errors are not reported for _top-level elements_. (The same error is already reported in local elements.) Typically in such code, the developer has incorrectly expected inference to flow a certain way and infer a type which satisfies a bound, and the CFE and analyzer don’t report any error, so they submit their code. Here is a minified example:

```
class C<P extends num> {
  factory C(Iterable<P> p) => C._();
  C._();
}

var c = C([]);
```

A developer expects (reasonably) that inference would land on `C<num>` and `List<num>` for the types of `c` and the List literal. However, details in the inference algorithms actually mean that inference cannot determine the implicit type of `C`, which needs to be a compile-time error.