### PR TITLE
Make `cloneCss() clone modules that transitively contain CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@
 * Properly mark the warning for passing numbers with units to `random()` as a
   deprecation warning.
 
+* Fix a bug where `@extend` could behave unpredicatably when used along with
+  `meta.load-css()` and shared modules that contained no CSS themselves but
+  loaded CSS from other modules.
+
 ### Dart API
 
 * Emit a deprecation warning when passing a `sassIndex` with units to

--- a/lib/src/async_environment.dart
+++ b/lib/src/async_environment.dart
@@ -1014,7 +1014,7 @@ class _EnvironmentModule implements Module {
   }
 
   Module cloneCss() {
-    if (css.children.isEmpty) return this;
+    if (!transitivelyContainsCss) return this;
 
     var newCssAndExtensionStore = cloneCssStylesheet(css, extensionStore);
     return _EnvironmentModule._(

--- a/lib/src/environment.dart
+++ b/lib/src/environment.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_environment.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 88f81b417129a74e4eb776d518c8e019dbf2ec36
+// Checksum: 38c688423116df1e489aa6eafc16de1bf9bc2bf5
 //
 // ignore_for_file: unused_import
 
@@ -1022,7 +1022,7 @@ class _EnvironmentModule implements Module<Callable> {
   }
 
   Module<Callable> cloneCss() {
-    if (css.children.isEmpty) return this;
+    if (!transitivelyContainsCss) return this;
 
     var newCssAndExtensionStore = cloneCssStylesheet(css, extensionStore);
     return _EnvironmentModule._(


### PR DESCRIPTION
Previously we were only cloning modules that directly contained CSS,
but this created a problem where extensions could be added to their
*shared* extension store across `load-css()` boundaries and thereby
applied to upstream CSS.

Closes #3322
See https://github.com/sass/sass-spec/pull/1835