### PR TITLE
Delete unreachable `default` clause.

### DIFF
--- a/lib/src/ast/sass/statement/stylesheet.dart
+++ b/lib/src/ast/sass/statement/stylesheet.dart
@@ -91,8 +91,6 @@ final class Stylesheet extends ParentStatement<List<Statement>> {
           return Stylesheet.parseScss(contents, url: url, logger: logger);
         case Syntax.css:
           return Stylesheet.parseCss(contents, url: url, logger: logger);
-        default:
-          throw ArgumentError("Unknown syntax $syntax.");
       }
     } on SassException catch (error, stackTrace) {
       var url = error.span.sourceUrl;


### PR DESCRIPTION
The Dart analyzer will soon be changed so that if the `default` clause of a `switch` statement is determined to be unreachable by the exhaustiveness checker, a new warning of type
`unreachable_switch_default` will be issued. This parallels the behavior of the existing `unreachable_switch_case` warning, which is issued whenever a `case` clause of a `switch` statement is determined to be unreachable. For details see
https://github.com/dart-lang/sdk/issues/54575.

This PR deletes an unreachable `default` clause from `dart-sass` now, to avoid a spurious warning when the analyzer change lands.