### PR TITLE
Escape non-US-ASCII characters in `SassException.toCssString()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.69.6
 
+* When generating CSS error messages to display in-browser, escape all code
+  points that aren't in the US-ASCII region. Previously only code points U+0100
+  LATIN CAPITAL LETTER A WITH MACRON were escaped.
+
 ### JS API
 
 * Fix a bug where certain exceptions could produce `SourceSpan`s that didn't

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -82,12 +82,12 @@ class SassException extends SourceSpanException {
         .replaceAll("\r\n", "\n");
     term_glyph.ascii = wasAscii;
 
-    // For the string comment, render all non-ASCII characters as escape
+    // For the string comment, render all non-US-ASCII characters as escape
     // sequences so that they'll show up even if the HTTP headers are set
     // incorrectly.
     var stringMessage = StringBuffer();
     for (var rune in SassString(toString(color: false)).toString().runes) {
-      if (rune > 0xFF) {
+      if (rune > 0x7F) {
         stringMessage
           ..writeCharCode($backslash)
           ..write(rune.toRadixString(16))


### PR DESCRIPTION
Currently `SassException.toCssString()` would write code points between 128 and 255 in UTF-8. The result cannot be parsed as US-ASCII (ASCII-7BIT).

UTF-8 encoded file with only code points less than 128 is completely interchangeable with US-ASCII. Therefore, this PR further escapes code points between 128 and 255. 