### PR TITLE
Require node>=14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.60.0
+
+* **Potentially breaking change:** Drop support for End-of-Life Node.js 12.
+
 ## 1.59.2
 
 * No user-visible changes.

--- a/package/package.json
+++ b/package/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/nex3"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "chokidar": ">=3.0.0 <4.0.0",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.59.3
+version: 1.60.0-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This PR updates node version requirement to align with compatibility policy in README.

- Closes #1909
- Closes #1910
- Closes #1912
- Closes #1914
- Closes #1915