### PR TITLE
Use macos-14 runner instead of macos-latest-xlarge runner

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,9 +16,9 @@ jobs:
         include:
           - arch: x64
             runner: macos-latest
-          # https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+          # https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
           - arch: arm64
-            runner: macos-latest-xlarge
+            runner: macos-14
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - arch: x64
-            runner: macos-latest
+            runner: macos-13
           # https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
           - arch: arm64
             runner: macos-14

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,7 +16,6 @@ jobs:
         include:
           - arch: x64
             runner: macos-13
-          # https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
           - arch: arm64
             runner: macos-14
 


### PR DESCRIPTION
GitHub now offers a free m1 runner for open source: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

This PR switches from the paid runner to the free runner.