### PR TITLE
Fix flaky shutdown

### DIFF
--- a/lib/src/embedded/compilation_dispatcher.dart
+++ b/lib/src/embedded/compilation_dispatcher.dart
@@ -386,7 +386,8 @@ final class CompilationDispatcher {
     try {
       return _mailbox.take();
     } on StateError catch (_) {
-      // [_mailbox] has been closed, exit the current isolate
+      // The [_mailbox] has been closed, exit the current isolate immediately
+      // to avoid bubble the error up as [SassException] during [_sendRequest].
       Isolate.exit();
     }
   }

--- a/lib/src/embedded/compilation_dispatcher.dart
+++ b/lib/src/embedded/compilation_dispatcher.dart
@@ -51,24 +51,18 @@ final class CompilationDispatcher {
   /// This is used in outgoing messages.
   late Uint8List _compilationIdVarint;
 
-  /// Whether we detected a [ProtocolError] while parsing an incoming response.
-  ///
-  /// If we have, we don't want to send the final compilation result because
-  /// it'll just be a wrapper around the error.
-  var _requestError = false;
-
   /// Creates a [CompilationDispatcher] that receives encoded protocol buffers
   /// through [_mailbox] and sends them through [_sendPort].
   CompilationDispatcher(this._mailbox, this._sendPort);
 
   /// Listens for incoming `CompileRequests` and runs their compilations.
   void listen() {
-    do {
+    while (true) {
       Uint8List packet;
       try {
         packet = _mailbox.take();
       } on StateError catch (_) {
-        break;
+        Isolate.exit();
       }
 
       try {
@@ -88,9 +82,7 @@ final class CompilationDispatcher {
           case InboundMessage_Message.compileRequest:
             var request = message.compileRequest;
             var response = _compile(request);
-            if (!_requestError) {
-              _send(OutboundMessage()..compileResponse = response);
-            }
+            _send(OutboundMessage()..compileResponse = response);
 
           case InboundMessage_Message.versionRequest:
             throw paramsError("VersionRequest must have compilation ID 0.");
@@ -113,7 +105,7 @@ final class CompilationDispatcher {
       } catch (error, stackTrace) {
         _handleError(error, stackTrace);
       }
-    } while (!_requestError);
+    }
   }
 
   OutboundMessage_CompileResponse _compile(
@@ -287,19 +279,13 @@ final class CompilationDispatcher {
   void sendLog(OutboundMessage_LogEvent event) =>
       _send(OutboundMessage()..logEvent = event);
 
-  /// Sends [error] to the host.
+  /// Sends [error] to the host and exit.
   ///
   /// This is used during compilation by other classes like host callable.
-  /// Therefore it must set _requestError = true to prevent sending a CompileFailure after
-  /// sending a ProtocolError.
-  void sendError(ProtocolError error) {
-    _sendError(error);
-    _requestError = true;
+  Never sendError(ProtocolError error) {
+    Isolate.exit(
+        _sendPort, _serializePacket((OutboundMessage()..error = error)));
   }
-
-  /// Sends [error] to the host.
-  void _sendError(ProtocolError error) =>
-      _send(OutboundMessage()..error = error);
 
   InboundMessage_CanonicalizeResponse sendCanonicalizeRequest(
           OutboundMessage_CanonicalizeRequest request) =>
@@ -330,10 +316,7 @@ final class CompilationDispatcher {
     try {
       packet = _mailbox.take();
     } on StateError catch (_) {
-      // Compiler is shutting down, throw without calling `_handleError` as we
-      // don't want to report this as an actual error.
-      _requestError = true;
-      rethrow;
+      Isolate.exit();
     }
 
     try {
@@ -376,8 +359,6 @@ final class CompilationDispatcher {
       return response;
     } catch (error, stackTrace) {
       _handleError(error, stackTrace);
-      _requestError = true;
-      rethrow;
     }
   }
 
@@ -385,12 +366,17 @@ final class CompilationDispatcher {
   ///
   /// The [messageId] indicate the IDs of the message being responded to, if
   /// available.
-  void _handleError(Object error, StackTrace stackTrace, {int? messageId}) {
-    _sendError(handleError(error, stackTrace, messageId: messageId));
+  Never _handleError(Object error, StackTrace stackTrace, {int? messageId}) {
+    sendError(handleError(error, stackTrace, messageId: messageId));
   }
 
   /// Sends [message] to the host with the given [wireId].
   void _send(OutboundMessage message) {
+    _sendPort.send(_serializePacket(message));
+  }
+
+  /// Serialize [message] to [Uint8List].
+  Uint8List _serializePacket(OutboundMessage message) {
     var protobufWriter = CodedBufferWriter();
     message.writeToCodedBufferWriter(protobufWriter);
 
@@ -407,6 +393,6 @@ final class CompilationDispatcher {
     };
     packet.setAll(1, _compilationIdVarint);
     protobufWriter.writeTo(packet, 1 + _compilationIdVarint.length);
-    _sendPort.send(packet);
+    return packet;
   }
 }

--- a/lib/src/embedded/compilation_dispatcher.dart
+++ b/lib/src/embedded/compilation_dispatcher.dart
@@ -283,8 +283,7 @@ final class CompilationDispatcher {
   ///
   /// This is used during compilation by other classes like host callable.
   Never sendError(ProtocolError error) {
-    Isolate.exit(
-        _sendPort, _serializePacket((OutboundMessage()..error = error)));
+    Isolate.exit(_sendPort, _serializePacket(OutboundMessage()..error = error));
   }
 
   InboundMessage_CanonicalizeResponse sendCanonicalizeRequest(

--- a/lib/src/embedded/host_callable.dart
+++ b/lib/src/embedded/host_callable.dart
@@ -53,7 +53,6 @@ Callable hostCallable(
       }
     } on ProtocolError catch (error, stackTrace) {
       dispatcher.sendError(handleError(error, stackTrace));
-      throw error.message;
     }
   });
   return callable;

--- a/lib/src/embedded/isolate_dispatcher.dart
+++ b/lib/src/embedded/isolate_dispatcher.dart
@@ -44,8 +44,8 @@ class IsolateDispatcher {
   /// See https://github.com/sass/dart-sass/pull/2019
   final _isolatePool = Pool(sizeOf<IntPtr>() <= 4 ? 7 : 15);
 
-  /// Whether the stdin has been closed or not.
-  bool _closed = false;
+  /// Whether [_channel] has been closed or not.
+  var _closed = false;
 
   IsolateDispatcher(this._channel);
 
@@ -62,9 +62,7 @@ class IsolateDispatcher {
               compilationId, () => _getIsolate(compilationId!));
 
           // The shutdown may have started by the time the isolate is spawned
-          if (_closed) {
-            return;
-          }
+          if (_closed) return;
 
           try {
             isolate.send(packet);

--- a/lib/src/embedded/isolate_dispatcher.dart
+++ b/lib/src/embedded/isolate_dispatcher.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:ffi';
+import 'dart:io';
 import 'dart:isolate';
 import 'dart:typed_data';
 
@@ -140,10 +141,8 @@ class IsolateDispatcher {
             _channel.sink.add(packet);
             isolate.release();
           case 2:
-            _activeIsolates.remove(compilationId);
             _channel.sink.add(packet);
-            _channel.sink.close();
-            isolate.release();
+            exit(exitCode);
         }
       }, onError: (Object error, StackTrace stackTrace) {
         _handleError(error, stackTrace);

--- a/lib/src/embedded/isolate_dispatcher.dart
+++ b/lib/src/embedded/isolate_dispatcher.dart
@@ -115,8 +115,10 @@ class IsolateDispatcher {
       var future = ReusableIsolate.spawn(_isolateMain);
       isolate = await future;
       isolate.receivePort.listen((message) {
-        assert(isolate.borrowed,
-            "Shouldn't receive a message before being borrowed.");
+        if (!isolate.borrowed) {
+          throw StateError(
+              "Shouldn't receive a message before being borrowed.");
+        }
 
         var fullBuffer = message as Uint8List;
 

--- a/lib/src/embedded/reusable_isolate.dart
+++ b/lib/src/embedded/reusable_isolate.dart
@@ -8,8 +8,7 @@ import 'dart:typed_data';
 
 import 'package:native_synchronization/mailbox.dart';
 import 'package:native_synchronization/sendable.dart';
-import 'embedded_sass.pb.dart';
-import 'utils.dart';
+import 'package:pool/pool.dart';
 
 /// The entrypoint for a [ReusableIsolate].
 ///
@@ -32,16 +31,12 @@ class ReusableIsolate {
 
   /// The [ReceivePort] that receives messages from the wrapped isolate.
   final ReceivePort _receivePort;
+  ReceivePort get receivePort => _receivePort;
 
-  /// The subscription to [_port].
-  final StreamSubscription<Object?> _subscription;
+  /// The [PoolResource] used to track whether this isolate is being used.
+  PoolResource? _resource;
 
-  /// Whether [checkOut] has been called and the returned stream has not yet
-  /// closed.
-  bool _checkedOut = false;
-
-  ReusableIsolate._(this._isolate, this._mailbox, this._receivePort)
-      : _subscription = _receivePort.listen(_defaultOnData);
+  ReusableIsolate._(this._isolate, this._mailbox, this._receivePort);
 
   /// Spawns a [ReusableIsolate] that runs the given [entryPoint].
   static Future<ReusableIsolate> spawn(
@@ -53,58 +48,20 @@ class ReusableIsolate {
     return ReusableIsolate._(isolate, mailbox, receivePort);
   }
 
-  /// Checks out this isolate and returns a stream of messages from it.
-  ///
-  /// This isolate is considered "checked out" until the returned stream
-  /// completes. While checked out, messages may be sent to the isolate using
-  /// [send].
-  ///
-  /// Throws a [StateError] if this is called while the isolate is already
-  /// checked out.
-  Stream<Uint8List> checkOut() {
-    if (_checkedOut) {
-      throw StateError(
-          "Can't call ResuableIsolate.checkOut until the previous stream has "
-          "completed.");
-    }
-    _checkedOut = true;
+  /// Whether this isolate is in use
+  bool get borrowed => _resource != null;
 
-    var controller = StreamController<Uint8List>(sync: true);
+  /// Request this isolate as part of a pool and mark it as in use.
+  void borrow(PoolResource resource) {
+    assert(!borrowed, 'ReusableIsolate has already been borrowed.');
+    _resource = resource;
+  }
 
-    _subscription.onData((message) {
-      var fullBuffer = message as Uint8List;
-
-      // The first byte of messages from isolates indicates whether the entire
-      // compilation is finished (1) or if it encountered an error (2). Sending
-      // this as part of the message buffer rather than a separate message
-      // avoids a race condition where the host might send a new compilation
-      // request with the same ID as one that just finished before the
-      // [IsolateDispatcher] receives word that the isolate with that ID is
-      // done. See sass/dart-sass#2004.
-      var category = fullBuffer[0];
-      var packet = Uint8List.sublistView(fullBuffer, 1);
-
-      if (category == 2) {
-        // Parse out the compilation ID and surface the [ProtocolError] as an
-        // error. This allows the [IsolateDispatcher] to notice that an error
-        // has occurred and close out the underlying channel.
-        var (_, buffer) = parsePacket(packet);
-        controller.addError(OutboundMessage.fromBuffer(buffer).error);
-        return;
-      }
-
-      controller.sink.add(packet);
-      if (category == 1) {
-        _checkedOut = false;
-        _subscription.onData(_defaultOnData);
-        _subscription.onError(null);
-        controller.close();
-      }
-    });
-
-    _subscription.onError(controller.addError);
-
-    return controller.stream;
+  /// Release this isolate from the pool.
+  void release() {
+    assert(borrowed, 'ReusableIsolate has not been borrowed.');
+    _resource!.release();
+    _resource = null;
   }
 
   /// Sends [message] to the isolate.
@@ -113,6 +70,7 @@ class ReusableIsolate {
   /// out, or if a second message is sent before the isolate has processed the
   /// first one.
   void send(Uint8List message) {
+    assert(borrowed, 'Cannot send a message before being borrowed');
     _mailbox.put(message);
   }
 
@@ -124,12 +82,6 @@ class ReusableIsolate {
     _isolate.kill(priority: Isolate.immediate);
     _receivePort.close();
   }
-}
-
-/// The default handler for data events from the wrapped isolate when it's not
-/// checked out.
-void _defaultOnData(Object? _) {
-  throw StateError("Shouldn't receive a message before being checked out.");
 }
 
 void _isolateMain(

--- a/lib/src/embedded/reusable_isolate.dart
+++ b/lib/src/embedded/reusable_isolate.dart
@@ -118,12 +118,11 @@ class ReusableIsolate {
 
   /// Shuts down the isolate.
   void kill() {
-    _isolate.kill();
-    _receivePort.close();
-
     // If the isolate is blocking on [Mailbox.take], it won't even process a
     // kill event, so we closed the mailbox to nofity and wake it up.
     _mailbox.close();
+    _isolate.kill(priority: Isolate.immediate);
+    _receivePort.close();
   }
 }
 

--- a/lib/src/embedded/reusable_isolate.dart
+++ b/lib/src/embedded/reusable_isolate.dart
@@ -53,13 +53,17 @@ class ReusableIsolate {
 
   /// Request this isolate as part of a pool and mark it as in use.
   void borrow(PoolResource resource) {
-    assert(!borrowed, 'ReusableIsolate has already been borrowed.');
+    if (borrowed) {
+      throw StateError('ReusableIsolate has already been borrowed.');
+    }
     _resource = resource;
   }
 
   /// Release this isolate from the pool.
   void release() {
-    assert(borrowed, 'ReusableIsolate has not been borrowed.');
+    if (!borrowed) {
+      throw StateError('ReusableIsolate has not been borrowed.');
+    }
     _resource!.release();
     _resource = null;
   }
@@ -70,7 +74,9 @@ class ReusableIsolate {
   /// out, or if a second message is sent before the isolate has processed the
   /// first one.
   void send(Uint8List message) {
-    assert(borrowed, 'Cannot send a message before being borrowed');
+    if (!borrowed) {
+      throw StateError('Cannot send a message before being borrowed');
+    }
     _mailbox.put(message);
   }
 


### PR DESCRIPTION
This PR fixes a few shutdown reliability issues including the following flaky test on GitHub Actions windows runner:

```
❌ test\embedded\importer_test.dart: emits a protocol error for a response without a corresponding request ID (failed)
  
  Process `dart_sass_embedded` was killed with SIGKILL in a tear-down. Output:
      canonicalizeRequest: {
        id: 0
        importerId: 1
        url: other
        fromImport: true
      }
      
  [e] Host caused params error: Response ID 1 doesn't match any outstanding requests in compilation 4321.
      error: {
        type: PARAMS
        id: 4294967295
        message: Response ID 1 doesn't match any outstanding requests in compilation 4321.
      }
  TimeoutException after 0:00:30.000000: Test timed out after 30 seconds. See https://pub.dev/packages/test#timeouts
  dart:isolate  _RawReceivePort._handleMessage
``` 