### PR TITLE
Update synchronization tests to verify the entire file

### DIFF
--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -1122,6 +1122,11 @@ class _EvaluateVisitor
       throw _exception(
           "Declarations may only be used within style rules.", node.span);
     }
+    if (_declarationName != null && node.isCustomProperty) {
+      throw _exception(
+          'Declarations whose names begin with "--" may not be nested.',
+          node.span);
+    }
 
     var name = await _interpolationToValue(node.name, warnForColor: true);
     if (_declarationName != null) {

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: a14e075a5435c7457d1d1371d8b97dd327a66ec4
+// Checksum: a8472983eeb4c8348befed4953326f285b68c4a8
 //
 // ignore_for_file: unused_import
 

--- a/lib/src/visitor/find_dependencies.dart
+++ b/lib/src/visitor/find_dependencies.dart
@@ -104,5 +104,8 @@ class DependencyReport {
   Set<Uri> get all => UnionSet({uses, forwards, metaLoadCss, imports});
 
   DependencyReport._(
-      {required this.uses, required this.forwards, required this.metaLoadCss, required this.imports});
+      {required this.uses,
+      required this.forwards,
+      required this.metaLoadCss,
+      required this.imports});
 }

--- a/test/double_check_test.dart
+++ b/test/double_check_test.dart
@@ -5,7 +5,6 @@
 import 'dart:io';
 import 'dart:convert';
 
-import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -16,21 +15,13 @@ import '../tool/grind/synchronize.dart' as synchronize;
 /// Tests that double-check that everything in the repo looks sensible.
 void main() {
   group("synchronized file is up-to-date:", () {
-    /// The pattern of a checksum in a generated file.
-    var checksumPattern = RegExp(r"^// Checksum: (.*)$", multiLine: true);
-
     synchronize.sources.forEach((sourcePath, targetPath) {
       test(targetPath, () {
-        var message = "$targetPath is out-of-date.\n"
-            "Run pub run grinder to update it.";
-
-        var target = File(targetPath).readAsStringSync();
-        var match = checksumPattern.firstMatch(target);
-        if (match == null) fail(message);
-
-        var source = File(sourcePath).readAsBytesSync();
-        var expectedHash = sha1.convert(source).toString();
-        expect(match[1], equals(expectedHash), reason: message);
+        if (File(targetPath).readAsStringSync() !=
+            synchronize.synchronizeFile(sourcePath)) {
+          fail("$targetPath is out-of-date.\n"
+              "Run `dart pub run grinder` to update it.");
+        }
       });
     });
   },

--- a/tool/grind/synchronize.dart
+++ b/tool/grind/synchronize.dart
@@ -43,15 +43,19 @@ final _sharedClasses = const ['EvaluateResult'];
 /// to a synchronous equivalent.
 @Task('Compile async code to synchronous code.')
 void synchronize() {
-  sources.forEach((source, target) {
-    var visitor = _Visitor(File(source).readAsStringSync(), source);
+  sources.forEach((source, target) =>
+      File(target).writeAsStringSync(synchronizeFile(source)));
+}
 
-    parseFile(path: source, featureSet: FeatureSet.latestLanguageVersion())
-        .unit
-        .accept(visitor);
-    var formatted = DartFormatter().format(visitor.result);
-    File(target).writeAsStringSync(formatted);
-  });
+/// Returns the result of synchronizing [source].
+String synchronizeFile(String source) {
+  source = p.absolute(source);
+  var visitor = _Visitor(File(source).readAsStringSync(), source);
+
+  parseFile(path: source, featureSet: FeatureSet.latestLanguageVersion())
+      .unit
+      .accept(visitor);
+  return DartFormatter().format(visitor.result);
 }
 
 /// The visitor that traverses the asynchronous parse tree and converts it to


### PR DESCRIPTION
This catches cases where the target file is edited directly without
also editing the source file.

Also re-run `pub run grinder`.