### PR TITLE
Do not validate a CSS declaration if its key is interpolated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   emitted in source order as much as possible, instead of always being emitted
   after the CSS of all module dependencies.
 
+* Fix a bug where an interpolation in a custom property name crashed if the file
+  was loaded by a `@use` nested in an `@import`.
+
 ### JavaScript API
 
 * Produce a better error message when an environment that supports some Node.js

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -3034,7 +3034,7 @@ class _EvaluateVisitor
 
   Future<void> visitCssDeclaration(CssDeclaration node) async {
     _parent.addChild(ModifiableCssDeclaration(node.name, node.value, node.span,
-        parsedAsCustomProperty: node.isCustomProperty,
+        parsedAsCustomProperty: node.parsedAsCustomProperty,
         valueSpanForMap: node.valueSpanForMap));
   }
 

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 0f0705b9773f694816ebf00cc91f43146d8c46ab
+// Checksum: 81aac8d1ac5bea43a019307cc5eb754610b0c6be
 //
 // ignore_for_file: unused_import
 
@@ -3009,7 +3009,7 @@ class _EvaluateVisitor
 
   void visitCssDeclaration(CssDeclaration node) {
     _parent.addChild(ModifiableCssDeclaration(node.name, node.value, node.span,
-        parsedAsCustomProperty: node.isCustomProperty,
+        parsedAsCustomProperty: node.parsedAsCustomProperty,
         valueSpanForMap: node.valueSpanForMap));
   }
 


### PR DESCRIPTION
Specs: https://github.com/sass/sass-spec/pull/1923
Fixes: https://github.com/sass/dart-sass/issues/2023