### PR TITLE
Avoid useless allocations for interpolations without maps

### DIFF
--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -3403,7 +3403,7 @@ final class _EvaluateVisitor
   Future<String> _performInterpolation(Interpolation interpolation,
       {bool warnForColor = false}) async {
     var (result, _) = await _performInterpolationHelper(interpolation,
-        sourceMap: true, warnForColor: warnForColor);
+        sourceMap: false, warnForColor: warnForColor);
     return result;
   }
 

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 7669de19668af665d1a9a60cf67e53e071bf415e
+// Checksum: 1c3027293ac9cb8a0d03b18c9ca447d62c2733d7
 //
 // ignore_for_file: unused_import
 
@@ -3372,7 +3372,7 @@ final class _EvaluateVisitor
   String _performInterpolation(Interpolation interpolation,
       {bool warnForColor = false}) {
     var (result, _) = _performInterpolationHelper(interpolation,
-        sourceMap: true, warnForColor: warnForColor);
+        sourceMap: false, warnForColor: warnForColor);
     return result;
   }
 


### PR DESCRIPTION
The `_performInterpolationHelper` method was implemented with support for skipping the allocation of the InterpolationMap, but `_performInterpolation` was not using that feature, allocating an InterpolationMap to would be ignored.