### PR TITLE
Remove dead code in the extension store

### DIFF
--- a/lib/src/extend/extension_store.dart
+++ b/lib/src/extend/extension_store.dart
@@ -355,11 +355,6 @@ class ExtensionStore {
           }
         }
       }
-
-      // If [selectors] doesn't contain [extension.extender], for example if it
-      // was replaced due to :not() expansion, we must get rid of the old
-      // version.
-      if (!containsExtension) sources.remove(extension.extender);
     }
 
     return additionalExtensions;


### PR DESCRIPTION
The `sources` Map will never contain `extension.extender` as it is an `Extender` object, not a ComplexSelector.
I updated that by assuming that the comment just above it is true and that the selector should actually be removed.
An alternative could be to remove that line of code entirely, preserving the current behavior where nothing is removed.

The dart compiler does not catch this mistake as `Map.remove` allows passing any object, not just objects matching the key type.

I caught this when porting that code to PHP for the Scssphp project, where phpstan (the PHP static analyzer we use) has a different signature for the storage we use, requiring a valid key type.