### PR TITLE
Fix empty `@at-root` in the indented syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.78.0
 
+* Fix a crash when using `@at-root` without any queries or children in the
+  indented syntax.
+
 ### JS API
 
 * Fix a bug where accessing `SourceSpan.url` would crash when a relative URL was

--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -731,7 +731,7 @@ abstract class StylesheetParser extends Parser {
       whitespace();
       return _withChildren(_statement, start,
           (children, span) => AtRootRule(children, span, query: query));
-    } else if (lookingAtChildren()) {
+    } else if (lookingAtChildren() || (indented && atEndOfStatement())) {
       return _withChildren(
           _statement, start, (children, span) => AtRootRule(children, span));
     } else {


### PR DESCRIPTION
See sass/sass-spec#2010