### PR TITLE
Use implementation name dart-sass for VersionResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.69.8
+
+### Embedded Sass
+
+* The Dart Sass embedded compiler now reports its name as "dart-sass" rather
+  than "Dart Sass", to match the JS API's `info` field.
+
 ## 1.69.7
 
 ### Embedded Sass

--- a/lib/src/embedded/isolate_dispatcher.dart
+++ b/lib/src/embedded/isolate_dispatcher.dart
@@ -137,7 +137,7 @@ class IsolateDispatcher {
       ..protocolVersion = const String.fromEnvironment("protocol-version")
       ..compilerVersion = const String.fromEnvironment("compiler-version")
       ..implementationVersion = const String.fromEnvironment("compiler-version")
-      ..implementationName = "Dart Sass";
+      ..implementationName = "dart-sass";
   }
 
   /// Handles an error thrown by the dispatcher or code it dispatches to.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.69.7
+version: 1.69.8-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/test/embedded/protocol_test.dart
+++ b/test/embedded/protocol_test.dart
@@ -96,7 +96,7 @@ void main() {
     Version.parse(response.protocolVersion); // shouldn't throw
     Version.parse(response.compilerVersion); // shouldn't throw
     Version.parse(response.implementationVersion); // shouldn't throw
-    expect(response.implementationName, equals("Dart Sass"));
+    expect(response.implementationName, equals("dart-sass"));
     await process.close();
   });
 


### PR DESCRIPTION
This is mostly cosmetic.

As documented by https://sass-lang.com/documentation/js-api/variables/info/:

> For Dart Sass, the implementation name is `dart-sass`.

The motivation is that I'm [enhancing the `.info` string for ruby host](https://github.com/sass-contrib/sass-embedded-host-ruby/commit/d6ed0d95e41f8789bd1b0df1f47c4cca5d0e4022), and I want to use the implementation name returned by the VersionResponse and produce an output like below:

```
irb(main):001> require 'sass-embedded';
irb(main):002> puts Sass.info;
sass-embedded	1.69.6	(Embedded Host)	[Ruby]
dart-sass	1.69.6	(Sass Compiler)	[Dart]
```