### PR TITLE
Use a `file:` dependency for sass-parser -> sass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,11 @@ jobs:
           version: 'lts/*'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
+
+        # The repo package has a file dependency, but the released version needs
+        # a real dependency on the released version of Sass.
+      - run: npm install sass@${{ steps.version.outputs.version }}
+
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,11 +344,7 @@ jobs:
 
       - run: dart run grinder pkg-npm-dev
         env: {UPDATE_SASS_SASS_REPO: false}
-      - run: npm link
-        working-directory: build/npm
       - run: npm install
-        working-directory: pkg/sass-parser/
-      - run: npm link sass
         working-directory: pkg/sass-parser/
       - name: Run tests
         run: npm test
@@ -362,6 +358,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: {node-version: 'lts/*'}
+      - uses: ./.github/util/initialize
+        with: {github-token: "${{ github.token }}"}
+
+      - run: dart run grinder pkg-npm-dev
+        env: {UPDATE_SASS_SASS_REPO: false}
+      - run: npm install
+        working-directory: build/npm/
       - run: npm install
         working-directory: pkg/sass-parser/
       - name: Run static analysis

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "postcss": ">=8.4.41 <8.5.0",
-    "sass": "1.78.0"
+    "sass": "file:../../build/npm"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/test/double_check_test.dart
+++ b/test/double_check_test.dart
@@ -111,14 +111,6 @@ void main() {
         () => expect(packageJson["version"].toString(),
             matchesChangelogVersion(_changelogVersion("pkg/sass-parser"))));
 
-    test("depends on the current sass version", () {
-      if (_isDevVersion(sassPubspec.version!)) return;
-
-      var dependencies = packageJson["dependencies"] as Map<String, Object?>;
-      expect(
-          dependencies, containsPair("sass", sassPubspec.version.toString()));
-    });
-
     test(
         "increments along with the sass version",
         () => _checkVersionIncrementsAlong('sass-parser', sassPubspec,


### PR DESCRIPTION
This makes it harder to accidentally test against the wrong version,
and ensures CI doesn't break when the repo's Sass version number is
unreleased.