### PR TITLE
Deprecate function and mixin names beginning with `--`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 1.75.1
+## 1.76.0
 
 * Throw errors for misplaced statements in keyframe blocks.
+
+* Mixins and functions whose names begin with `--` are now deprecated for
+  forwards-compatibility with the in-progress CSS functions and mixins spec.
+  This deprecation is named `css-function-mixin`.
 
 ## 1.75.0
 

--- a/lib/src/deprecation.dart
+++ b/lib/src/deprecation.dart
@@ -74,6 +74,10 @@ enum Deprecation {
       description:
           'Using the current working directory as an implicit load path.'),
 
+  cssFunctionMixin('css-function-mixin',
+      deprecatedIn: '1.76.0',
+      description: 'Function and mixin names beginning with --.'),
+
   @Deprecated('This deprecation name was never actually used.')
   calcInterp('calc-interp', deprecatedIn: null),
 

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -846,7 +846,19 @@ abstract class StylesheetParser extends Parser {
   FunctionRule _functionRule(LineScannerState start) {
     var precedingComment = lastSilentComment;
     lastSilentComment = null;
+    var beforeName = scanner.state;
     var name = identifier(normalize: true);
+
+    if (name.startsWith('--')) {
+      logger.warnForDeprecation(
+          Deprecation.cssFunctionMixin,
+          'Sass @function names beginning with -- are deprecated for forward-'
+          'compatibility with plain CSS mixins.\n'
+          '\n'
+          'For details, see https://sass-lang.com/d/css-function-mixin',
+          span: scanner.spanFrom(beforeName));
+    }
+
     whitespace();
     var arguments = _argumentDeclaration();
 
@@ -1261,7 +1273,19 @@ abstract class StylesheetParser extends Parser {
   MixinRule _mixinRule(LineScannerState start) {
     var precedingComment = lastSilentComment;
     lastSilentComment = null;
+    var beforeName = scanner.state;
     var name = identifier(normalize: true);
+
+    if (name.startsWith('--')) {
+      logger.warnForDeprecation(
+          Deprecation.cssFunctionMixin,
+          'Sass @mixin names beginning with -- are deprecated for forward-'
+          'compatibility with plain CSS mixins.\n'
+          '\n'
+          'For details, see https://sass-lang.com/d/css-function-mixin',
+          span: scanner.spanFrom(beforeName));
+    }
+
     whitespace();
     var arguments = scanner.peekChar() == $lparen
         ? _argumentDeclaration()

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.3.0
+
+* No user-visible changes.
+
 ## 10.2.1
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 10.2.1-dev
+version: 10.3.0
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sass: 1.75.1
+  sass: 1.76.0
 
 dev_dependencies:
   dartdoc: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.75.1-dev
+version: 1.76.0
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
See #2197
See sass/sass#3854
See sass/sass-spec#1982
[skip sass-embedded]