### PR TITLE
Emit deprecation warnings for the legacy JS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,12 @@
 
 ### JS API
 
+* While the legacy API has been deprecated since we released the modern API, we
+  now emit warnings when the legacy API is used to make sure users are aware
+  that it will be removed in Dart Sass 2.0.0. In the meantime, you can silence
+  these warnings by passing `legacy-js-api` in `silenceDeprecations` when using
+  the legacy API.
+
 * Modify `SassColor` to accept a new `space` option, with support for all the
   new color spaces defined in Color Level 4.
 

--- a/lib/src/async_compile.dart
+++ b/lib/src/async_compile.dart
@@ -159,6 +159,12 @@ Future<CompileResult> _compileStylesheet(
     bool quietDeps,
     bool sourceMap,
     bool charset) async {
+  if (nodeImporter != null) {
+    logger?.warnForDeprecation(
+        Deprecation.legacyJsApi,
+        'The legacy JS API is deprecated and will be removed in '
+        'Dart Sass 2.0.0.');
+  }
   var evaluateResult = await evaluateAsync(stylesheet,
       importCache: importCache,
       nodeImporter: nodeImporter,

--- a/lib/src/compile.dart
+++ b/lib/src/compile.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_compile.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 69b31749dc94c7f717e9d395327e4209c4d3feb0
+// Checksum: 02482100b0a8b4621fe9a70bac549a37f04891f8
 //
 // ignore_for_file: unused_import
 
@@ -168,6 +168,12 @@ CompileResult _compileStylesheet(
     bool quietDeps,
     bool sourceMap,
     bool charset) {
+  if (nodeImporter != null) {
+    logger?.warnForDeprecation(
+        Deprecation.legacyJsApi,
+        'The legacy JS API is deprecated and will be removed in '
+        'Dart Sass 2.0.0.');
+  }
   var evaluateResult = evaluate(stylesheet,
       importCache: importCache,
       nodeImporter: nodeImporter,

--- a/lib/src/deprecation.dart
+++ b/lib/src/deprecation.dart
@@ -15,7 +15,7 @@ enum Deprecation {
   // DO NOT EDIT. This section was generated from the language repo.
   // See tool/grind/generate_deprecations.dart for details.
   //
-  // Checksum: 5470e7252641d3eaa7093b072b52e423c3b77375
+  // Checksum: 0243e0f7ee85127d6e1bda5c08e363509959e758
 
   /// Deprecation for passing a string directly to meta.call().
   callString('call-string',
@@ -108,6 +108,10 @@ enum Deprecation {
   colorFunctions('color-functions',
       deprecatedIn: '1.79.0',
       description: 'Using global color functions instead of sass:color.'),
+
+  /// Deprecation for legacy JS API.
+  legacyJsApi('legacy-js-api',
+      deprecatedIn: '1.79.0', description: 'Legacy JS API.'),
 
   /// Deprecation for @import rules.
   import.future('import', description: '@import rules.'),


### PR DESCRIPTION
See https://github.com/sass/sass/pull/3932
See https://github.com/sass/sass-spec/pull/2016

[skip sass-embedded]