### PR TITLE
Update and lock sass_api version when releasing dart-sass-embedded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,8 +488,8 @@ jobs:
       - name: Get version
         id: version
         run: |
-          echo "sass=${GITHUB_REF##*/}" | tee -a $GITHUB_OUTPUT
-          echo "sass_api=$(curl -fsSL https://raw.githubusercontent.com/sass/dart-sass/${GITHUB_REF##*/}/pkg/sass_api/pubspec.yaml | yq .version)" | tee -a $GITHUB_OUTPUT
+          echo "sass=${GITHUB_REF##*/}" | tee --append $GITHUB_OUTPUT
+          echo "sass_api=$(curl --fail --silent --show-error --location https://raw.githubusercontent.com/sass/dart-sass/${GITHUB_REF##*/}/pkg/sass_api/pubspec.yaml | yq .version)" | tee --append $GITHUB_OUTPUT
 
       - name: Update version
         run: |
@@ -517,7 +517,7 @@ jobs:
           # make sure we're releasing against the latest version of all deps.
           dart pub upgrade
 
-          curl -fsSLo CHANGELOG.md https://raw.githubusercontent.com/sass/dart-sass/${{ steps.version.outputs.sass }}/CHANGELOG.md
+          curl --fail --silent --show-error --location --output CHANGELOG.md https://raw.githubusercontent.com/sass/dart-sass/${{ steps.version.outputs.sass }}/CHANGELOG.md
 
       - uses: EndBug/add-and-commit@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,13 +487,17 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "::set-output name=version::${GITHUB_REF##*/}"
+        run: |
+          echo "sass=${GITHUB_REF##*/}" | tee -a $GITHUB_OUTPUT
+          echo "sass_api=$(curl -fsSL https://raw.githubusercontent.com/sass/dart-sass/${GITHUB_REF##*/}/pkg/sass_api/pubspec.yaml | yq .version)" | tee -a $GITHUB_OUTPUT
 
       - name: Update version
         run: |
-          sed -i 's/version: .*/version: ${{ steps.version.outputs.version }}/' pubspec.yaml
+          sed -i 's/version: .*/version: ${{ steps.version.outputs.sass }}/' pubspec.yaml
+          dart pub remove sass_api
           dart pub remove sass
-          dart pub add sass:${{ steps.version.outputs.version }}
+          dart pub add sass:${{ steps.version.outputs.sass }}
+          dart pub add sass_api:^${{ steps.version.outputs.sass_api }}
 
           # Delete a dependency override on Sass if it exists, and delete the
           # dependency_overrides field if it's now empty. The embedded compiler
@@ -513,11 +517,11 @@ jobs:
           # make sure we're releasing against the latest version of all deps.
           dart pub upgrade
 
-          curl https://raw.githubusercontent.com/sass/dart-sass/${{ steps.version.outputs.version }}/CHANGELOG.md > CHANGELOG.md
+          curl -fsSLo CHANGELOG.md https://raw.githubusercontent.com/sass/dart-sass/${{ steps.version.outputs.sass }}/CHANGELOG.md
 
       - uses: EndBug/add-and-commit@v8
         with:
           author_name: Sass Bot
           author_email: sass.bot.beep.boop@gmail.com
           message: Update Dart Sass version and release
-          tag: ${{ steps.version.outputs.version }}
+          tag: ${{ steps.version.outputs.sass }}


### PR DESCRIPTION
This PR should fix the recent release failure: https://github.com/sass/dart-sass/actions/runs/4059809489/jobs/6988410784

@nex3