### PR TITLE
Fix bulma and release 1.74.1

### DIFF
--- a/.github/workflows/test-vendor.yml
+++ b/.github/workflows/test-vendor.yml
@@ -69,4 +69,4 @@ jobs:
       - run: dart run grinder fetch-bulma
         env: {GITHUB_BEARER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"}
       - name: Build
-        run: dart bin/sass.dart --quiet build/bulma/bulma.sass build/bulma-output.css
+        run: dart bin/sass.dart --quiet build/bulma/bulma.scss build/bulma-output.css

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.74.1
+
+* No user-visible changes.
+
 ## 1.74.0
 
 ### JS API

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.1
+
+* No user-visible changes.
+
 ## 10.1.0
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 10.1.0
+version: 10.1.1
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sass: 1.74.0
+  sass: 1.74.1
 
 dev_dependencies:
   dartdoc: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.74.0
+version: 1.74.1
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
bulma switched to the SCSS syntax, breaking one of our release tests, which caused the 1.74.0 release to fail.