### PR TITLE
Add all CSS length units in known compatibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.57.2
+## 1.58.0
 
 * Remove sourcemap comments from Sass sources. The generated sourcemap comment
   for the compiled CSS output remains unaffected.
@@ -15,6 +15,9 @@
   `--`.
 
 * Fix a crash when a selector ends in an escaped backslash.
+
+* Add the relative length units from CSS Values 4 and CSS Contain 3 as known
+  units to validate bad computation in `calc`.
 
 ## 1.57.1
 

--- a/lib/src/value/number/single_unit.dart
+++ b/lib/src/value/number/single_unit.dart
@@ -18,8 +18,11 @@ import '../number.dart';
 /// sets in this list.
 const _knownCompatibilities = [
   {
-    "em", "ex", "ch", "rem", "vw", "vh", "vmin", "vmax", "cm", "mm", "q", //
-    "in", "pt", "pc", "px"
+    "em", "rem", "ex", "rex", "cap", "rcap", "ch", "rch", "ic", "ric", "lh", //
+    "rlh", "vw", "lvw", "svw", "dvw", "vh", "lvh", "svh", "dvh", "vi", "lvi", //
+    "svi", "dvi", "vb", "lvb", "svb", "dvb", "vmin", "lvmin", "svmin", //
+    "dvmin", "vmax", "lvmax", "svmax", "dvmax", "cqw", "cqh", "cqi", "cqb", //
+    "cqmin", "cqmax", "cm", "mm", "q", "in", "pt", "pc", "px"
   },
   {"deg", "grad", "rad", "turn"},
   {"s", "ms"},

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  sass: 1.57.2
+  sass: 1.58.0
 
 dev_dependencies:
   dartdoc: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.57.2-dev
+version: 1.58.0-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This allows more validation of wrong computations in first-class calc.

This adds the missing font-relative and viewport-relative units from https://drafts.csswg.org/css-values-4/#font-relative-lengths