### PR TITLE
Limit pool size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.63.5
+
+### Embedded Sass
+
+* Fix a deadlock when running at high concurrency on 32-bit systems.
+
 ## 1.63.4
 
 ### JavaScript API

--- a/lib/src/embedded/isolate_dispatcher.dart
+++ b/lib/src/embedded/isolate_dispatcher.dart
@@ -3,6 +3,7 @@
 // https://opensource.org/licenses/MIT.
 
 import 'dart:async';
+import 'dart:ffi';
 import 'dart:io';
 import 'dart:isolate';
 import 'dart:typed_data';
@@ -51,9 +52,10 @@ class IsolateDispatcher {
   /// A pool controlling how many isolates (and thus concurrent compilations)
   /// may be live at once.
   ///
-  /// More than 15 concurrent `waitFor()` calls seems to deadlock the Dart VM,
-  /// even across isolates. See sass/dart-sass#1959.
-  final _isolatePool = Pool(15);
+  /// More than MaxMutatorThreadCount isolates in the same isolate group
+  /// can deadlock the Dart VM.
+  /// See https://github.com/sass/dart-sass/pull/2019
+  final _isolatePool = Pool(sizeOf<IntPtr>() <= 4 ? 7 : 15);
 
   /// Whether the underlying channel has closed and the dispatcher is shutting
   /// down.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.63.4
+version: 1.63.5-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Currently we limit the isolate pool size to 15 as we know 16 isolates would deadlock. However, it turns out on 32-bit Dart SDK it would deadlock with 8 isolates.

The issue is that in Dart SDK having more than `MaxMutatorThreadCount` number of isolates would deadlock the whole Dart VM:

- https://github.com/dart-lang/sdk/issues/51254

The number of `MaxMutatorThreadCount` is determined through the following logic: 

https://github.com/dart-lang/sdk/blob/3.0.5/runtime/bin/main_impl.cc#L1174-L1181

``` cpp
  // When running from the command line we assume that we are optimizing for
  // throughput, and therefore use a larger new gen semi space size and a faster
  // new gen growth factor unless others have been specified.
  if (kWordSize <= 4) {
    vm_options.AddArgument("--new_gen_semi_max_size=16");
  } else {
    vm_options.AddArgument("--new_gen_semi_max_size=32");
  }
```

https://github.com/dart-lang/sdk/blob/3.0.5/runtime/vm/heap/scavenger.h#L121

``` cpp
  static const intptr_t kTLABSize = 512 * KB;
```

https://github.com/dart-lang/sdk/blob/3.0.5/runtime/vm/heap/scavenger.h#L222-L231

``` cpp
  // The maximum number of Dart mutator threads we allow to execute at the same
  // time.
  static intptr_t MaxMutatorThreadCount() {
    // With a max new-space of 16 MB and 512kb TLABs we would allow up to 8
    // mutator threads to run at the same time.
    const intptr_t max_parallel_tlab_usage =
        (FLAG_new_gen_semi_max_size * MB) / Scavenger::kTLABSize;
    const intptr_t max_pool_size = max_parallel_tlab_usage / 4;
    return max_pool_size > 0 ? max_pool_size : 1;
  }
```

For current Dart SDK:

- 32-bit: `16MB / 512KB / 4 = 8`
- 64-bit: `32MB / 512KB / 4 = 16`

Main isolate counts as one so the limit is really 7 for 32-bit and 15 for 64 bit.

Unfortunately, there is no programatic way to get `MaxMutatorThreadCount` from Dart code, so we can only hard code for whatever is the default today.