### PR TITLE
Enable AOT build for linux-riscv64-musl

### DIFF
--- a/.github/workflows/build-linux-musl.yml
+++ b/.github/workflows/build-linux-musl.yml
@@ -26,9 +26,8 @@ jobs:
           # https://gitlab.com/qemu-project/qemu/-/issues/1729
           - arch: arm
             platform: linux/amd64 # linux/arm/v7
-          # There is no docker image for riscv64 dart-sdk, build kernel snapshot instead.
           - arch: riscv64
-            platform: linux/amd64 # linux/riscv64
+            platform: linux/riscv64
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Alpine 3.20 has added stable support of `riscv64`, and I started to publish containers for `linux-riscv64-musl` for `dart >=3.4.3`: https://github.com/dart-musl/dart/pkgs/container/dart