### PR TITLE
Ignore new `unreachable_switch_default` warning.

### DIFF
--- a/lib/src/functions/map.dart
+++ b/lib/src/functions/map.dart
@@ -61,7 +61,15 @@ final _set = BuiltInCallable.overloadedFunction("set", {
         throw SassScriptException("Expected \$args to contain a value.");
       case [...var keys, var value]:
         return _modify(map, keys, (_) => value);
-      default:
+      default: // ignore: unreachable_switch_default
+        // This code is unreachable, and the compiler knows it (hence the
+        // `unreachable_switch_default` warning being ignored above). However,
+        // due to architectural limitations in the Dart front end, the compiler
+        // doesn't understand that the code is unreachable until late in the
+        // compilation process (after flow analysis). So this `default` clause
+        // must be kept around to avoid flow analysis incorrectly concluding
+        // that the function fails to return. See
+        // https://github.com/dart-lang/language/issues/2977 for details.
         throw '[BUG] Unreachable code';
     }
   },
@@ -87,7 +95,15 @@ final _merge = BuiltInCallable.overloadedFunction("merge", {
           if (nestedMap == null) return map2;
           return SassMap({...nestedMap.contents, ...map2.contents});
         });
-      default:
+      default: // ignore: unreachable_switch_default
+        // This code is unreachable, and the compiler knows it (hence the
+        // `unreachable_switch_default` warning being ignored above). However,
+        // due to architectural limitations in the Dart front end, the compiler
+        // doesn't understand that the code is unreachable until late in the
+        // compilation process (after flow analysis). So this `default` clause
+        // must be kept around to avoid flow analysis incorrectly concluding
+        // that the function fails to return. See
+        // https://github.com/dart-lang/language/issues/2977 for details.
         throw '[BUG] Unreachable code';
     }
   },


### PR DESCRIPTION
The Dart analyzer will soon be changed so that if the `default` clause of a `switch` statement is determined to be unreachable by the exhaustiveness checker, a new warning of type
`unreachable_switch_default` will be issued. This parallels the behavior of the existing `unreachable_switch_case` warning, which is issued whenever a `case` clause of a `switch` statement is determined to be unreachable.

In the vast majority of cases, the most reasonable way to address the warning is to remove the unreachable `default` clause. However, in a few rare cases, the `default` clause must be kept, due to the fact that flow analysis is not as sophisticated as exhaustiveness checking (see https://github.com/dart-lang/language/issues/2977 for details).

Two of these rare cases crop up in dart-sass. This change adds `ignore` comments to avoid a spurious warning, and adds a comment explaining why the `default` clause needs to be kept.