### PR TITLE
Address deprecation warning in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,7 +550,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "::set-output name=version::${GITHUB_REF##*/}"
+        run: echo "version=${GITHUB_REF##*/}" | tee --append "$GITHUB_OUTPUT"
 
       - name: Update version
         run: |


### PR DESCRIPTION
This PR addresses one deprecation warning. More warnings are addressed in https://github.com/sass/clone-linked-repo/pull/8.