### PR TITLE
Enable AOT build for windows-arm64

### DIFF
--- a/.github/util/initialize/action.yml
+++ b/.github/util/initialize/action.yml
@@ -44,6 +44,8 @@ runs:
     - uses: bufbuild/buf-setup-action@v1.30.0
       with: {github_token: "${{ inputs.github-token }}"}
 
+    # This composite action requires bash, but bash is not available on windows-arm64 runner.
+    # Avoid running this composite action on non-PR, so that we can release on windows-arm64.
     - name: Check out the language repo
       if: github.event_name == 'pull_request'
       uses: sass/clone-linked-repo@v1

--- a/.github/util/initialize/action.yml
+++ b/.github/util/initialize/action.yml
@@ -20,18 +20,18 @@ runs:
     # See: https://github.com/dart-lang/sdk/issues/52266
     - run: Invoke-WebRequest https://pub.dev
       if: runner.os == 'Windows'
-      shell: pwsh
+      shell: powershell
 
     # See: https://github.com/orgs/community/discussions/131594
     # The composite action requires an explict shell, but bash is not available on windows-arm64 runner.
-    # For the following commands conditionally use bash or pwsh based on the runner.os:
+    # For the following commands conditionally use bash or powershell based on the runner.os:
     - run: dart pub get
       if: runner.os != 'Windows'
       shell: bash
 
     - run: dart pub get
       if: runner.os == 'Windows'
-      shell: pwsh
+      shell: powershell
 
     - run: npm install
       if: runner.os != 'Windows'
@@ -39,7 +39,7 @@ runs:
 
     - run: npm install
       if: runner.os == 'Windows'
-      shell: pwsh
+      shell: powershell
 
     - uses: bufbuild/buf-setup-action@v1.30.0
       with: {github_token: "${{ inputs.github-token }}"}
@@ -63,4 +63,4 @@ runs:
       run: dart run grinder protobuf
       env:
         UPDATE_SASS_SASS_REPO: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-      shell: pwsh
+      shell: powershell

--- a/.github/util/initialize/action.yml
+++ b/.github/util/initialize/action.yml
@@ -17,20 +17,48 @@ runs:
       with:
         node-version: "${{ inputs.node-version }}"
 
+    # See: https://github.com/dart-lang/sdk/issues/52266
+    - run: Invoke-WebRequest https://pub.dev
+      if: runner.os == 'Windows'
+      shell: pwsh
+
+    # See: https://github.com/orgs/community/discussions/131594
+    # The composite action requires an explict shell, but bash is not available on windows-arm64 runner.
+    # For the following commands conditionally use bash or pwsh based on the runner.os:
     - run: dart pub get
+      if: runner.os != 'Windows'
+      shell: bash
+
+    - run: dart pub get
+      if: runner.os == 'Windows'
+      shell: pwsh
+
+    - run: npm install
+      if: runner.os != 'Windows'
       shell: bash
 
     - run: npm install
-      shell: bash
+      if: runner.os == 'Windows'
+      shell: pwsh
 
     - uses: bufbuild/buf-setup-action@v1.30.0
       with: {github_token: "${{ inputs.github-token }}"}
 
     - name: Check out the language repo
+      if: github.event_name == 'pull_request'
       uses: sass/clone-linked-repo@v1
       with: {repo: sass/sass, path: build/language}
 
     - name: Generate Dart from protobuf
+      if: runner.os != 'Windows'
       run: dart run grinder protobuf
-      env: {UPDATE_SASS_SASS_REPO: false}
+      env:
+        UPDATE_SASS_SASS_REPO: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
       shell: bash
+
+    - name: Generate Dart from protobuf
+      if: runner.os == 'Windows'
+      run: dart run grinder protobuf
+      env:
+        UPDATE_SASS_SASS_REPO: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
+      shell: pwsh

--- a/.github/util/initialize/action.yml
+++ b/.github/util/initialize/action.yml
@@ -51,16 +51,21 @@ runs:
       uses: sass/clone-linked-repo@v1
       with: {repo: sass/sass, path: build/language}
 
+    # Git is not pre-installed on windows-arm64 runner, however actions/checkout support
+    # downloading repo via GitHub API.
+    - name: Check out the language repo
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@v4
+      with: {repository: sass/sass, path: build/language}
+
     - name: Generate Dart from protobuf
       if: runner.os != 'Windows'
       run: dart run grinder protobuf
-      env:
-        UPDATE_SASS_SASS_REPO: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
+      env: {UPDATE_SASS_SASS_REPO: false}
       shell: bash
 
     - name: Generate Dart from protobuf
       if: runner.os == 'Windows'
       run: dart run grinder protobuf
-      env:
-        UPDATE_SASS_SASS_REPO: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
+      env: {UPDATE_SASS_SASS_REPO: false}
       shell: powershell

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,10 +19,7 @@ jobs:
           - arch: ia32
             runner: windows-latest
           - arch: arm64
-            # This should be windows-arm64, but it's broken by several issues:
-            # https://github.com/orgs/community/discussions/131594
-            # https://github.com/orgs/community/discussions/131754
-            runner: windows-latest
+            runner: windows-arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -37,8 +34,13 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1.30.0
         with: {github_token: "${{ github.token }}"}
 
+      # See: https://github.com/dart-lang/sdk/issues/52266
+      - name: Setup Root CA
+        shell: pwsh
+        run: Invoke-WebRequest https://pub.dev
+
       - name: Install Dependencies
-        run: dart pub get --verbose
+        run: dart pub get
 
       - name: Compile Protobuf
         run: dart run grinder protobuf

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,26 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # See: https://github.com/orgs/community/discussions/131594
-      # The composite action requires bash which is not available on windows-arm64 runner.
-      # - uses: ./.github/util/initialize
-      #   with: {github-token: "${{ github.token }}"}
-
-      - uses: dart-lang/setup-dart@v1
-
-      - uses: bufbuild/buf-setup-action@v1.30.0
-        with: {github_token: "${{ github.token }}"}
-
-      # See: https://github.com/dart-lang/sdk/issues/52266
-      - name: Setup Root CA
-        shell: pwsh
-        run: Invoke-WebRequest https://pub.dev
-
-      - name: Install Dependencies
-        run: dart pub get
-
-      - name: Compile Protobuf
-        run: dart run grinder protobuf
+      - uses: ./.github/util/initialize
+        with: {github-token: "${{ github.token }}"}
 
       - name: Build
         run: dart run grinder pkg-standalone-windows-${{ matrix.arch }}


### PR DESCRIPTION
This PR is another attempt to enable AOT snapshot for windows-arm64. It turns out the TLS issue we're seeing is likely not a windows runner bug but a windows feature and a dart bug: https://github.com/dart-lang/sdk/issues/52266

In summary, the problem is that windows would lazily initialize some trusted certificates, but dart does not support this lazy initialization. The x86_64 windows runner image likely already have the missing root certificates initialized at some point by other calls made to other google services during its image provisioning, but this arm64 image isn't the same.

@nex3 I would like to give this another try, but I don't have access to arm64 runners. If you can push this commit to a branch directly in sass/dart-sass repo, you can use "run workflow" feature to test it without needing to merge this PR first.
