### PR TITLE
Check require.main for null before getting require.main.filename

### DIFF
--- a/lib/src/js/compile.dart
+++ b/lib/src/js/compile.dart
@@ -336,8 +336,8 @@ final JSClass nodePackageImporterClass = () {
       'sass.NodePackageImporter',
       (Object self, [String? entryPointDirectory]) => NodePackageImporter(
           entryPointDirectory ??
-              (requireMainFilename != null
-                  ? p.dirname(requireMainFilename!)
+              (requireMainFilename() != null
+                  ? p.dirname(requireMainFilename()!)
                   : null)));
   return jsClass;
 }();

--- a/lib/src/js/utils.dart
+++ b/lib/src/js/utils.dart
@@ -234,6 +234,19 @@ Syntax parseSyntax(String? syntax) => switch (syntax) {
       _ => jsThrow(JsError('Unknown syntax "$syntax".'))
     };
 
-/// The value of require.main.filename
+/// The value of require.main
+@JS("require.main")
+external Object? get _requireMain;
+
+/// The value of require.main.filename. require.main is not defined when the
+/// entry point is not a CommonJS module, so this throws if require.main is
+/// null.
 @JS("require.main.filename")
-external String? get requireMainFilename;
+external String? get _unsafeRequireMainFilename;
+
+/// The value of require.main.filename, or null if require.main or
+/// require.main.filename are null.
+String? requireMainFilename =
+    _requireMain != null && _unsafeRequireMainFilename != null
+        ? _unsafeRequireMainFilename
+        : null;

--- a/lib/src/js/utils.dart
+++ b/lib/src/js/utils.dart
@@ -246,7 +246,7 @@ external String? get _unsafeRequireMainFilename;
 
 /// The value of require.main.filename, or null if require.main or
 /// require.main.filename are null.
-String? requireMainFilename =
+String? requireMainFilename() =>
     _requireMain != null && _unsafeRequireMainFilename != null
         ? _unsafeRequireMainFilename
         : null;


### PR DESCRIPTION
Addresses #2178. This allows Sass in ESM to throw with the correct error message regarding needing to set an entry point directory, instead of throwing with `reading "filename" of undefined`.