### PR TITLE
Fix printing usage when no args provided

### DIFF
--- a/bin/sass.dart
+++ b/bin/sass.dart
@@ -4,6 +4,7 @@
 
 import 'dart:isolate';
 
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:stack_trace/stack_trace.dart';
 import 'package:term_glyph/term_glyph.dart' as term_glyph;
@@ -41,7 +42,7 @@ Future<void> main(List<String> args) async {
     }
   }
 
-  if (args.length > 0 && args[0] == '--embedded') {
+  if (args.firstOrNull == '--embedded') {
     embedded.main(args.sublist(1));
     return;
   }

--- a/bin/sass.dart
+++ b/bin/sass.dart
@@ -41,7 +41,7 @@ Future<void> main(List<String> args) async {
     }
   }
 
-  if (args[0] == '--embedded') {
+  if (args.length > 0 && args[0] == '--embedded') {
     embedded.main(args.sublist(1));
     return;
   }


### PR DESCRIPTION
This PR fixes the following exception when running `sass` without any arguments:

```
Unhandled exception:
RangeError (index): Invalid value: Valid value range is empty: 0
#0      _Array.[] (dart:core-patch/array.dart:10)
#1      main (file:///Users/ntkme/Developer/dart-sass/bin/sass.dart:44)
#2      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:294)
#3      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:189)
```