### PR TITLE
Enable AOT build for windows-arm64

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,8 +19,7 @@ jobs:
           - arch: ia32
             runner: windows-latest
           - arch: arm64
-            # TODO: switch the following to windows-arm64, blocked by https://github.com/dart-lang/setup-dart/issues/118
-            runner: windows-latest # windows-arm64
+            runner: windows-arm64
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Now https://github.com/dart-lang/setup-dart/issues/118 is fixed, we should be able to enable AOT for windows-arm64.