### PR TITLE
Add compatibility with Node.js 21.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.69.5
+
+### JS API
+
+* Compatibility with Node.js 21.0.0.
+
 ## 1.69.4
 
 * No user-visible changes.

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.2.5
+
+* No user-visible changes.
+
 ## 9.2.4
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 9.2.4
+version: 9.2.5
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sass: 1.69.4
+  sass: 1.69.5
 
 dev_dependencies:
   dartdoc: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.69.4
+version: 1.69.5
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
See dart-lang/sdk#53784. Although Node.js 21.1.0 fixed the issue on
its end, this release will use Dart 3.1.5 which will ensure we're
compatible even with the earlier release as well.