### PR TITLE
Fix an error during embedded compiler shutdown

### DIFF
--- a/lib/src/embedded/dispatcher.dart
+++ b/lib/src/embedded/dispatcher.dart
@@ -266,6 +266,12 @@ final class Dispatcher {
     _send(message);
 
     var packet = _mailbox.take();
+    if (packet.isEmpty) {
+      // Compiler is shutting down, throw without calling `_handleError` as we
+      // don't want to report this as an actual error.
+      _requestError = true;
+      throw StateError('Compiler is shutting down.');
+    }
 
     try {
       var messageBuffer =


### PR DESCRIPTION
@nex3 This PR fixes the error in this failed CI run: https://github.com/sass/dart-sass/actions/runs/6254921481/job/16983359566?pr=2090