### PR TITLE
Un-skip a test

### DIFF
--- a/test/embedded/protocol_test.dart
+++ b/test/embedded/protocol_test.dart
@@ -245,7 +245,7 @@ void main() {
     }
 
     await process.close();
-  }, skip: "Enable once dart-lang/stream_channel#92 is released");
+  });
 
   test("doesn't include a source map by default", () async {
     process.send(compileString("a {b: 1px + 2px}"));


### PR DESCRIPTION
This should pass now that dart-lang/stream_channel#92 has landed and been released.