### PR TITLE
Check the fs library to determine if we're on Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   emitted in source order as much as possible, instead of always being emitted
   after the CSS of all module dependencies.
 
+### JavaScript API
+
+* Produce a better error message when an environment that supports some Node.js
+  APIs loads the browser entrypoint but attempts to access the filesystem.
+
 ### Embedded Sass
 
 * Fix a bug where nested relative `@imports` failed to load when using the

--- a/lib/src/io/node.dart
+++ b/lib/src/io/node.dart
@@ -230,7 +230,16 @@ bool get isMacOS => process?.platform == 'darwin';
 
 bool get isJS => true;
 
-bool get isNode => process != null;
+/// The fs module object, used to check whether this has been loaded as Node.
+///
+/// It's safest to check for a library we load in manually rather than one
+/// that's ambiently available so that we don't get into a weird state in
+/// environments like VS Code that support some Node.js libraries but don't load
+/// Node.js entrypoints for dependencies.
+@JS('fs')
+external final Object? _fsNullable;
+
+bool get isNode => _fsNullable != null;
 
 bool get isBrowser => isJS && !isNode;
 


### PR DESCRIPTION
This fixes an issue where some environments (like VS Code) define
`process` but don't load the Node.js entrypoint, causing Sass to think
it's running under Node without access to its Node dependencies.

Closes #2032