### PR TITLE
Remove Node 12 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,11 +140,6 @@ jobs:
         dart_channel: [stable]
         node_version: [18]
         include:
-          # Temporarily adding back Node 12 here until we actually drop support
-          # in the package.json.
-          - os: ubuntu-latest
-            dart_channel: stable
-            node_version: 12
           # Include LTS versions on Ubuntu
           - os: ubuntu-latest
             dart_channel: stable


### PR DESCRIPTION
Now that we've properly dropped Node 12 support, we can remove it entirely from the CI