### PR TITLE
Extension methods on Stream adding common transform operators.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   source_maps: ^0.10.10
   source_span: ^1.8.1
   stack_trace: ^1.10.0
-  stream_transform: ^2.0.0
+  stream_transform: ^2.1.0
   string_scanner: ^1.1.0
   term_glyph: ^1.2.0
   tuple: ^2.0.0


### PR DESCRIPTION
asyncMapBuffer, asyncMapSample, concurrentAsyncMap Alternatives to asyncMap. asyncMapBuffer prevents the callback from overlapping execution and collects events while it is executing. asyncMapSample prevents overlapping execution and discards events while it is executing. concurrentAsyncMap allows overlap and removes ordering guarantees for higher throughput.

Like asyncMap but events are buffered in a List until previous events have been processed rather than being called for each element individually.
asyncWhere 
Like where but allows an asynchronous predicate.

audit 
Waits for a period of time after receiving a value and then only emits the most recent value.

buffer 
Collects values from a source stream until a trigger stream fires and the collected values are emitted.

combineLatest, combineLatestAll 
Combine the most recent event from multiple streams through a callback or into a list.

debounce, debounceBuffer 
Prevents a source stream from emitting too frequently by dropping or collecting values that occur within a given duration.

followedBy 
Appends the values of a stream after another stream finishes.

merge, mergeAll, concurrentAsyncExpand 
Interleaves events from multiple streams into a single stream.

scan 
Scan is like fold, but instead of producing a single value it yields each intermediate accumulation.

startWith, startWithMany, startWithStream 
Prepend a value, an iterable, or a stream to the beginning of another stream.

switchMap, switchLatest 
Flatten a Stream of Streams into a Stream which forwards values from the most recent Stream

takeUntil 
Let values through until a Future fires.

tap 
Taps into a single-subscriber stream to react to values as they pass, without being a real subscriber.

throttle 
Blocks events for a duration after an event is successfully emitted.

whereType 
Like Iterable.whereType for a stream.

Comparison to Rx Operators 
The semantics and naming in this package have some overlap, and some conflict, with the [ReactiveX](https://reactivex.io/) suite of libraries. Some of the conflict is intentional - Dart Stream predates Observable and coherence with the Dart ecosystem semantics and naming is a strictly higher priority than consistency with ReactiveX.