### PR TITLE
docs: Fix link to custom importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ files, you'll need to pass a [custom importer] to [`compileString()`] or
 
 [`compile()`]: https://sass-lang.com/documentation/js-api/functions/compile
 [`compileAsync()`]: https://sass-lang.com/documentation/js-api/functions/compileAsync
-[custom importer]: https://sass-lang.com/documentation/js-api/interfaces/StringOptionsWithImporter#importer
+[custom importer]: https://sass-lang.com/documentation/js-api/interfaces/stringoptions/#importer
 [`compileString()`]: https://sass-lang.com/documentation/js-api/functions/compileString
 [`compileStringAsync()`]: https://sass-lang.com/documentation/js-api/functions/compileStringAsync
 [legacy API]: #legacy-javascript-api


### PR DESCRIPTION
This pull request fixes the link to the *custom importer* option in the section "Dart Sass in the Browser" in the README.

The original link at [`/interfaces/StringOptionsWithImporter#importer`](https://sass-lang.com/documentation/js-api/interfaces/StringOptionsWithImporter#importer) goes to 404 page not found. In addition, the referenced interface `StringOptionsWithImporter` is deprecated and links to `StringOptions`, where the `importer` option is documented.

The updated URL is: https://sass-lang.com/documentation/js-api/interfaces/stringoptions/#importer

---

After creating this PR, I read the [contribution guide](https://github.com/sass/dart-sass/blob/280f95cf4aca39ec3a78fb4a84621b187f55a266/CONTRIBUTING.md#before-you-contribute) and learned that I would need to sign the Google Individual CLA. Unfortunately I'd prefer not to create a Google account in order to sign the CLA, or change my Git author email. I hereby declare this PR to be in the public domain. Maybe someone who has signed a CLA can take over and get it merged - otherwise please feel free to close it.

https://opensource.google/documentation/reference/cla

> Contributors must sign in with a Google account to sign the CLA or manage their CLA agreements.
>
> One of the most common problems is that the git author email in the commit is not an email address associated with a CLA. The solution is to [change the git author email](https://www.google.com/search?q=git+change+commit+email) to be an address covered by the CLA. That email should also be [added to their GitHub account](https://help.github.com/articles/adding-an-email-address-to-your-github-account/); it doesn't need to be the primary email, but it should be on the account.
