### PR TITLE
Support linux-riscv64 and windows-arm64

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -26,6 +26,10 @@ jobs:
           - arch: arm
             lib: lib
             platform: linux/arm64
+          # There is no docker image for riscv64 dart-sdk, build kernel snapshot instead.
+          - arch: riscv64
+            lib: lib64
+            platform: linux/amd64 # linux/riscv64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-linux-musl.yml
+++ b/.github/workflows/build-linux-musl.yml
@@ -26,6 +26,9 @@ jobs:
           # https://gitlab.com/qemu-project/qemu/-/issues/1729
           - arch: arm
             platform: linux/amd64 # linux/arm/v7
+          # There is no docker image for riscv64 dart-sdk, build kernel snapshot instead.
+          - arch: riscv64
+            platform: linux/amd64 # linux/riscv64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,6 +22,10 @@ jobs:
             platform: linux/arm/v7
           - arch: arm64
             platform: linux/arm64
+          # There is no docker image for riscv64 dart-sdk, build kernel snapshot instead.
+          # https://github.com/dart-lang/dart-docker/issues/96#issuecomment-1669860829
+          - arch: riscv64
+            platform: linux/amd64 # linux/riscv64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,10 +18,8 @@ jobs:
             runner: windows-latest
           - arch: ia32
             runner: windows-latest
-          # The support of windows-arm64 dart-sdk is in beta.
-          # TODO: Enable this once windows-arm64 support is stable.
-          # - arch: arm64
-          #   runner: windows-latest
+          - arch: arm64
+            runner: windows-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.72.1
+
+* Add linux-riscv64 and windows-arm64 releases.
+
 ## 1.72.0
 
 * Support adjacent `/`s without whitespace in between when parsing plain CSS

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.72.0
+version: 1.72.1-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
As of dart-sdk 3.3.0, linux-riscv64 and windows-arm64 are now stable. We don't have a good way to build aot snapshot for these right now, such that all of them are using kernel snapshot.