### PR TITLE
Return an error when using a custom property in a propset instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Produce a better error message for a number with a leading `+` or `-`, a
   decimal point, but no digits.
 
+* Produce a better error message for a nested property whose name starts with
+  `--`.
+
 ## 1.57.1
 
 * No user-visible changes.

--- a/lib/src/ast/sass/statement/declaration.dart
+++ b/lib/src/ast/sass/statement/declaration.dart
@@ -42,25 +42,14 @@ class Declaration extends ParentStatement {
   bool get isCustomProperty => name.initialPlain.startsWith('--');
 
   /// Creates a declaration with no children.
-  Declaration(this.name, this.value, this.span) : super(null) {
-    if (isCustomProperty && value is! StringExpression) {
-      throw ArgumentError(
-          'Declarations whose names begin with "--" must have StringExpression '
-          'values (was `$value` of type ${value.runtimeType}).');
-    }
-  }
+  Declaration(this.name, this.value, this.span) : super(null);
 
   /// Creates a declaration with children.
   ///
   /// For these declarations, a value is optional.
   Declaration.nested(this.name, Iterable<Statement> children, this.span,
       {this.value})
-      : super(List.unmodifiable(children)) {
-    if (isCustomProperty && value is! StringExpression) {
-      throw ArgumentError(
-          'Declarations whose names begin with "--" may not be nested.');
-    }
-  }
+      : super(List.unmodifiable(children));
 
   T accept<T>(StatementVisitor<T> visitor) => visitor.visitDeclaration(this);
 

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -1126,6 +1126,11 @@ class _EvaluateVisitor
       throw _exception(
           "Declarations may only be used within style rules.", node.span);
     }
+    if (_declarationName != null && node.isCustomProperty) {
+      throw _exception(
+          'Declarations whose names begin with "--" may not be nested.',
+          node.span);
+    }
 
     var name = _interpolationToValue(node.name, warnForColor: true);
     if (_declarationName != null) {


### PR DESCRIPTION
Fixes: https://github.com/sass/dart-sass/issues/1857
See: https://github.com/sass/sass-spec/pull/1873