### PR TITLE
Add wait time before update website

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,9 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF##*/}" | tee --append "$GITHUB_OUTPUT"
 
+      - name: Wait for npm registry's CDN to catch up on replications
+        run: sleep 600
+
       - name: Update Dart Sass version
         run: npm install sass@${{ steps.version.outputs.version }}
 


### PR DESCRIPTION
We have hit this issue multiple times in the past. While there is a few reports of the same kind of delay, there isn't much technical explanation available.

According to [a super old npm blog article from 2014](https://blog.npmjs.org/post/75707294465/new-npm-registry-architecture.html):

> Your replications might be a few seconds or minutes behind the official database of record.

The delay is likely that the time taken for each CDN node to replicate the CouchDB metadata containing the package list, and it can take up to minutes. Therefore this PR goes conservative and adds 10 minutes delay before we update the website, trying to minimize chance of failure.

cc @nex3  