### PR TITLE
Fix linux-ia32, linux-arm-musl, and windows-arm64 releases

### DIFF
--- a/.github/workflows/build-linux-musl.yml
+++ b/.github/workflows/build-linux-musl.yml
@@ -19,7 +19,7 @@ jobs:
             platform: linux/amd64
           - arch: ia32
             runner: ubuntu-latest
-            platform: linux/386
+            platform: linux/amd64
           - arch: arm64
             runner: linux-arm64
             platform: linux/arm64
@@ -51,7 +51,7 @@ jobs:
       - name: Build
         run: |
           docker run --rm -i \
-                     --platform ${{ matrix.arch == 'arm' && 'linux/amd64' || matrix.platform }} \
+                     --platform ${{ matrix.platform }} \
                      --volume "$PWD:$PWD" \
                      --workdir "$PWD" \
                      ghcr.io/dart-musl/dart <<'EOF'

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -19,7 +19,7 @@ jobs:
             platform: linux/amd64
           - arch: ia32
             runner: ubuntu-latest
-            platform: linux/386
+            platform: linux/amd64
           - arch: arm64
             runner: linux-arm64
             platform: linux/arm64

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,7 +19,8 @@ jobs:
           - arch: ia32
             runner: windows-latest
           - arch: arm64
-            runner: windows-arm64
+            # TODO: switch the following to windows-arm64, blocked by https://github.com/dart-lang/setup-dart/issues/118
+            runner: windows-latest # windows-arm64
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
@nex3 Sorry that my recent commit broken the release CI. This PR should fix it.

https://github.com/sass/dart-sass/actions/runs/9554504858/job/26336030878