### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   sass: 1.78.0
 
 dev_dependencies:
-  dartdoc: ">=6.0.0 <9.0.0"
+  dartdoc: ^8.0.14
 
 dependency_overrides:
   sass: { path: ../.. }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   cli_pkg: ^2.8.0
   cli_repl: ^0.2.1
   collection: ^1.16.0
-  http: "^1.1.0"
+  http: ^1.1.0
   js: ^0.6.3
   meta: ^1.3.0
   native_synchronization: ^0.3.0
@@ -38,15 +38,15 @@ dependencies:
   watcher: ^1.0.0
 
 dev_dependencies:
-  analyzer: ">=5.13.0 <7.0.0"
+  analyzer: ^6.8.0
   archive: ^3.1.2
   crypto: ^3.0.0
   dart_style: ^2.0.0
-  dartdoc: ">=6.0.0 <9.0.0"
+  dartdoc: ^8.0.14
   grinder: ^0.9.0
   node_preamble: ^2.0.2
-  lints: ">=2.0.0 <5.0.0"
-  protoc_plugin: ">=20.0.0 <22.0.0"
+  lints: ^4.0.0
+  protoc_plugin: ^21.1.2
   pub_api_client: ^2.1.1
   pubspec_parse: ^1.3.0
   test: ^1.16.7


### PR DESCRIPTION
For normal dependencies sometimes we use a range that covers multiple major versions to allow wilder selection for increased compatibility with other sibling libraries which may not be up to date. However, for dev dependencies, there isn't any good reason to use a large range that covers multiple major version because dev dependencies will not be installed as transitive dependencies.

This PR replace the ranged version of dev dependencies with [caret syntax](https://dart.dev/tools/pub/dependencies#caret-syntax).

Closes 2320. - It looks like we're also hitting a bug in dependabot that it keeps sends us empty PR with no actual changes to update dartdoc.