### PR TITLE
Escape unprintable 0x7F (delete control character)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Produce better output for numbers with complex units in `meta.inspect()` and
   debugging messages.
 
+* Escape U+007F DELETE when serializing strings.
+
 * When generating CSS error messages to display in-browser, escape all code
   points that aren't in the US-ASCII region. Previously only code points U+0100
   LATIN CAPITAL LETTER A WITH MACRON were escaped.

--- a/lib/src/visitor/serialize.dart
+++ b/lib/src/visitor/serialize.dart
@@ -1072,7 +1072,8 @@ final class _SerializeVisitor
               $fs ||
               $gs ||
               $rs ||
-              $us:
+              $us ||
+              $del:
           _writeEscape(buffer, char, string, i);
 
         case $backslash:


### PR DESCRIPTION
This PR adds 0x7F (delete control character) to the escape list as it is an unprintable ASCII control character.