### PR TITLE
[Hotfix Node Package Importer]- Handle subpath without extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.72.0
+
+* Allow the Node.js `pkg:` importer to load Sass stylesheets for `package.json`
+  `exports` field entries without extensions.
+
 ## 1.71.1
 
 ### Command-Line Interface

--- a/lib/src/importer/node_package.dart
+++ b/lib/src/importer/node_package.dart
@@ -354,6 +354,7 @@ class NodePackageImporter extends Importer {
       paths.add(subpath);
     } else {
       paths.addAll([
+        subpath,
         '$subpath.scss',
         '$subpath.sass',
         '$subpath.css',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.71.1
+version: 1.72.0-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
https://github.com/sass/dart-sass/issues/2183

Adds `subpath` to the list of subpath variants to check. Before, only the subpath with extension or `_` were being checked.

sass- https://github.com/sass/sass/pull/3793
sass-spec- https://github.com/sass/sass-spec/pull/1960

[skip sass-embedded]
