### PR TITLE
*ImportCache.canonicalize: Deprecate base importer without URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 1.75.0
+
+### JS API
+
+* Passing an `importer` argument without a corresponding canonical `url` to
+  `compileString()` and `compileStringAsync()` will now emit a deprecation named
+  `importer-without-url`. This was always forbidden by the TypeScript types, and
+  so was officially undefined behavior, but the previous behavior (passing
+  relative URLs as-is to the `importer` before passing them to the `importers`
+  list) will be preserved until Dart Sass 2.0.0. See
+  https://sass-lang.com/d/importer-without-url for more information.
+
+### Dart API
+
+* Passing an `importer` argument without a corresponding canonical `url` to
+  `compileStringToResult()`, `compileStringToResultAsync()`, `compileString()`,
+  and `compileStringAsync()` will now emit a deprecation named
+  `importer-without-url`. See https://sass-lang.com/d/importer-without-url for
+  more information.
+
 ## 1.74.1
 
 * No user-visible changes.

--- a/lib/src/async_compile.dart
+++ b/lib/src/async_compile.dart
@@ -118,6 +118,16 @@ Future<CompileResult> compileStringAsync(String source,
           futureDeprecations: {...?futureDeprecations},
           limitRepetition: !verbose);
 
+  // Allow NoOpImporter because various first-party callers use that to opt out
+  // of the also-deprecated FilesystemImporter.cwd behavior.
+  if (importer != null && importer is! NoOpImporter && url == null) {
+    logger.warnForDeprecation(
+        Deprecation.importerWithoutUrl,
+        "Passing an importer to compileString* without a canonical URL is "
+        "deprecated and will be an error in future versions of Sass. Use the "
+        "importers argument for non-relative loads.");
+  }
+
   var stylesheet =
       Stylesheet.parse(source, syntax ?? Syntax.scss, url: url, logger: logger);
 

--- a/lib/src/compile.dart
+++ b/lib/src/compile.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_compile.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: ab2c6fa2588988a86abdbe87512134098e01b39e
+// Checksum: 7e80ff5e991b0815e71b91b23a869222f12cf90b
 //
 // ignore_for_file: unused_import
 
@@ -126,6 +126,16 @@ CompileResult compileString(String source,
           fatalDeprecations: {...?fatalDeprecations},
           futureDeprecations: {...?futureDeprecations},
           limitRepetition: !verbose);
+
+  // Allow NoOpImporter because various first-party callers use that to opt out
+  // of the also-deprecated FilesystemImporter.cwd behavior.
+  if (importer != null && importer is! NoOpImporter && url == null) {
+    logger.warnForDeprecation(
+        Deprecation.importerWithoutUrl,
+        "Passing an importer to compileString* without a canonical URL is "
+        "deprecated and will be an error in future versions of Sass. Use the "
+        "importers argument for non-relative loads.");
+  }
 
   var stylesheet =
       Stylesheet.parse(source, syntax ?? Syntax.scss, url: url, logger: logger);

--- a/lib/src/deprecation.dart
+++ b/lib/src/deprecation.dart
@@ -74,6 +74,11 @@ enum Deprecation {
       description:
           'Using the current working directory as an implicit load path.'),
 
+  importerWithoutUrl('importer-without-url',
+      deprecatedIn: '1.75.0',
+      description:
+          'Passing a base importer without a base URL to compileString*.'),
+
   @Deprecated('This deprecation name was never actually used.')
   calcInterp('calc-interp', deprecatedIn: null),
 

--- a/lib/src/embedded/logger.dart
+++ b/lib/src/embedded/logger.dart
@@ -8,7 +8,6 @@ import 'package:stack_trace/stack_trace.dart';
 
 import '../deprecation.dart';
 import '../logger.dart';
-import '../util/nullable.dart';
 import '../utils.dart';
 import 'compilation_dispatcher.dart';
 import 'embedded_sass.pb.dart' hide SourceSpan;
@@ -34,7 +33,9 @@ final class EmbeddedLogger extends LoggerWithDeprecationType {
       ..type = LogEventType.DEBUG
       ..message = message
       ..span = protofySpan(span)
-      ..formatted = (span.start.sourceUrl.andThen(p.prettyUri) ?? '-') +
+      ..formatted = (isRealUrl(span.start.sourceUrl)
+              ? p.prettyUri(span.start.sourceUrl)
+              : '-') +
           ':${span.start.line + 1} ' +
           (_color ? '\u001b[1mDebug\u001b[0m' : 'DEBUG') +
           ': $message\n');

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -68,13 +68,12 @@ Future<(int, String, String?)?> compileStylesheet(ExecutableOptions options,
 Future<void> _compileStylesheetWithoutErrorHandling(ExecutableOptions options,
     StylesheetGraph graph, String? source, String? destination,
     {bool ifModified = false}) async {
-  var importer = FilesystemImporter.cwd;
   if (ifModified) {
     try {
       if (source != null &&
           destination != null &&
-          !graph.modifiedSince(p.toUri(p.absolute(source)),
-              modificationTime(destination), importer)) {
+          !graph.modifiedSince(
+              p.toUri(p.absolute(source)), modificationTime(destination))) {
         return;
       }
     } on FileSystemException catch (_) {
@@ -105,6 +104,7 @@ Future<void> _compileStylesheetWithoutErrorHandling(ExecutableOptions options,
               logger: options.logger,
               importCache: importCache,
               importer: FilesystemImporter.cwd,
+              url: p.toUri(p.absolute('(stdin)${syntax.extension}')),
               style: options.style,
               quietDeps: options.quietDeps,
               verbose: options.verbose,
@@ -130,6 +130,7 @@ Future<void> _compileStylesheetWithoutErrorHandling(ExecutableOptions options,
               logger: options.logger,
               importCache: graph.importCache,
               importer: FilesystemImporter.cwd,
+              url: p.toUri(p.absolute('(stdin)${syntax.extension}')),
               style: options.style,
               quietDeps: options.quietDeps,
               verbose: options.verbose,

--- a/lib/src/executable/repl.dart
+++ b/lib/src/executable/repl.dart
@@ -22,9 +22,8 @@ Future<void> repl(ExecutableOptions options) async {
   var repl = Repl(prompt: '>> ');
   var logger = TrackingLogger(options.logger);
   var evaluator = Evaluator(
-      importer: FilesystemImporter.cwd,
       importCache: ImportCache(
-          importers: options.pkgImporters,
+          importers: [...options.pkgImporters, FilesystemImporter('.')],
           loadPaths: options.loadPaths,
           logger: logger),
       logger: logger);

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_import_cache.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: d157b83599dbc07a80ac6cb5ffdf5dde03b60376
+// Checksum: 01bc58f71fe5862d20d4c9ab7d8c7ba1eb612b7f
 //
 // ignore_for_file: unused_import
 
@@ -154,6 +154,8 @@ final class ImportCache {
     }
 
     if (baseImporter != null && url.scheme == '') {
+      // TODO(sass/sass#3831): Throw an ArgumentError here if baseImporter is
+      // passed without a baseUrl as well.
       var relativeResult = _relativeCanonicalizeCache.putIfAbsent(
           (
             url,
@@ -179,17 +181,11 @@ final class ImportCache {
 
   /// Calls [importer.canonicalize] and prints a deprecation warning if it
   /// returns a relative URL.
-  ///
-  /// If [resolveUrl] is `true`, this resolves [url] relative to [baseUrl]
-  /// before passing it to [importer].
   CanonicalizeResult? _canonicalize(
-      Importer importer, Uri url, Uri? baseUrl, bool forImport,
-      {bool resolveUrl = false}) {
-    var resolved =
-        resolveUrl && baseUrl != null ? baseUrl.resolveUri(url) : url;
+      Importer importer, Uri url, Uri? baseUrl, bool forImport) {
     var canonicalize = forImport
-        ? () => inImportRule(() => importer.canonicalize(resolved))
-        : () => importer.canonicalize(resolved);
+        ? () => inImportRule(() => importer.canonicalize(url))
+        : () => importer.canonicalize(url);
 
     var passContainingUrl = baseUrl != null &&
         (url.scheme == '' || importer.isNonCanonicalScheme(url.scheme));
@@ -200,15 +196,15 @@ final class ImportCache {
     if (result.scheme == '') {
       _logger.warnForDeprecation(
           Deprecation.relativeCanonical,
-          "Importer $importer canonicalized $resolved to $result.\n"
+          "Importer $importer canonicalized $url to $result.\n"
           "Relative canonical URLs are deprecated and will eventually be "
           "disallowed.");
     } else if (importer.isNonCanonicalScheme(result.scheme)) {
-      throw "Importer $importer canonicalized $resolved to $result, which "
+      throw "Importer $importer canonicalized $url to $result, which "
           "uses a scheme declared as non-canonical.";
     }
 
-    return (importer, result, originalUrl: resolved);
+    return (importer, result, originalUrl: url);
   }
 
   /// Tries to import [url] using one of this cache's importers.

--- a/lib/src/logger/stderr.dart
+++ b/lib/src/logger/stderr.dart
@@ -47,8 +47,9 @@ final class StderrLogger implements Logger {
 
   void debug(String message, SourceSpan span) {
     var result = StringBuffer();
-    var url =
-        span.start.sourceUrl == null ? '-' : p.prettyUri(span.start.sourceUrl);
+    var url = isRealUrl(span.start.sourceUrl)
+        ? p.prettyUri(span.start.sourceUrl)
+        : '-';
     result.write('$url:${span.start.line + 1} ');
     result.write(color ? '\u001b[1mDebug\u001b[0m' : 'DEBUG');
     result.write(': $message');

--- a/lib/src/stylesheet_graph.dart
+++ b/lib/src/stylesheet_graph.dart
@@ -41,12 +41,8 @@ class StylesheetGraph {
   /// Returns whether the stylesheet at [url] or any of the stylesheets it
   /// imports were modified since [since].
   ///
-  /// If [baseImporter] is non-`null`, this first tries to use [baseImporter] to
-  /// import [url] (resolved relative to [baseUrl] if it's passed).
-  ///
   /// Returns `true` if the import cache can't find a stylesheet at [url].
-  bool modifiedSince(Uri url, DateTime since,
-      [Importer? baseImporter, Uri? baseUrl]) {
+  bool modifiedSince(Uri url, DateTime since) {
     DateTime transitiveModificationTime(StylesheetNode node) {
       return _transitiveModificationTimes.putIfAbsent(node.canonicalUrl, () {
         var latest = node.importer.modificationTime(node.canonicalUrl);
@@ -63,7 +59,7 @@ class StylesheetGraph {
       });
     }
 
-    var node = _add(url, baseImporter, baseUrl);
+    var node = _add(url);
     if (node == null) return true;
     return transitiveModificationTime(node).isAfter(since);
   }
@@ -71,14 +67,10 @@ class StylesheetGraph {
   /// Adds the stylesheet at [url] and all the stylesheets it imports to this
   /// graph and returns its node.
   ///
-  /// If [baseImporter] is non-`null`, this first tries to use [baseImporter] to
-  /// import [url] (resolved relative to [baseUrl] if it's passed).
-  ///
   /// Returns `null` if the import cache can't find a stylesheet at [url].
-  StylesheetNode? _add(Uri url, [Importer? baseImporter, Uri? baseUrl]) {
-    var result = _ignoreErrors(() => importCache.canonicalize(url,
-        baseImporter: baseImporter, baseUrl: baseUrl));
-    if (result case (var importer, var canonicalUrl, :var originalUrl)) {
+  StylesheetNode? _add(Uri url) {
+    if (_ignoreErrors(() => importCache.canonicalize(url))
+        case (var importer, var canonicalUrl, :var originalUrl)) {
       addCanonical(importer, canonicalUrl, originalUrl);
       return nodes[canonicalUrl];
     } else {

--- a/lib/src/syntax.dart
+++ b/lib/src/syntax.dart
@@ -2,6 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 /// An enum of syntaxes that Sass can parse.
@@ -26,6 +27,16 @@ enum Syntax {
 
   /// The name of the syntax.
   final String _name;
+
+  /// The file extension used for this syntax, including the period.
+  ///
+  /// :nodoc:
+  @internal
+  String get extension => switch (this) {
+        Syntax.sass => '.sass',
+        Syntax.scss => '.scss',
+        Syntax.css => 'css'
+      };
 
   const Syntax(this._name);
 

--- a/lib/src/util/source_map_buffer.dart
+++ b/lib/src/util/source_map_buffer.dart
@@ -74,7 +74,13 @@ class SourceMapBuffer implements StringBuffer {
       if (entry.target.offset == target.offset) return;
     }
 
-    _entries.add(Entry(source, target, null));
+    _entries.add(Entry(
+        isRealUrl(source.sourceUrl)
+            ? source
+            : SourceLocation(source.offset,
+                sourceUrl: null, line: source.line, column: source.column),
+        target,
+        null));
   }
 
   void clear() =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.74.1
+version: 1.75.0-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/test/embedded/file_importer_test.dart
+++ b/test/embedded/file_importer_test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
+import 'package:sass/src/deprecation.dart';
 import 'package:sass/src/embedded/embedded_sass.pb.dart';
 import 'package:sass/src/embedded/utils.dart';
 
@@ -253,6 +254,8 @@ void main() {
       process.send(compileString("@import 'other'",
           importer: InboundMessage_CompileRequest_Importer()
             ..fileImporterId = 1));
+
+      await expectDeprecationMessage(process, Deprecation.importerWithoutUrl);
 
       var request = await getFileImportRequest(process);
       expect(request.url, equals("other"));

--- a/test/embedded/importer_test.dart
+++ b/test/embedded/importer_test.dart
@@ -8,6 +8,7 @@ import 'package:source_maps/source_maps.dart' as source_maps;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
+import 'package:sass/src/deprecation.dart';
 import 'package:sass/src/embedded/embedded_sass.pb.dart';
 import 'package:sass/src/embedded/utils.dart';
 
@@ -104,6 +105,13 @@ void main() {
         await process.shouldExit(76);
       });
     });
+  });
+
+  test("emits a deprecation for an importer without a base URL", () async {
+    process.send(compileString('',
+        importer: InboundMessage_CompileRequest_Importer()..importerId = 1));
+    await expectDeprecationMessage(process, Deprecation.importerWithoutUrl);
+    await process.close();
   });
 
   group("canonicalization", () {
@@ -522,7 +530,8 @@ void main() {
 
   test("handles an importer for a string compile request", () async {
     process.send(compileString("@import 'other'",
-        importer: InboundMessage_CompileRequest_Importer()..importerId = 1));
+        importer: InboundMessage_CompileRequest_Importer()..importerId = 1,
+        url: "x:foo/bar.scss"));
     await _canonicalize(process);
 
     var request = await getImportRequest(process);

--- a/test/embedded/utils.dart
+++ b/test/embedded/utils.dart
@@ -5,6 +5,7 @@
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+import 'package:sass/src/deprecation.dart';
 import 'package:sass/src/embedded/embedded_sass.pb.dart';
 import 'package:sass/src/embedded/utils.dart';
 import 'package:sass/src/util/nullable.dart';
@@ -178,6 +179,15 @@ Future<OutboundMessage_LogEvent> getLogEvent(EmbeddedProcess process) async {
   expect(message.hasLogEvent(), isTrue,
       reason: "Expected $message to have a LogEvent");
   return message.logEvent;
+}
+
+/// Asserts that [process] emits a deprecation warning of the given type.
+Future<void> expectDeprecationMessage(
+    EmbeddedProcess process, Deprecation deprecation) async {
+  var event = await getLogEvent(process);
+  expect(event.type, equals(LogEventType.DEPRECATION_WARNING),
+      reason: "Expected a deprecation warning.");
+  expect(event.deprecationType, equals('importer-without-url'));
 }
 
 /// Asserts that [process] emits a `CompileResponse` with CSS that matches


### PR DESCRIPTION
See #2208
See sass/sass#3832
See sass/sass-spec#1971

[skip sass-embedded]