### PR TITLE
Implement access tracking for containingUrl

### DIFF
--- a/lib/src/embedded/importer/file.dart
+++ b/lib/src/embedded/importer/file.dart
@@ -21,8 +21,8 @@ final class FileImporter extends ImporterBase {
       ..importerId = _importerId
       ..url = url.toString()
       ..fromImport = fromImport;
-    var containingUrl = canonicalizeContext.containingUrlWithoutMarking;
-    if (containingUrl case var containingUrl?) {
+    if (canonicalizeContext.containingUrlWithoutMarking
+        case var containingUrl?) {
       request.containingUrl = containingUrl.toString();
     }
     var response = dispatcher.sendFileImportRequest(request);

--- a/lib/src/embedded/importer/file.dart
+++ b/lib/src/embedded/importer/file.dart
@@ -21,10 +21,12 @@ final class FileImporter extends ImporterBase {
       ..importerId = _importerId
       ..url = url.toString()
       ..fromImport = fromImport;
+    var containingUrl = canonicalizeContext.containingUrlWithoutMarking;
     if (containingUrl case var containingUrl?) {
       request.containingUrl = containingUrl.toString();
     }
     var response = dispatcher.sendFileImportRequest(request);
+    if (!response.containingUrlUnused) canonicalizeContext.containingUrl;
 
     switch (response.whichResult()) {
       case InboundMessage_FileImportResponse_Result.fileUrl:

--- a/lib/src/embedded/importer/host.dart
+++ b/lib/src/embedded/importer/host.dart
@@ -35,8 +35,8 @@ final class HostImporter extends ImporterBase {
       ..importerId = _importerId
       ..url = url.toString()
       ..fromImport = fromImport;
-    var containingUrl = canonicalizeContext.containingUrlWithoutMarking;
-    if (containingUrl case var containingUrl?) {
+    if (canonicalizeContext.containingUrlWithoutMarking
+        case var containingUrl?) {
       request.containingUrl = containingUrl.toString();
     }
     var response = dispatcher.sendCanonicalizeRequest(request);

--- a/lib/src/embedded/importer/host.dart
+++ b/lib/src/embedded/importer/host.dart
@@ -35,10 +35,12 @@ final class HostImporter extends ImporterBase {
       ..importerId = _importerId
       ..url = url.toString()
       ..fromImport = fromImport;
+    var containingUrl = canonicalizeContext.containingUrlWithoutMarking;
     if (containingUrl case var containingUrl?) {
       request.containingUrl = containingUrl.toString();
     }
     var response = dispatcher.sendCanonicalizeRequest(request);
+    if (!response.containingUrlUnused) canonicalizeContext.containingUrl;
 
     return switch (response.whichResult()) {
       InboundMessage_CanonicalizeResponse_Result.url =>

--- a/lib/src/importer/async.dart
+++ b/lib/src/importer/async.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 
+import 'canonicalize_context.dart';
 import 'result.dart';
 import 'utils.dart' as utils;
 
@@ -54,7 +55,19 @@ abstract class AsyncImporter {
   /// Outside of that context, its value is undefined and subject to change.
   @protected
   @nonVirtual
-  Uri? get containingUrl => utils.containingUrl;
+  Uri? get containingUrl => utils.canonicalizeContext.containingUrl;
+
+  /// The canonicalize context of the stylesheet that caused the current
+  /// [canonicalize] invocation.
+  ///
+  /// Subclasses should only access this from within calls to [canonicalize].
+  /// Outside of that context, its value is undefined and subject to change.
+  ///
+  /// @nodoc
+  @internal
+  @protected
+  @nonVirtual
+  CanonicalizeContext get canonicalizeContext => utils.canonicalizeContext;
 
   /// If [url] is recognized by this importer, returns its canonical format.
   ///

--- a/lib/src/importer/canonicalize_context.dart
+++ b/lib/src/importer/canonicalize_context.dart
@@ -1,0 +1,49 @@
+// Copyright 2014 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:meta/meta.dart';
+
+/// Contextual information used by importers' `canonicalize` method.
+@internal
+final class CanonicalizeContext {
+  /// Whether the Sass compiler is currently evaluating an `@import` rule.
+  bool get fromImport => _fromImport;
+  bool _fromImport;
+
+  /// The URL of the stylesheet that contains the current load.
+  Uri? get containingUrl {
+    _wasContainingUrlAccessed = true;
+    return _containingUrl;
+  }
+
+  final Uri? _containingUrl;
+
+  /// Returns the same value as [containingUrl], but doesn't mark it accessed.
+  Uri? get containingUrlWithoutMarking => _containingUrl;
+
+  /// Whether [containingUrl] has been accessed.
+  ///
+  /// This is used to determine whether canonicalize result is cacheable.
+  ///
+  /// @nodoc
+  @internal
+  bool get wasContainingUrlAccessed => _wasContainingUrlAccessed;
+  var _wasContainingUrlAccessed = false;
+
+  /// Runs [callback] in a context with specificed [fromImport].
+  ///
+  /// @nodoc
+  @internal
+  T withFromImport<T>(bool fromImport, T callback()) {
+    var oldFromImport = _fromImport;
+    _fromImport = fromImport;
+    try {
+      return callback();
+    } finally {
+      _fromImport = oldFromImport;
+    }
+  }
+
+  CanonicalizeContext(this._containingUrl, this._fromImport);
+}

--- a/lib/src/importer/canonicalize_context.dart
+++ b/lib/src/importer/canonicalize_context.dart
@@ -1,6 +1,8 @@
-// Copyright 2014 Google Inc. Use of this source code is governed by an
+// Copyright 2024 Google Inc. Use of this source code is governed by an
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
+
+import 'dart:async';
 
 import 'package:meta/meta.dart';
 
@@ -25,17 +27,13 @@ final class CanonicalizeContext {
   /// Whether [containingUrl] has been accessed.
   ///
   /// This is used to determine whether canonicalize result is cacheable.
-  ///
-  /// @nodoc
-  @internal
   bool get wasContainingUrlAccessed => _wasContainingUrlAccessed;
   var _wasContainingUrlAccessed = false;
 
   /// Runs [callback] in a context with specificed [fromImport].
-  ///
-  /// @nodoc
-  @internal
   T withFromImport<T>(bool fromImport, T callback()) {
+    assert(Zone.current[#_canonicalizeContext] == this);
+
     var oldFromImport = _fromImport;
     _fromImport = fromImport;
     try {

--- a/lib/src/importer/js_to_dart/async.dart
+++ b/lib/src/importer/js_to_dart/async.dart
@@ -20,7 +20,7 @@ import 'utils.dart';
 /// a Dart [AsyncImporter].
 final class JSToDartAsyncImporter extends AsyncImporter {
   /// The wrapped canonicalize function.
-  final Object? Function(String, CanonicalizeContext) _canonicalize;
+  final Object? Function(String, JSCanonicalizeContext) _canonicalize;
 
   /// The wrapped load function.
   final Object? Function(JSUrl) _load;
@@ -39,10 +39,7 @@ final class JSToDartAsyncImporter extends AsyncImporter {
 
   FutureOr<Uri?> canonicalize(Uri url) async {
     var result = wrapJSExceptions(() => _canonicalize(
-        url.toString(),
-        CanonicalizeContext(
-            fromImport: fromImport,
-            containingUrl: containingUrl.andThen(dartToJSUrl))));
+        url.toString(), dartToJSCanonicalizeContext(canonicalizeContext)));
     if (isPromise(result)) result = await promiseToFuture(result as Promise);
     if (result == null) return null;
 

--- a/lib/src/importer/js_to_dart/async.dart
+++ b/lib/src/importer/js_to_dart/async.dart
@@ -13,6 +13,7 @@ import '../../js/url.dart';
 import '../../js/utils.dart';
 import '../../util/nullable.dart';
 import '../async.dart';
+import '../canonicalize_context.dart';
 import '../result.dart';
 import 'utils.dart';
 
@@ -20,7 +21,7 @@ import 'utils.dart';
 /// a Dart [AsyncImporter].
 final class JSToDartAsyncImporter extends AsyncImporter {
   /// The wrapped canonicalize function.
-  final Object? Function(String, JSCanonicalizeContext) _canonicalize;
+  final Object? Function(String, CanonicalizeContext) _canonicalize;
 
   /// The wrapped load function.
   final Object? Function(JSUrl) _load;
@@ -38,8 +39,8 @@ final class JSToDartAsyncImporter extends AsyncImporter {
   }
 
   FutureOr<Uri?> canonicalize(Uri url) async {
-    var result = wrapJSExceptions(() => _canonicalize(
-        url.toString(), dartToJSCanonicalizeContext(canonicalizeContext)));
+    var result = wrapJSExceptions(
+        () => _canonicalize(url.toString(), canonicalizeContext));
     if (isPromise(result)) result = await promiseToFuture(result as Promise);
     if (result == null) return null;
 

--- a/lib/src/importer/js_to_dart/async_file.dart
+++ b/lib/src/importer/js_to_dart/async_file.dart
@@ -11,7 +11,6 @@ import 'package:node_interop/util.dart';
 import '../../js/importer.dart';
 import '../../js/url.dart';
 import '../../js/utils.dart';
-import '../../util/nullable.dart';
 import '../async.dart';
 import '../filesystem.dart';
 import '../result.dart';
@@ -21,7 +20,7 @@ import '../utils.dart';
 /// it as a Dart [AsyncImporter].
 final class JSToDartAsyncFileImporter extends AsyncImporter {
   /// The wrapped `findFileUrl` function.
-  final Object? Function(String, CanonicalizeContext) _findFileUrl;
+  final Object? Function(String, JSCanonicalizeContext) _findFileUrl;
 
   JSToDartAsyncFileImporter(this._findFileUrl);
 
@@ -29,10 +28,7 @@ final class JSToDartAsyncFileImporter extends AsyncImporter {
     if (url.scheme == 'file') return FilesystemImporter.cwd.canonicalize(url);
 
     var result = wrapJSExceptions(() => _findFileUrl(
-        url.toString(),
-        CanonicalizeContext(
-            fromImport: fromImport,
-            containingUrl: containingUrl.andThen(dartToJSUrl))));
+        url.toString(), dartToJSCanonicalizeContext(canonicalizeContext)));
     if (isPromise(result)) result = await promiseToFuture(result as Promise);
     if (result == null) return null;
     if (!isJSUrl(result)) {

--- a/lib/src/importer/js_to_dart/async_file.dart
+++ b/lib/src/importer/js_to_dart/async_file.dart
@@ -8,10 +8,10 @@ import 'package:cli_pkg/js.dart';
 import 'package:node_interop/js.dart';
 import 'package:node_interop/util.dart';
 
-import '../../js/importer.dart';
 import '../../js/url.dart';
 import '../../js/utils.dart';
 import '../async.dart';
+import '../canonicalize_context.dart';
 import '../filesystem.dart';
 import '../result.dart';
 import '../utils.dart';
@@ -20,15 +20,15 @@ import '../utils.dart';
 /// it as a Dart [AsyncImporter].
 final class JSToDartAsyncFileImporter extends AsyncImporter {
   /// The wrapped `findFileUrl` function.
-  final Object? Function(String, JSCanonicalizeContext) _findFileUrl;
+  final Object? Function(String, CanonicalizeContext) _findFileUrl;
 
   JSToDartAsyncFileImporter(this._findFileUrl);
 
   FutureOr<Uri?> canonicalize(Uri url) async {
     if (url.scheme == 'file') return FilesystemImporter.cwd.canonicalize(url);
 
-    var result = wrapJSExceptions(() => _findFileUrl(
-        url.toString(), dartToJSCanonicalizeContext(canonicalizeContext)));
+    var result = wrapJSExceptions(
+        () => _findFileUrl(url.toString(), canonicalizeContext));
     if (isPromise(result)) result = await promiseToFuture(result as Promise);
     if (result == null) return null;
     if (!isJSUrl(result)) {

--- a/lib/src/importer/js_to_dart/file.dart
+++ b/lib/src/importer/js_to_dart/file.dart
@@ -6,24 +6,24 @@ import 'package:cli_pkg/js.dart';
 import 'package:node_interop/js.dart';
 
 import '../../importer.dart';
-import '../../js/importer.dart';
 import '../../js/url.dart';
 import '../../js/utils.dart';
+import '../canonicalize_context.dart';
 import '../utils.dart';
 
 /// A wrapper for a potentially-asynchronous JS API file importer that exposes
 /// it as a Dart [AsyncImporter].
 final class JSToDartFileImporter extends Importer {
   /// The wrapped `findFileUrl` function.
-  final Object? Function(String, JSCanonicalizeContext) _findFileUrl;
+  final Object? Function(String, CanonicalizeContext) _findFileUrl;
 
   JSToDartFileImporter(this._findFileUrl);
 
   Uri? canonicalize(Uri url) {
     if (url.scheme == 'file') return FilesystemImporter.cwd.canonicalize(url);
 
-    var result = wrapJSExceptions(() => _findFileUrl(
-        url.toString(), dartToJSCanonicalizeContext(canonicalizeContext)));
+    var result = wrapJSExceptions(
+        () => _findFileUrl(url.toString(), canonicalizeContext));
     if (result == null) return null;
 
     if (isPromise(result)) {

--- a/lib/src/importer/js_to_dart/file.dart
+++ b/lib/src/importer/js_to_dart/file.dart
@@ -9,14 +9,13 @@ import '../../importer.dart';
 import '../../js/importer.dart';
 import '../../js/url.dart';
 import '../../js/utils.dart';
-import '../../util/nullable.dart';
 import '../utils.dart';
 
 /// A wrapper for a potentially-asynchronous JS API file importer that exposes
 /// it as a Dart [AsyncImporter].
 final class JSToDartFileImporter extends Importer {
   /// The wrapped `findFileUrl` function.
-  final Object? Function(String, CanonicalizeContext) _findFileUrl;
+  final Object? Function(String, JSCanonicalizeContext) _findFileUrl;
 
   JSToDartFileImporter(this._findFileUrl);
 
@@ -24,10 +23,7 @@ final class JSToDartFileImporter extends Importer {
     if (url.scheme == 'file') return FilesystemImporter.cwd.canonicalize(url);
 
     var result = wrapJSExceptions(() => _findFileUrl(
-        url.toString(),
-        CanonicalizeContext(
-            fromImport: fromImport,
-            containingUrl: containingUrl.andThen(dartToJSUrl))));
+        url.toString(), dartToJSCanonicalizeContext(canonicalizeContext)));
     if (result == null) return null;
 
     if (isPromise(result)) {

--- a/lib/src/importer/js_to_dart/sync.dart
+++ b/lib/src/importer/js_to_dart/sync.dart
@@ -10,13 +10,14 @@ import '../../js/importer.dart';
 import '../../js/url.dart';
 import '../../js/utils.dart';
 import '../../util/nullable.dart';
+import '../canonicalize_context.dart';
 import 'utils.dart';
 
 /// A wrapper for a synchronous JS API importer that exposes it as a Dart
 /// [Importer].
 final class JSToDartImporter extends Importer {
   /// The wrapped canonicalize function.
-  final Object? Function(String, JSCanonicalizeContext) _canonicalize;
+  final Object? Function(String, CanonicalizeContext) _canonicalize;
 
   /// The wrapped load function.
   final Object? Function(JSUrl) _load;
@@ -34,8 +35,8 @@ final class JSToDartImporter extends Importer {
   }
 
   Uri? canonicalize(Uri url) {
-    var result = wrapJSExceptions(() => _canonicalize(
-        url.toString(), dartToJSCanonicalizeContext(canonicalizeContext)));
+    var result = wrapJSExceptions(
+        () => _canonicalize(url.toString(), canonicalizeContext));
     if (result == null) return null;
     if (isJSUrl(result)) return jsToDartUrl(result as JSUrl);
 

--- a/lib/src/importer/js_to_dart/sync.dart
+++ b/lib/src/importer/js_to_dart/sync.dart
@@ -16,7 +16,7 @@ import 'utils.dart';
 /// [Importer].
 final class JSToDartImporter extends Importer {
   /// The wrapped canonicalize function.
-  final Object? Function(String, CanonicalizeContext) _canonicalize;
+  final Object? Function(String, JSCanonicalizeContext) _canonicalize;
 
   /// The wrapped load function.
   final Object? Function(JSUrl) _load;
@@ -35,10 +35,7 @@ final class JSToDartImporter extends Importer {
 
   Uri? canonicalize(Uri url) {
     var result = wrapJSExceptions(() => _canonicalize(
-        url.toString(),
-        CanonicalizeContext(
-            fromImport: fromImport,
-            containingUrl: containingUrl.andThen(dartToJSUrl))));
+        url.toString(), dartToJSCanonicalizeContext(canonicalizeContext)));
     if (result == null) return null;
     if (isJSUrl(result)) return jsToDartUrl(result as JSUrl);
 

--- a/lib/src/js.dart
+++ b/lib/src/js.dart
@@ -7,6 +7,7 @@ import 'package:js/js_util.dart';
 import 'js/exception.dart';
 import 'js/deprecations.dart';
 import 'js/exports.dart';
+import 'js/importer/canonicalize_context.dart';
 import 'js/compile.dart';
 import 'js/compiler.dart';
 import 'js/legacy.dart';
@@ -64,6 +65,7 @@ void main() {
       "dart2js\t${const String.fromEnvironment('dart-version')}\t"
       "(Dart Compiler)\t[Dart]";
 
+  updateCanonicalizeContextPrototype();
   updateSourceSpanPrototype();
 
   // Legacy API

--- a/lib/src/js/importer.dart
+++ b/lib/src/js/importer.dart
@@ -9,19 +9,17 @@ import 'url.dart';
 @JS()
 @anonymous
 class JSImporter {
-  external Object? Function(String, CanonicalizeContext)? get canonicalize;
+  external Object? Function(String, JSCanonicalizeContext)? get canonicalize;
   external Object? Function(JSUrl)? get load;
-  external Object? Function(String, CanonicalizeContext)? get findFileUrl;
+  external Object? Function(String, JSCanonicalizeContext)? get findFileUrl;
   external Object? get nonCanonicalScheme;
 }
 
 @JS()
 @anonymous
-class CanonicalizeContext {
+class JSCanonicalizeContext {
   external bool get fromImport;
   external JSUrl? get containingUrl;
-
-  external factory CanonicalizeContext({bool fromImport, JSUrl? containingUrl});
 }
 
 @JS()

--- a/lib/src/js/importer.dart
+++ b/lib/src/js/importer.dart
@@ -4,22 +4,16 @@
 
 import 'package:js/js.dart';
 
+import '../importer/canonicalize_context.dart';
 import 'url.dart';
 
 @JS()
 @anonymous
 class JSImporter {
-  external Object? Function(String, JSCanonicalizeContext)? get canonicalize;
+  external Object? Function(String, CanonicalizeContext)? get canonicalize;
   external Object? Function(JSUrl)? get load;
-  external Object? Function(String, JSCanonicalizeContext)? get findFileUrl;
+  external Object? Function(String, CanonicalizeContext)? get findFileUrl;
   external Object? get nonCanonicalScheme;
-}
-
-@JS()
-@anonymous
-class JSCanonicalizeContext {
-  external bool get fromImport;
-  external JSUrl? get containingUrl;
 }
 
 @JS()

--- a/lib/src/js/importer/canonicalize_context.dart
+++ b/lib/src/js/importer/canonicalize_context.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:js/js.dart';
+
+import '../../importer/canonicalize_context.dart';
+import '../url.dart';
+import '../../util/nullable.dart';
+import '../utils.dart';
+
+@JSExport()
+class JSExportCanonicalizeContext {
+  final CanonicalizeContext _canonicalizeContext;
+
+  bool get fromImport => _canonicalizeContext.fromImport;
+  JSUrl? get containingUrl =>
+      _canonicalizeContext.containingUrl.andThen(dartToJSUrl);
+
+  JSExportCanonicalizeContext(this._canonicalizeContext);
+}

--- a/lib/src/js/importer/canonicalize_context.dart
+++ b/lib/src/js/importer/canonicalize_context.dart
@@ -2,20 +2,15 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'package:js/js.dart';
-
 import '../../importer/canonicalize_context.dart';
-import '../url.dart';
 import '../../util/nullable.dart';
+import '../reflection.dart';
 import '../utils.dart';
 
-@JSExport()
-class JSExportCanonicalizeContext {
-  final CanonicalizeContext _canonicalizeContext;
-
-  bool get fromImport => _canonicalizeContext.fromImport;
-  JSUrl? get containingUrl =>
-      _canonicalizeContext.containingUrl.andThen(dartToJSUrl);
-
-  JSExportCanonicalizeContext(this._canonicalizeContext);
-}
+/// Adds JS members to Dart's `CanonicalizeContext` class.
+void updateCanonicalizeContextPrototype() =>
+    getJSClass(CanonicalizeContext(null, false)).defineGetters({
+      'fromImport': (CanonicalizeContext self) => self.fromImport,
+      'containingUrl': (CanonicalizeContext self) =>
+          self.containingUrl.andThen(dartToJSUrl),
+    });

--- a/lib/src/js/utils.dart
+++ b/lib/src/js/utils.dart
@@ -9,14 +9,11 @@ import 'package:node_interop/node.dart' hide module;
 import 'package:js/js.dart';
 import 'package:js/js_util.dart';
 
-import '../importer/canonicalize_context.dart';
 import '../syntax.dart';
 import '../utils.dart';
 import '../value.dart';
 import 'array.dart';
 import 'function.dart';
-import 'importer.dart';
-import 'importer/canonicalize_context.dart';
 import 'module.dart';
 import 'reflection.dart';
 import 'url.dart';
@@ -199,12 +196,6 @@ Uri jsToDartUrl(JSUrl url) => Uri.parse(url.toString());
 
 /// Converts a Dart [Uri] object to a standard JS `URL` object.
 JSUrl dartToJSUrl(Uri url) => JSUrl(url.toString());
-
-JSCanonicalizeContext dartToJSCanonicalizeContext(
-    CanonicalizeContext canonicalizeContext) {
-  return createDartExport(JSExportCanonicalizeContext(canonicalizeContext))
-      as JSCanonicalizeContext;
-}
 
 /// Creates a JavaScript array containing [iterable].
 ///

--- a/lib/src/js/utils.dart
+++ b/lib/src/js/utils.dart
@@ -9,11 +9,14 @@ import 'package:node_interop/node.dart' hide module;
 import 'package:js/js.dart';
 import 'package:js/js_util.dart';
 
+import '../importer/canonicalize_context.dart';
 import '../syntax.dart';
 import '../utils.dart';
 import '../value.dart';
 import 'array.dart';
 import 'function.dart';
+import 'importer.dart';
+import 'importer/canonicalize_context.dart';
 import 'module.dart';
 import 'reflection.dart';
 import 'url.dart';
@@ -196,6 +199,12 @@ Uri jsToDartUrl(JSUrl url) => Uri.parse(url.toString());
 
 /// Converts a Dart [Uri] object to a standard JS `URL` object.
 JSUrl dartToJSUrl(Uri url) => JSUrl(url.toString());
+
+JSCanonicalizeContext dartToJSCanonicalizeContext(
+    CanonicalizeContext canonicalizeContext) {
+  return createDartExport(JSExportCanonicalizeContext(canonicalizeContext))
+      as JSCanonicalizeContext;
+}
 
 /// Creates a JavaScript array containing [iterable].
 ///

--- a/lib/src/js/value/mixin.dart
+++ b/lib/src/js/value/mixin.dart
@@ -13,7 +13,8 @@ import '../utils.dart';
 final JSClass mixinClass = () {
   var jsClass = createJSClass('sass.SassMixin', (Object self) {
     jsThrow(JsError(
-        'It is not possible to construct a SassMixin through the JavaScript API'));
+        'It is not possible to construct a SassMixin through the JavaScript '
+        'API'));
   });
 
   getJSClass(SassMixin(Callable('f', '', (_) => sassNull)))


### PR DESCRIPTION
This PR adds a `CanonicalizeContext` class in dart which is able to track if `containingUrl` is accessed or not, it also changes the dart2js `JSCanonicalizeContext` class to be a wrapper, so that the containingUrl in JS would lazily access the dart `containingUrl` method instead of eagerly during construction. Finally for embedded host, this adds a `containingUrlWithoutMarking` method that allow the serialization of embedded protocol without marking, and we can mark it accordingly depends on the result from host. 

https://github.com/sass/sass/pull/3835
https://github.com/sass/embedded-host-node/pull/285

