### PR TITLE
Fix the performance of selector span expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * **Potentially breaking change:** Drop support for End-of-Life Node.js 12.
 
+* Fix remaining cases for the performance regression introduced in 1.59.0.
+
 ### Embedded Sass
 
 * The JS embedded host now loads files from the working directory when using the

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.0
+
+* No user-visible changes.
+
 ## 6.1.0
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 6.1.0
+version: 6.2.0
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  sass: 1.60.0
+  sass: 1.61.0
 
 dev_dependencies:
   dartdoc: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.61.0-dev
+version: 1.61.0
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 
@@ -23,7 +23,7 @@ dependencies:
   path: ^1.8.0
   pub_semver: ^2.0.0
   source_maps: ^0.10.10
-  source_span: ^1.8.1
+  source_span: ^1.10.0
   stack_trace: ^1.10.0
   stream_transform: ^2.0.0
   string_scanner: ^1.1.0


### PR DESCRIPTION
Instead of calling `SourceFile.getText()`, which creates string copies
of a substantial subset of the text of the file every time, this
directly accesses the file's underlying code units without doing any
copies.

Closes #1913