### PR TITLE
Use musl support in cli_pkg

### DIFF
--- a/.github/workflows/build-linux-musl.yml
+++ b/.github/workflows/build-linux-musl.yml
@@ -20,8 +20,12 @@ jobs:
             platform: linux/386
           - arch: arm64
             platform: linux/arm64
+          # There is a bug in qemu's mremap causing pthread_getattr_np in musl to stuck in a loop on arm.
+          # Unless qemu fixes the bug or we get a real linux-arm runner, we cannot build aot-snapshot
+          # for arm on CI. So, we create a kernel snapshot for arm build in amd64 container instead.
+          # https://gitlab.com/qemu-project/qemu/-/issues/1729
           - arch: arm
-            platform: linux/arm/v7
+            platform: linux/amd64 # linux/arm/v7
 
     steps:
       - uses: actions/checkout@v4
@@ -41,11 +45,6 @@ jobs:
           dart run grinder protobuf
           EOF
 
-      # https://gitlab.com/qemu-project/qemu/-/issues/1729
-      #
-      # There is a bug in qemu's mremap causing pthread_getattr_np in musl to stuck in a loop on arm.
-      # Unless qemu fixes the bug or we get a real linux-arm runner, we cannot build aot-snapshot
-      # for arm on CI. So, we create a kernel snapshot for arm build in amd64 container instead.
       - name: Build
         run: |
           docker run --rm -i \
@@ -58,26 +57,6 @@ jobs:
           dart run grinder pkg-standalone-linux-${{ matrix.arch }}
           # Rename the artifact from -linux- to -linux-musl- to avoid conflict with glibc builds.
           find build -name '*.tar.gz' -print0 | xargs -0 -n 1 -- sh -xc 'mv "$1" "$(echo "$1" | sed -e "s/linux/linux-musl/")"' --
-          EOF
-
-      # The kernel snapshot created for arm in the previous step is bundling a glibc based dart runtime
-      # due to how cli_pkg downloads the sdk for building non-native platforms. Therefore we need to
-      # replace it with musl-libc based dart runtime to create a working linux-musl-arm package.
-      - name: Fix Dart Runtime
-        if: matrix.arch == 'arm'
-        run: |
-          docker run --rm -i \
-                     --platform ${{ matrix.platform }} \
-                     --volume $PWD:$PWD \
-                     --workdir $PWD \
-                     ghcr.io/dart-musl/dart <<'EOF'
-          set -e
-          apk add --no-cache tar
-          cd build
-          DART_RUNTIME=$(tar -tzf *.tar.gz --wildcards "*/src/dart")
-          tar -xzf *.tar.gz
-          cp $DART_SDK/bin/dart $DART_RUNTIME
-          tar -czf *.tar.gz "$(dirname "$(dirname "$DART_RUNTIME")")"
           EOF
 
       - name: Upload Artifact

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   args: ^2.0.0
   async: ^2.5.0
   charcode: ^1.2.0
-  cli_pkg: ^2.7.1
+  cli_pkg: ^2.8.0
   cli_repl: ^0.2.1
   collection: ^1.16.0
   http: "^1.1.0"


### PR DESCRIPTION
This PR uses the native support for building kernel snapshot for musl-linux from cli_pkg 2.8.0, instead of the current complex workaround.