### PR TITLE
Indent comma-separated multiline selectors inside @media queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.55.1
+
+* Fix indentation for selectors that span multiple lines in a `@media` query.
+
 ## 1.55.0
 
 * **Potentially breaking bug fix:** Sass numbers are now universally stored as

--- a/lib/src/visitor/serialize.dart
+++ b/lib/src/visitor/serialize.dart
@@ -1240,6 +1240,7 @@ class _SerializeVisitor
         _buffer.writeCharCode($comma);
         if (complex.lineBreak) {
           _writeLineFeed();
+          _writeIndentation();
         } else {
           _writeOptionalSpace();
         }
@@ -1318,7 +1319,7 @@ class _SerializeVisitor
 
       if (_isTrailingComment(child, previous ?? parent)) {
         _writeOptionalSpace();
-        _withoutIndendation(() => child.accept(this));
+        _withoutIndentation(() => child.accept(this));
       } else {
         _writeLineFeed();
         _indent(() {
@@ -1431,7 +1432,7 @@ class _SerializeVisitor
   }
 
   /// Runs [callback] without any indentation.
-  void _withoutIndendation(void callback()) {
+  void _withoutIndentation(void callback()) {
     var savedIndentation = _indentation;
     _indentation = 0;
     callback();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.55.0
+version: 1.55.1-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Fixes sass/dart-sass#1406

See: https://github.com/sass/sass-spec/pull/1829