### PR TITLE
Complete implementation the deprecations API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,26 @@
 
 * Add a new `--silence-deprecation` flag to match the new JS API.
 
+* Previously, if a future deprecation was passed to `--fatal-deprecation` but
+  not `--future-deprecation`, it would be treated as fatal despite not being
+  enabled. Both flags are now required to treat a future deprecation as fatal
+  with a warning emitted if `--fatal-deprecation` is passed without
+  `--future-deprecation`, matching the JS API's behavior.
+
 ### Dart API
 
 * The `compile` methods now take in a `silenceDeprecations` parameter to match
   the JS API.
+
+* Add `Deprecation.obsoleteIn` to match the JS API. This is currently null for
+  all deprecations, but will be used once some deprecations become obsolete in
+  Dart Sass 2.0.0.
+
+* Fix a bug where `compileStringToResultAsync` ignored `fatalDeprecations` and
+  `futureDeprecations`.
+
+* The behavior around making future deprecations fatal mentioned in the CLI
+  section above has also been changed in the Dart API.
 
 ## 1.73.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 1.74.0
+
+### JS API
+
+* The deprecations API is now available in the JS API! The `compile` methods
+  support the same `fatalDeprecations` and `futureDeprecations` options that
+  were already available in the Dart API and the CLI, as well as a new
+  `silenceDeprecations` option that allows you to silence deprecation warnings
+  of a given type.
+
+### Command-Line Interface
+
+* Add a new `--silence-deprecation` flag to match the new JS API.
+
+### Dart API
+
+* The `compile` methods now take in a `silenceDeprecations` parameter to match
+  the JS API.
+
 ## 1.73.0
 
 * Add support for nesting in plain CSS files. This is not processed by Sass at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,25 @@
 
 ### JS API
 
-* The deprecations API is now available in the JS API! The `compile` methods
-  support the same `fatalDeprecations` and `futureDeprecations` options that
-  were already available in the Dart API and the CLI, as well as a new
-  `silenceDeprecations` option that allows you to silence deprecation warnings
-  of a given type.
+* Add a new top-level `deprecations` object, which contains various
+  `Deprecation` objects that define the different types of deprecation used by
+  the Sass compiler and can be passed to the options below.
+
+* Add a new `fatalDeprecations` compiler option that causes the compiler to
+  error if any deprecation warnings of the provided types are encountered. You
+  can also pass in a `Version` object to treat all deprecations that were active
+  in that Dart Sass version as fatal.
+
+* Add a new `futureDeprecations` compiler option that allows you to opt-in to
+  certain deprecations early (currently just `import`).
+
+* Add a new `silenceDeprecations` compiler option to ignore any deprecation
+  warnings of the provided types.
 
 ### Command-Line Interface
 
-* Add a new `--silence-deprecation` flag to match the new JS API.
+* Add a new `--silence-deprecation` flag, which causes the compiler to ignore
+  any deprecation warnings of the provided types.
 
 * Previously, if a future deprecation was passed to `--fatal-deprecation` but
   not `--future-deprecation`, it would be treated as fatal despite not being
@@ -20,15 +30,15 @@
 
 ### Dart API
 
-* The `compile` methods now take in a `silenceDeprecations` parameter to match
-  the JS API.
+* The `compile` methods now take in a `silenceDeprecations` parameter, which
+  causes the compiler to ignore any deprecation warnings of the provided types.
 
 * Add `Deprecation.obsoleteIn` to match the JS API. This is currently null for
   all deprecations, but will be used once some deprecations become obsolete in
   Dart Sass 2.0.0.
 
-* Fix a bug where `compileStringToResultAsync` ignored `fatalDeprecations` and
-  `futureDeprecations`.
+* **Potentially breaking bug fix:** Fix a bug where `compileStringToResultAsync`
+  ignored `fatalDeprecations` and `futureDeprecations`.
 
 * The behavior around making future deprecations fatal mentioned in the CLI
   section above has also been changed in the Dart API.

--- a/bin/sass.dart
+++ b/bin/sass.dart
@@ -15,7 +15,7 @@ import 'package:sass/src/executable/watch.dart';
 import 'package:sass/src/import_cache.dart';
 import 'package:sass/src/importer/filesystem.dart';
 import 'package:sass/src/io.dart';
-import 'package:sass/src/logger/deprecation_handling.dart';
+import 'package:sass/src/logger/deprecation_processing.dart';
 import 'package:sass/src/stylesheet_graph.dart';
 import 'package:sass/src/utils.dart';
 import 'package:sass/src/embedded/executable.dart'
@@ -53,7 +53,7 @@ Future<void> main(List<String> args) async {
         // limit repetition. A separate DeprecationHandlingLogger is created for
         // each compilation, which will limit repetition if verbose is not
         // passed in addition to handling fatal/future deprecations.
-        logger: DeprecationHandlingLogger(options.logger,
+        logger: DeprecationProcessingLogger(options.logger,
             silenceDeprecations: options.silenceDeprecations,
             fatalDeprecations: options.fatalDeprecations,
             futureDeprecations: options.futureDeprecations,

--- a/bin/sass.dart
+++ b/bin/sass.dart
@@ -53,6 +53,7 @@ Future<void> main(List<String> args) async {
         // each compilation, which will limit repetition if verbose is not
         // passed in addition to handling fatal/future deprecations.
         logger: DeprecationHandlingLogger(options.logger,
+            silenceDeprecations: options.silenceDeprecations,
             fatalDeprecations: options.fatalDeprecations,
             futureDeprecations: options.futureDeprecations,
             limitRepetition: false)));

--- a/lib/sass.dart
+++ b/lib/sass.dart
@@ -108,6 +108,7 @@ CompileResult compileToResult(String path,
         bool verbose = false,
         bool sourceMap = false,
         bool charset = true,
+        Iterable<Deprecation>? silenceDeprecations,
         Iterable<Deprecation>? fatalDeprecations,
         Iterable<Deprecation>? futureDeprecations}) =>
     c.compile(path,
@@ -123,6 +124,7 @@ CompileResult compileToResult(String path,
         verbose: verbose,
         sourceMap: sourceMap,
         charset: charset,
+        silenceDeprecations: silenceDeprecations,
         fatalDeprecations: fatalDeprecations,
         futureDeprecations: futureDeprecations);
 
@@ -207,6 +209,7 @@ CompileResult compileStringToResult(String source,
         bool verbose = false,
         bool sourceMap = false,
         bool charset = true,
+        Iterable<Deprecation>? silenceDeprecations,
         Iterable<Deprecation>? fatalDeprecations,
         Iterable<Deprecation>? futureDeprecations}) =>
     c.compileString(source,
@@ -225,6 +228,7 @@ CompileResult compileStringToResult(String source,
         verbose: verbose,
         sourceMap: sourceMap,
         charset: charset,
+        silenceDeprecations: silenceDeprecations,
         fatalDeprecations: fatalDeprecations,
         futureDeprecations: futureDeprecations);
 
@@ -245,6 +249,7 @@ Future<CompileResult> compileToResultAsync(String path,
         bool verbose = false,
         bool sourceMap = false,
         bool charset = true,
+        Iterable<Deprecation>? silenceDeprecations,
         Iterable<Deprecation>? fatalDeprecations,
         Iterable<Deprecation>? futureDeprecations}) =>
     c.compileAsync(path,
@@ -260,6 +265,7 @@ Future<CompileResult> compileToResultAsync(String path,
         verbose: verbose,
         sourceMap: sourceMap,
         charset: charset,
+        silenceDeprecations: silenceDeprecations,
         fatalDeprecations: fatalDeprecations,
         futureDeprecations: futureDeprecations);
 
@@ -285,6 +291,7 @@ Future<CompileResult> compileStringToResultAsync(String source,
         bool verbose = false,
         bool sourceMap = false,
         bool charset = true,
+        Iterable<Deprecation>? silenceDeprecations,
         Iterable<Deprecation>? fatalDeprecations,
         Iterable<Deprecation>? futureDeprecations}) =>
     c.compileStringAsync(source,
@@ -302,7 +309,10 @@ Future<CompileResult> compileStringToResultAsync(String source,
         quietDeps: quietDeps,
         verbose: verbose,
         sourceMap: sourceMap,
-        charset: charset);
+        charset: charset,
+        silenceDeprecations: silenceDeprecations,
+        fatalDeprecations: fatalDeprecations,
+        futureDeprecations: futureDeprecations);
 
 /// Like [compileToResult], but returns [CompileResult.css] rather than
 /// returning [CompileResult] directly.

--- a/lib/src/async_compile.dart
+++ b/lib/src/async_compile.dart
@@ -42,10 +42,12 @@ Future<CompileResult> compileAsync(String path,
     bool verbose = false,
     bool sourceMap = false,
     bool charset = true,
+    Iterable<Deprecation>? silenceDeprecations,
     Iterable<Deprecation>? fatalDeprecations,
     Iterable<Deprecation>? futureDeprecations}) async {
   DeprecationHandlingLogger deprecationLogger = logger =
       DeprecationHandlingLogger(logger ?? Logger.stderr(),
+          silenceDeprecations: {...?silenceDeprecations},
           fatalDeprecations: {...?fatalDeprecations},
           futureDeprecations: {...?futureDeprecations},
           limitRepetition: !verbose);
@@ -106,10 +108,12 @@ Future<CompileResult> compileStringAsync(String source,
     bool verbose = false,
     bool sourceMap = false,
     bool charset = true,
+    Iterable<Deprecation>? silenceDeprecations,
     Iterable<Deprecation>? fatalDeprecations,
     Iterable<Deprecation>? futureDeprecations}) async {
   DeprecationHandlingLogger deprecationLogger = logger =
       DeprecationHandlingLogger(logger ?? Logger.stderr(),
+          silenceDeprecations: {...?silenceDeprecations},
           fatalDeprecations: {...?fatalDeprecations},
           futureDeprecations: {...?futureDeprecations},
           limitRepetition: !verbose);

--- a/lib/src/async_compile.dart
+++ b/lib/src/async_compile.dart
@@ -17,7 +17,7 @@ import 'importer/legacy_node.dart';
 import 'importer/no_op.dart';
 import 'io.dart';
 import 'logger.dart';
-import 'logger/deprecation_handling.dart';
+import 'logger/deprecation_processing.dart';
 import 'syntax.dart';
 import 'utils.dart';
 import 'visitor/async_evaluate.dart';
@@ -45,8 +45,8 @@ Future<CompileResult> compileAsync(String path,
     Iterable<Deprecation>? silenceDeprecations,
     Iterable<Deprecation>? fatalDeprecations,
     Iterable<Deprecation>? futureDeprecations}) async {
-  DeprecationHandlingLogger deprecationLogger = logger =
-      DeprecationHandlingLogger(logger ?? Logger.stderr(),
+  DeprecationProcessingLogger deprecationLogger = logger =
+      DeprecationProcessingLogger(logger ?? Logger.stderr(),
           silenceDeprecations: {...?silenceDeprecations},
           fatalDeprecations: {...?fatalDeprecations},
           futureDeprecations: {...?futureDeprecations},
@@ -111,8 +111,8 @@ Future<CompileResult> compileStringAsync(String source,
     Iterable<Deprecation>? silenceDeprecations,
     Iterable<Deprecation>? fatalDeprecations,
     Iterable<Deprecation>? futureDeprecations}) async {
-  DeprecationHandlingLogger deprecationLogger = logger =
-      DeprecationHandlingLogger(logger ?? Logger.stderr(),
+  DeprecationProcessingLogger deprecationLogger = logger =
+      DeprecationProcessingLogger(logger ?? Logger.stderr(),
           silenceDeprecations: {...?silenceDeprecations},
           fatalDeprecations: {...?fatalDeprecations},
           futureDeprecations: {...?futureDeprecations},

--- a/lib/src/compile.dart
+++ b/lib/src/compile.dart
@@ -26,7 +26,7 @@ import 'importer/legacy_node.dart';
 import 'importer/no_op.dart';
 import 'io.dart';
 import 'logger.dart';
-import 'logger/deprecation_handling.dart';
+import 'logger/deprecation_processing.dart';
 import 'syntax.dart';
 import 'utils.dart';
 import 'visitor/evaluate.dart';
@@ -54,8 +54,8 @@ CompileResult compile(String path,
     Iterable<Deprecation>? silenceDeprecations,
     Iterable<Deprecation>? fatalDeprecations,
     Iterable<Deprecation>? futureDeprecations}) {
-  DeprecationHandlingLogger deprecationLogger = logger =
-      DeprecationHandlingLogger(logger ?? Logger.stderr(),
+  DeprecationProcessingLogger deprecationLogger = logger =
+      DeprecationProcessingLogger(logger ?? Logger.stderr(),
           silenceDeprecations: {...?silenceDeprecations},
           fatalDeprecations: {...?fatalDeprecations},
           futureDeprecations: {...?futureDeprecations},
@@ -120,8 +120,8 @@ CompileResult compileString(String source,
     Iterable<Deprecation>? silenceDeprecations,
     Iterable<Deprecation>? fatalDeprecations,
     Iterable<Deprecation>? futureDeprecations}) {
-  DeprecationHandlingLogger deprecationLogger = logger =
-      DeprecationHandlingLogger(logger ?? Logger.stderr(),
+  DeprecationProcessingLogger deprecationLogger = logger =
+      DeprecationProcessingLogger(logger ?? Logger.stderr(),
           silenceDeprecations: {...?silenceDeprecations},
           fatalDeprecations: {...?fatalDeprecations},
           futureDeprecations: {...?futureDeprecations},

--- a/lib/src/compile.dart
+++ b/lib/src/compile.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_compile.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: a9421a2975e79ad591ae32474cd076e1379d0e75
+// Checksum: 9d2d66aa8a5b5613cbae25c448356526aebbadbf
 //
 // ignore_for_file: unused_import
 
@@ -51,10 +51,12 @@ CompileResult compile(String path,
     bool verbose = false,
     bool sourceMap = false,
     bool charset = true,
+    Iterable<Deprecation>? silenceDeprecations,
     Iterable<Deprecation>? fatalDeprecations,
     Iterable<Deprecation>? futureDeprecations}) {
   DeprecationHandlingLogger deprecationLogger = logger =
       DeprecationHandlingLogger(logger ?? Logger.stderr(),
+          silenceDeprecations: {...?silenceDeprecations},
           fatalDeprecations: {...?fatalDeprecations},
           futureDeprecations: {...?futureDeprecations},
           limitRepetition: !verbose);
@@ -115,10 +117,12 @@ CompileResult compileString(String source,
     bool verbose = false,
     bool sourceMap = false,
     bool charset = true,
+    Iterable<Deprecation>? silenceDeprecations,
     Iterable<Deprecation>? fatalDeprecations,
     Iterable<Deprecation>? futureDeprecations}) {
   DeprecationHandlingLogger deprecationLogger = logger =
       DeprecationHandlingLogger(logger ?? Logger.stderr(),
+          silenceDeprecations: {...?silenceDeprecations},
           fatalDeprecations: {...?fatalDeprecations},
           futureDeprecations: {...?futureDeprecations},
           limitRepetition: !verbose);

--- a/lib/src/compile.dart
+++ b/lib/src/compile.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_compile.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 9d2d66aa8a5b5613cbae25c448356526aebbadbf
+// Checksum: ab2c6fa2588988a86abdbe87512134098e01b39e
 //
 // ignore_for_file: unused_import
 

--- a/lib/src/deprecation.dart
+++ b/lib/src/deprecation.dart
@@ -107,14 +107,28 @@ enum Deprecation {
   /// what version of Dart Sass this deprecation will be live in.
   final bool isFuture;
 
+  /// Underlying version string used by [obsoleteIn].
+  ///
+  /// This is necessary because [Version] doesn't have a constant constructor,
+  /// so we can't use it directly as an enum property.
+  final String? _obsoleteIn;
+
+  /// The Dart Sass version this feature was fully removed in, making the
+  /// deprecation obsolete.
+  ///
+  /// For deprecations that are not yet obsolete, this should be null.
+  Version? get obsoleteIn => _obsoleteIn?.andThen(Version.parse);
+
   /// Constructs a regular deprecation.
   const Deprecation(this.id, {required String? deprecatedIn, this.description})
       : _deprecatedIn = deprecatedIn,
+        _obsoleteIn = null,
         isFuture = false;
 
   /// Constructs a future deprecation.
   const Deprecation.future(this.id, {this.description})
       : _deprecatedIn = null,
+        _obsoleteIn = null,
         isFuture = true;
 
   @override

--- a/lib/src/embedded/compilation_dispatcher.dart
+++ b/lib/src/embedded/compilation_dispatcher.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'dart:isolate';
 import 'dart:typed_data';
 
+import 'package:collection/collection.dart';
 import 'package:native_synchronization/mailbox.dart';
 import 'package:path/path.dart' as p;
 import 'package:protobuf/protobuf.dart';
@@ -124,6 +125,21 @@ final class CompilationDispatcher {
         : EmbeddedLogger(this,
             color: request.alertColor, ascii: request.alertAscii);
 
+    sass.Deprecation? deprecationOrWarn(String id) {
+      var deprecation = sass.Deprecation.fromId(id);
+      if (deprecation == null) {
+        logger.warn('Invalid deprecation "$id".');
+      }
+      return deprecation;
+    }
+
+    var fatalDeprecations =
+        request.fatalDeprecation.map(deprecationOrWarn).whereNotNull();
+    var silenceDeprecations =
+        request.silenceDeprecation.map(deprecationOrWarn).whereNotNull();
+    var futureDeprecations =
+        request.futureDeprecation.map(deprecationOrWarn).whereNotNull();
+
     try {
       var importers = request.importers.map((importer) =>
           _decodeImporter(request, importer) ??
@@ -148,6 +164,9 @@ final class CompilationDispatcher {
               url: input.url.isEmpty ? null : input.url,
               quietDeps: request.quietDeps,
               verbose: request.verbose,
+              fatalDeprecations: fatalDeprecations,
+              silenceDeprecations: silenceDeprecations,
+              futureDeprecations: futureDeprecations,
               sourceMap: request.sourceMap,
               charset: request.charset);
 
@@ -165,6 +184,9 @@ final class CompilationDispatcher {
                 style: style,
                 quietDeps: request.quietDeps,
                 verbose: request.verbose,
+                fatalDeprecations: fatalDeprecations,
+                silenceDeprecations: silenceDeprecations,
+                futureDeprecations: futureDeprecations,
                 sourceMap: request.sourceMap,
                 charset: request.charset);
           } on FileSystemException catch (error) {

--- a/lib/src/embedded/logger.dart
+++ b/lib/src/embedded/logger.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 import 'package:stack_trace/stack_trace.dart';
 
+import '../deprecation.dart';
 import '../logger.dart';
 import '../util/nullable.dart';
 import '../utils.dart';
@@ -14,7 +15,7 @@ import 'embedded_sass.pb.dart' hide SourceSpan;
 import 'utils.dart';
 
 /// A Sass logger that sends log messages as `LogEvent`s.
-final class EmbeddedLogger implements Logger {
+final class EmbeddedLogger implements DeprecationLogger {
   /// The [CompilationDispatcher] to which to send events.
   final CompilationDispatcher _dispatcher;
 
@@ -40,7 +41,10 @@ final class EmbeddedLogger implements Logger {
   }
 
   void warn(String message,
-      {FileSpan? span, Trace? trace, bool deprecation = false}) {
+      {FileSpan? span,
+      Trace? trace,
+      bool deprecation = false,
+      Deprecation? deprecationType}) {
     var formatted = withGlyphs(() {
       var buffer = StringBuffer();
       if (_color) {
@@ -71,6 +75,7 @@ final class EmbeddedLogger implements Logger {
       ..formatted = formatted;
     if (span != null) event.span = protofySpan(span);
     if (trace != null) event.stackTrace = trace.toString();
+    if (deprecationType != null) event.deprecationType = deprecationType.id;
     _dispatcher.sendLog(event);
   }
 }

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -290,10 +290,3 @@ class MultiSpanSassScriptException extends SassScriptException {
   MultiSpanSassException withSpan(FileSpan span) =>
       MultiSpanSassException(message, span, primaryLabel, secondarySpans);
 }
-
-/// An exception indicating that invalid arguments were passed.
-class UsageException implements Exception {
-  final String message;
-
-  UsageException(this.message);
-}

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -290,3 +290,10 @@ class MultiSpanSassScriptException extends SassScriptException {
   MultiSpanSassException withSpan(FileSpan span) =>
       MultiSpanSassException(message, span, primaryLabel, secondarySpans);
 }
+
+/// An exception indicating that invalid arguments were passed.
+class UsageException implements Exception {
+  final String message;
+
+  UsageException(this.message);
+}

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -91,45 +91,14 @@ final class ExecutableOptions {
               "Stylesheets imported through load paths count as dependencies.")
       ..addFlag('verbose',
           help: "Print all deprecation warnings even when they're repetitive.")
-      ..addMultiOption('silence-deprecation',
-          help: 'Deprecations to ignore.',
-          allowedHelp: {
-            for (var deprecation in Deprecation.values)
-              if (deprecation
-                  case Deprecation(
-                    deprecatedIn: Version(),
-                    obsoleteIn: null,
-                    :var description?
-                  ))
-                deprecation.id: description,
-          })
       ..addMultiOption('fatal-deprecation',
           help: 'Deprecations to treat as errors. You may also pass a Sass\n'
               'version to include any behavior deprecated in or before it.\n'
               'See https://sass-lang.com/documentation/breaking-changes for \n'
-              'a complete list.',
-          allowedHelp: {
-            for (var deprecation in Deprecation.values)
-              if (deprecation
-                  case Deprecation(
-                    deprecatedIn: _?,
-                    :var id,
-                    :var description?
-                  ))
-                id: description
-          })
+              'a complete list.')
+      ..addMultiOption('silence-deprecation', help: 'Deprecations to ignore.')
       ..addMultiOption('future-deprecation',
-          help: 'Opt in to a deprecation early.',
-          allowedHelp: {
-            for (var deprecation in Deprecation.values)
-              if (deprecation
-                  case Deprecation(
-                    deprecatedIn: null,
-                    :var id,
-                    :var description?
-                  ))
-                id: description
-          });
+          help: 'Opt in to a deprecation early.');
 
     parser
       ..addSeparator(_separator('Other'))

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -10,7 +10,6 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:term_glyph/term_glyph.dart' as term_glyph;
 
 import '../../sass.dart';
-import '../exception.dart';
 import '../importer/node_package.dart';
 import '../io.dart';
 import '../util/character.dart';

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -95,9 +95,13 @@ final class ExecutableOptions {
           help: 'Deprecations to ignore.',
           allowedHelp: {
             for (var deprecation in Deprecation.values)
-              if (deprecation.deprecatedIn != null &&
-                  deprecation.description != null)
-                deprecation.id: deprecation.description!,
+              if (deprecation
+                  case Deprecation(
+                    deprecatedIn: Version(),
+                    obsoleteIn: null,
+                    :var description?
+                  ))
+                deprecation.id: description,
           })
       ..addMultiOption('fatal-deprecation',
           help: 'Deprecations to treat as errors. You may also pass a Sass\n'

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -578,3 +578,10 @@ final class ExecutableOptions {
   Object? _ifParsed(String name) =>
       _options.wasParsed(name) ? _options[name] : null;
 }
+
+/// An exception indicating that invalid arguments were passed.
+class UsageException implements Exception {
+  final String message;
+
+  UsageException(this.message);
+}

--- a/lib/src/js.dart
+++ b/lib/src/js.dart
@@ -49,13 +49,14 @@ void main() {
   exports.sassNull = sassNull;
   exports.sassTrue = sassTrue;
   exports.sassFalse = sassFalse;
-  exports.deprecations = jsify(deprecations);
   exports.Exception = exceptionClass;
   exports.Logger = LoggerNamespace(
       silent: JSLogger(
           warn: allowInteropNamed('sass.Logger.silent.warn', (_, __) {}),
           debug: allowInteropNamed('sass.Logger.silent.debug', (_, __) {})));
   exports.NodePackageImporter = nodePackageImporterClass;
+  exports.deprecations = jsify(deprecations);
+  exports.Version = versionClass;
 
   exports.info =
       "dart-sass\t${const String.fromEnvironment('version')}\t(Sass Compiler)\t"

--- a/lib/src/js.dart
+++ b/lib/src/js.dart
@@ -2,7 +2,10 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import 'package:js/js_util.dart';
+
 import 'js/exception.dart';
+import 'js/deprecations.dart';
 import 'js/exports.dart';
 import 'js/compile.dart';
 import 'js/compiler.dart';
@@ -46,6 +49,7 @@ void main() {
   exports.sassNull = sassNull;
   exports.sassTrue = sassTrue;
   exports.sassFalse = sassFalse;
+  exports.deprecations = jsify(deprecations);
   exports.Exception = exceptionClass;
   exports.Logger = LoggerNamespace(
       silent: JSLogger(

--- a/lib/src/js/compile.dart
+++ b/lib/src/js/compile.dart
@@ -359,6 +359,11 @@ List<AsyncCallable> _parseFunctions(Object? functions, {bool asynch = false}) {
   return result;
 }
 
+/// Parses a list of [deprecations] from JS into an list of Dart [Deprecation]
+/// objects.
+///
+/// [deprecations] can contain deprecation IDs, JS Deprecation objects, and
+/// (if [supportVersions] is true) [Version]s.
 Iterable<Deprecation>? _parseDeprecations(
     JSToDartLogger logger, List<Object?>? deprecations,
     {bool supportVersions = false}) {

--- a/lib/src/js/compile_options.dart
+++ b/lib/src/js/compile_options.dart
@@ -23,6 +23,9 @@ class CompileOptions {
   external JSLogger? get logger;
   external List<Object?>? get importers;
   external Object? get functions;
+  external List<Object?>? get fatalDeprecations;
+  external List<Object?>? get silenceDeprecations;
+  external List<Object?>? get futureDeprecations;
 }
 
 @JS()

--- a/lib/src/js/deprecations.dart
+++ b/lib/src/js/deprecations.dart
@@ -27,17 +27,21 @@ class Deprecation {
 
 final Map<String, Deprecation?> deprecations = {
   for (var deprecation in dart.Deprecation.values)
-    deprecation.id: Deprecation(
-        id: deprecation.id,
-        status: (() => switch (deprecation) {
-              dart.Deprecation(isFuture: true) => 'future',
-              dart.Deprecation(deprecatedIn: null, obsoleteIn: null) => 'user',
-              dart.Deprecation(obsoleteIn: null) => 'active',
-              _ => 'obsolete'
-            })(),
-        description: deprecation.description,
-        deprecatedIn: deprecation.deprecatedIn,
-        obsoleteIn: deprecation.deprecatedIn),
+    // `calc-interp` was never actually used, so we don't want to expose it
+    // in the JS API.
+    if (deprecation != dart.Deprecation.calcInterp)
+      deprecation.id: Deprecation(
+          id: deprecation.id,
+          status: (() => switch (deprecation) {
+                dart.Deprecation(isFuture: true) => 'future',
+                dart.Deprecation(deprecatedIn: null, obsoleteIn: null) =>
+                  'user',
+                dart.Deprecation(obsoleteIn: null) => 'active',
+                _ => 'obsolete'
+              })(),
+          description: deprecation.description,
+          deprecatedIn: deprecation.deprecatedIn,
+          obsoleteIn: deprecation.deprecatedIn),
 };
 
 /// The JavaScript `Version` class.

--- a/lib/src/js/deprecations.dart
+++ b/lib/src/js/deprecations.dart
@@ -47,12 +47,6 @@ final JSClass versionClass = () {
     return Version(major, minor, patch);
   });
 
-  jsClass.defineGetters({
-    'major': (Version self) => self.major,
-    'minor': (Version self) => self.minor,
-    'patch': (Version self) => self.patch,
-  });
-
   jsClass.defineStaticMethod(
       'parse', (String version) => Version.parse(version));
 

--- a/lib/src/js/deprecations.dart
+++ b/lib/src/js/deprecations.dart
@@ -51,8 +51,14 @@ final JSClass versionClass = () {
     return Version(major, minor, patch);
   });
 
-  jsClass.defineStaticMethod(
-      'parse', (String version) => Version.parse(version));
+  jsClass.defineStaticMethod('parse', (String version) {
+    var v = Version.parse(version);
+    if (v.isPreRelease || v.build.isNotEmpty) {
+      throw FormatException(
+          'Build identifiers and prerelease versions not supported.');
+    }
+    return v;
+  });
 
   getJSClass(Version(0, 0, 0)).injectSuperclass(jsClass);
   return jsClass;

--- a/lib/src/js/deprecations.dart
+++ b/lib/src/js/deprecations.dart
@@ -1,0 +1,61 @@
+// Copyright 2023 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:js/js.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import '../deprecation.dart' as dart show Deprecation;
+import 'reflection.dart';
+
+@JS()
+@anonymous
+class Deprecation {
+  external String get id;
+  external String get status;
+  external String? get description;
+  external Version? get deprecatedIn;
+  external Version? get obsoleteIn;
+
+  external factory Deprecation(
+      {required String id,
+      required String status,
+      String? description,
+      Version? deprecatedIn,
+      Version? obsoleteIn});
+}
+
+final Map<String, Deprecation?> deprecations = {
+  for (var deprecation in dart.Deprecation.values)
+    deprecation.id: Deprecation(
+        id: deprecation.id,
+        status: (() => switch (deprecation) {
+              dart.Deprecation(isFuture: true) => 'future',
+              dart.Deprecation(deprecatedIn: null, obsoleteIn: null) => 'user',
+              dart.Deprecation(obsoleteIn: null) => 'active',
+              _ => 'obsolete'
+            })(),
+        description: deprecation.description,
+        deprecatedIn: deprecation.deprecatedIn,
+        obsoleteIn: deprecation.deprecatedIn),
+};
+
+/// The JavaScript `Version` class.
+final JSClass versionClass = () {
+  var jsClass = createJSClass('sass.Version',
+      (Object self, int major, int minor, int patch) {
+    return Version(major, minor, patch);
+  });
+
+  jsClass.defineGetters({
+    'major': (Version self) => self.major,
+    'minor': (Version self) => self.minor,
+    'patch': (Version self) => self.patch,
+  });
+
+  jsClass.defineStaticMethod(
+      'parse', (String version) => Version.parse(version));
+
+  getJSClass(Version(0, 0, 0)).injectSuperclass(jsClass);
+  return jsClass;
+}();

--- a/lib/src/js/exports.dart
+++ b/lib/src/js/exports.dart
@@ -28,6 +28,7 @@ class Exports {
   external set Logger(LoggerNamespace namespace);
   external set NodePackageImporter(JSClass function);
   external set deprecations(Object? object);
+  external set Version(JSClass version);
 
   // Value APIs
   external set Value(JSClass function);

--- a/lib/src/js/exports.dart
+++ b/lib/src/js/exports.dart
@@ -27,6 +27,7 @@ class Exports {
   external set Exception(JSClass function);
   external set Logger(LoggerNamespace namespace);
   external set NodePackageImporter(JSClass function);
+  external set deprecations(Object? object);
 
   // Value APIs
   external set Value(JSClass function);

--- a/lib/src/js/logger.dart
+++ b/lib/src/js/logger.dart
@@ -5,6 +5,8 @@
 import 'package:js/js.dart';
 import 'package:source_span/source_span.dart';
 
+import 'deprecations.dart';
+
 @JS()
 @anonymous
 class JSLogger {
@@ -20,11 +22,15 @@ class JSLogger {
 @anonymous
 class WarnOptions {
   external bool get deprecation;
+  external Deprecation? get deprecationType;
   external SourceSpan? get span;
   external String? get stack;
 
   external factory WarnOptions(
-      {required bool deprecation, SourceSpan? span, String? stack});
+      {required bool deprecation,
+      Deprecation? deprecationType,
+      SourceSpan? span,
+      String? stack});
 }
 
 @JS()

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -7,6 +7,7 @@ import 'package:source_span/source_span.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import 'deprecation.dart';
+import 'logger/deprecation_handling.dart';
 import 'logger/stderr.dart';
 
 /// An interface for loggers that print messages produced by Sass stylesheets.
@@ -64,13 +65,14 @@ extension WarnForDeprecation on Logger {
   /// Emits a deprecation warning for [deprecation] with the given [message].
   void warnForDeprecation(Deprecation deprecation, String message,
       {FileSpan? span, Trace? trace}) {
+    if (deprecation.isFuture && this is! DeprecationHandlingLogger) return;
     if (this case DeprecationLogger self) {
       self.warn(message,
           span: span,
           trace: trace,
           deprecation: true,
           deprecationType: deprecation);
-    } else if (!deprecation.isFuture) {
+    } else {
       warn(message, span: span, trace: trace, deprecation: true);
     }
   }

--- a/lib/src/logger/deprecation_handling.dart
+++ b/lib/src/logger/deprecation_handling.dart
@@ -86,7 +86,7 @@ final class DeprecationHandlingLogger implements DeprecationLogger {
       bool deprecation = false,
       Deprecation? deprecationType}) {
     if (deprecation && deprecationType != null) {
-      warnForDeprecation(deprecationType, message, span: span, trace: trace);
+      _handleDeprecation(deprecationType, message, span: span, trace: trace);
     } else {
       _inner.warn(message, span: span, trace: trace);
     }
@@ -101,7 +101,7 @@ final class DeprecationHandlingLogger implements DeprecationLogger {
   /// [limitRepetitions] is true, the warning is dropped.
   ///
   /// Otherwise, this is passed on to [warn].
-  void warnForDeprecation(Deprecation deprecation, String message,
+  void _handleDeprecation(Deprecation deprecation, String message,
       {FileSpan? span, Trace? trace}) {
     if (deprecation.isFuture && !futureDeprecations.contains(deprecation)) {
       return;
@@ -125,7 +125,15 @@ final class DeprecationHandlingLogger implements DeprecationLogger {
       if (count > _maxRepetitions) return;
     }
 
-    _inner.warnForDeprecation(deprecation, message, span: span, trace: trace);
+    if (_inner case DeprecationLogger inner) {
+      inner.warn(message,
+          span: span,
+          trace: trace,
+          deprecation: true,
+          deprecationType: deprecation);
+    } else {
+      _inner.warn(message, span: span, trace: trace, deprecation: true);
+    }
   }
 
   void debug(String message, SourceSpan span) => _inner.debug(message, span);

--- a/lib/src/logger/js_to_dart.dart
+++ b/lib/src/logger/js_to_dart.dart
@@ -7,11 +7,13 @@ import 'package:source_span/source_span.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:term_glyph/term_glyph.dart' as glyph;
 
+import '../deprecation.dart';
 import '../logger.dart';
+import '../js/deprecations.dart' show deprecations;
 import '../js/logger.dart';
 
 /// A wrapper around a [JSLogger] that exposes it as a Dart [Logger].
-final class JSToDartLogger implements Logger {
+final class JSToDartLogger implements DeprecationLogger {
   /// The wrapped logger object.
   final JSLogger? _node;
 
@@ -28,14 +30,18 @@ final class JSToDartLogger implements Logger {
       : _ascii = ascii ?? glyph.ascii;
 
   void warn(String message,
-      {FileSpan? span, Trace? trace, bool deprecation = false}) {
+      {FileSpan? span,
+      Trace? trace,
+      bool deprecation = false,
+      Deprecation? deprecationType}) {
     if (_node?.warn case var warn?) {
       warn(
           message,
           WarnOptions(
               span: span ?? (undefined as SourceSpan?),
               stack: trace.toString(),
-              deprecation: deprecation));
+              deprecation: deprecation,
+              deprecationType: deprecations[deprecationType?.id]));
     } else {
       _withAscii(() {
         _fallback.warn(message,

--- a/lib/src/logger/js_to_dart.dart
+++ b/lib/src/logger/js_to_dart.dart
@@ -13,7 +13,7 @@ import '../js/deprecations.dart' show deprecations;
 import '../js/logger.dart';
 
 /// A wrapper around a [JSLogger] that exposes it as a Dart [Logger].
-final class JSToDartLogger implements DeprecationLogger {
+final class JSToDartLogger extends LoggerWithDeprecationType {
   /// The wrapped logger object.
   final JSLogger? _node;
 
@@ -29,23 +29,20 @@ final class JSToDartLogger implements DeprecationLogger {
   JSToDartLogger(this._node, this._fallback, {bool? ascii})
       : _ascii = ascii ?? glyph.ascii;
 
-  void warn(String message,
-      {FileSpan? span,
-      Trace? trace,
-      bool deprecation = false,
-      Deprecation? deprecationType}) {
+  void internalWarn(String message,
+      {FileSpan? span, Trace? trace, Deprecation? deprecation}) {
     if (_node?.warn case var warn?) {
       warn(
           message,
           WarnOptions(
               span: span ?? (undefined as SourceSpan?),
               stack: trace.toString(),
-              deprecation: deprecation,
-              deprecationType: deprecations[deprecationType?.id]));
+              deprecation: deprecation != null,
+              deprecationType: deprecations[deprecation?.id]));
     } else {
       _withAscii(() {
         _fallback.warn(message,
-            span: span, trace: trace, deprecation: deprecation);
+            span: span, trace: trace, deprecation: deprecation != null);
       });
     }
   }

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.0
+
+* No user-visible changes.
+
 ## 10.0.0
 
 * Remove the `allowPlaceholders` argument from `SelectorList.parse()`. Instead,
@@ -95,7 +99,7 @@
 
 * All uses of classes from the `tuple` package have been replaced by record
   types.
-  
+
 ## 7.2.2
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 10.0.0
+version: 10.1.0
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sass: 1.73.0
+  sass: 1.74.0
 
 dev_dependencies:
   dartdoc: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.73.0
+version: 1.74.0
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/test/embedded/utils.dart
+++ b/test/embedded/utils.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 
 import 'package:sass/src/embedded/embedded_sass.pb.dart';
 import 'package:sass/src/embedded/utils.dart';
+import 'package:sass/src/util/nullable.dart';
 
 import 'embedded_process.dart';
 
@@ -16,23 +17,21 @@ const defaultCompilationId = 4321;
 
 /// Returns a (compilation ID, [InboundMessage]) pair that compiles the given
 /// plain CSS string.
-InboundMessage compileString(
-  String css, {
-  int? id,
-  bool? alertColor,
-  bool? alertAscii,
-  Syntax? syntax,
-  OutputStyle? style,
-  String? url,
-  bool? sourceMap,
-  bool? sourceMapIncludeSources,
-  Iterable<InboundMessage_CompileRequest_Importer>? importers,
-  InboundMessage_CompileRequest_Importer? importer,
-  Iterable<String>? functions,
-  Iterable<String>? fatalDeprecations,
-  Iterable<String>? futureDeprecations,
-  Iterable<String>? silenceDeprecations,
-}) {
+InboundMessage compileString(String css,
+    {int? id,
+    bool? alertColor,
+    bool? alertAscii,
+    Syntax? syntax,
+    OutputStyle? style,
+    String? url,
+    bool? sourceMap,
+    bool? sourceMapIncludeSources,
+    Iterable<InboundMessage_CompileRequest_Importer>? importers,
+    InboundMessage_CompileRequest_Importer? importer,
+    Iterable<String>? functions,
+    Iterable<String>? fatalDeprecations,
+    Iterable<String>? futureDeprecations,
+    Iterable<String>? silenceDeprecations}) {
   var input = InboundMessage_CompileRequest_StringInput()..source = css;
   if (syntax != null) input.syntax = syntax;
   if (url != null) input.url = url;
@@ -48,15 +47,9 @@ InboundMessage compileString(
   if (functions != null) request.globalFunctions.addAll(functions);
   if (alertColor != null) request.alertColor = alertColor;
   if (alertAscii != null) request.alertAscii = alertAscii;
-  if (fatalDeprecations != null) {
-    request.fatalDeprecation.addAll(fatalDeprecations);
-  }
-  if (futureDeprecations != null) {
-    request.futureDeprecation.addAll(futureDeprecations);
-  }
-  if (silenceDeprecations != null) {
-    request.silenceDeprecation.addAll(silenceDeprecations);
-  }
+  fatalDeprecations.andThen(request.fatalDeprecation.addAll);
+  futureDeprecations.andThen(request.futureDeprecation.addAll);
+  silenceDeprecations.andThen(request.silenceDeprecation.addAll);
   return InboundMessage()..compileRequest = request;
 }
 

--- a/test/embedded/utils.dart
+++ b/test/embedded/utils.dart
@@ -16,18 +16,23 @@ const defaultCompilationId = 4321;
 
 /// Returns a (compilation ID, [InboundMessage]) pair that compiles the given
 /// plain CSS string.
-InboundMessage compileString(String css,
-    {int? id,
-    bool? alertColor,
-    bool? alertAscii,
-    Syntax? syntax,
-    OutputStyle? style,
-    String? url,
-    bool? sourceMap,
-    bool? sourceMapIncludeSources,
-    Iterable<InboundMessage_CompileRequest_Importer>? importers,
-    InboundMessage_CompileRequest_Importer? importer,
-    Iterable<String>? functions}) {
+InboundMessage compileString(
+  String css, {
+  int? id,
+  bool? alertColor,
+  bool? alertAscii,
+  Syntax? syntax,
+  OutputStyle? style,
+  String? url,
+  bool? sourceMap,
+  bool? sourceMapIncludeSources,
+  Iterable<InboundMessage_CompileRequest_Importer>? importers,
+  InboundMessage_CompileRequest_Importer? importer,
+  Iterable<String>? functions,
+  Iterable<String>? fatalDeprecations,
+  Iterable<String>? futureDeprecations,
+  Iterable<String>? silenceDeprecations,
+}) {
   var input = InboundMessage_CompileRequest_StringInput()..source = css;
   if (syntax != null) input.syntax = syntax;
   if (url != null) input.url = url;
@@ -43,7 +48,15 @@ InboundMessage compileString(String css,
   if (functions != null) request.globalFunctions.addAll(functions);
   if (alertColor != null) request.alertColor = alertColor;
   if (alertAscii != null) request.alertAscii = alertAscii;
-
+  if (fatalDeprecations != null) {
+    request.fatalDeprecation.addAll(fatalDeprecations);
+  }
+  if (futureDeprecations != null) {
+    request.futureDeprecation.addAll(futureDeprecations);
+  }
+  if (silenceDeprecations != null) {
+    request.silenceDeprecation.addAll(silenceDeprecations);
+  }
   return InboundMessage()..compileRequest = request;
 }
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -87,6 +87,8 @@ void main(List<String> args) {
     'NULL',
     'types',
     'NodePackageImporter',
+    'deprecations',
+    'Version',
   };
 
   pkg.githubReleaseNotes.fn = () =>


### PR DESCRIPTION
This implements the full deprecations API for the JS API and the embedded compiler, and also adds `silenceDeprecations`/`--silence-deprecation` to the Dart API and CLI to complete those implementations.

See https://github.com/sass/sass/pull/3826
See https://github.com/sass/sass-spec/pull/1967
[skip sass-embedded]