### PR TITLE
Implement support for the relative color syntax of CSS Color 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.68.1
+## 1.69.0
+
+* Add support for the relative color syntax from CSS Color 5. This syntax
+  cannot be used to create Sass color values. It is always emitted as-is in the
+  CSS output.
 
 ### Dart API
 

--- a/lib/src/functions/color.dart
+++ b/lib/src/functions/color.dart
@@ -736,6 +736,14 @@ Object /* SassString | List<Value> */ _parseChannels(
   }
 
   var list = channels.asList;
+  if (list.length > 1) {
+    switch (list[0]) {
+      case SassString(:var text, hasQuotes: false)
+          when equalsIgnoreCase(text, "from"):
+        return _functionString(name, [originalChannels]);
+    }
+  }
+
   if (list.length > 3) {
     throw SassScriptException("Only 3 elements allowed, but ${list.length} "
         "were passed.");

--- a/lib/src/functions/color.dart
+++ b/lib/src/functions/color.dart
@@ -736,12 +736,9 @@ Object /* SassString | List<Value> */ _parseChannels(
   }
 
   var list = channels.asList;
-  if (list.length > 1) {
-    switch (list[0]) {
-      case SassString(:var text, hasQuotes: false)
-          when equalsIgnoreCase(text, "from"):
-        return _functionString(name, [originalChannels]);
-    }
+  if (list case [SassString(:var text, hasQuotes: false), _, ...]
+      when equalsIgnoreCase(text, "from")) {
+    return _functionString(name, [originalChannels]);
   }
 
   if (list.length > 3) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.68.1-dev
+version: 1.69.0-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Implements the change for https://github.com/sass/sass/pull/3673

https://github.com/sass/sass-spec/pull/1940