### PR TITLE
Add current stylesheet to loadedUrls when throwing parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.63.4
+
+### Embedded Sass
+
+* Properly include the root stylesheet's URL in the set of loaded URLs when it
+  fails to parse.
+
 ## 1.63.3
 
 ### JavaScript API

--- a/lib/src/ast/sass/statement/stylesheet.dart
+++ b/lib/src/ast/sass/statement/stylesheet.dart
@@ -76,15 +76,22 @@ class Stylesheet extends ParentStatement<List<Statement>> {
   /// Throws a [SassFormatException] if parsing fails.
   factory Stylesheet.parse(String contents, Syntax syntax,
       {Object? url, Logger? logger}) {
-    switch (syntax) {
-      case Syntax.sass:
-        return Stylesheet.parseSass(contents, url: url, logger: logger);
-      case Syntax.scss:
-        return Stylesheet.parseScss(contents, url: url, logger: logger);
-      case Syntax.css:
-        return Stylesheet.parseCss(contents, url: url, logger: logger);
-      default:
-        throw ArgumentError("Unknown syntax $syntax.");
+    try {
+      switch (syntax) {
+        case Syntax.sass:
+          return Stylesheet.parseSass(contents, url: url, logger: logger);
+        case Syntax.scss:
+          return Stylesheet.parseScss(contents, url: url, logger: logger);
+        case Syntax.css:
+          return Stylesheet.parseCss(contents, url: url, logger: logger);
+        default:
+          throw ArgumentError("Unknown syntax $syntax.");
+      }
+    } on SassException catch (error) {
+      var url = error.span.sourceUrl;
+      if (url == null || url.toString() == 'stdin') rethrow;
+
+      throw error.withLoadedUrls(Set.unmodifiable({url}));
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.63.3
+version: 1.63.4-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This PR fixes the bug where the `loadedUrls` on `Exception` would be empty when throwing a parsing error on root stylesheet:

``` js
sass.compileString(`a { `, { url: new URL('file:///a.scss' ) });
```

The root cause is that root stylesheet parsing error is thrown by `Stylesheet.parse` before the evaluation starts in `_compileStylesheet`.
