### PR TITLE
Fix dart-sass-embedded release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,7 +511,7 @@ jobs:
 
           # The embedded compiler has a checked-in pubspec.yaml, so upgrade to
           # make sure we're releasing against the latest version of all deps.
-          pub upgrade
+          dart pub upgrade
 
           curl https://raw.githubusercontent.com/sass/dart-sass/${{ steps.version.outputs.version }}/CHANGELOG.md > CHANGELOG.md
 


### PR DESCRIPTION
Top level pub command is no longer available and it’s causing 1.57.0 release to fail.

@nex3 We need to either manually cut 1.57.0 for dart-sass-embedded or cut 1.57.1 instead.