### PR TITLE
Bump chokidar to v4

### DIFF
--- a/lib/src/io/js.dart
+++ b/lib/src/io/js.dart
@@ -252,8 +252,7 @@ Future<Stream<WatchEvent>> watchDir(String path, {bool poll = false}) {
   if (!isNodeJs) {
     throw UnsupportedError("watchDir() is only supported on Node.js");
   }
-  var watcher = chokidar.watch(
-      path, ChokidarOptions(disableGlobbing: true, usePolling: poll));
+  var watcher = chokidar.watch(path, ChokidarOptions(usePolling: poll));
 
   // Don't assign the controller until after the ready event fires. Otherwise,
   // Chokidar will give us a bunch of add events for files that already exist.

--- a/lib/src/js/chokidar.dart
+++ b/lib/src/js/chokidar.dart
@@ -12,10 +12,9 @@ class Chokidar {
 @JS()
 @anonymous
 class ChokidarOptions {
-  external bool? get disableGlobbing;
   external bool? get usePolling;
 
-  external factory ChokidarOptions({bool? disableGlobbing, bool? usePolling});
+  external factory ChokidarOptions({bool? usePolling});
 }
 
 @JS()

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "name": "sass",
   "devDependencies": {
-    "chokidar": ">=3.0.0 <4.0.0",
+    "chokidar": "^4.0.0",
     "immutable": "^4.0.0",
     "intercept-stdout": "^0.1.2"
   }

--- a/package/package.json
+++ b/package/package.json
@@ -17,7 +17,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "chokidar": ">=3.0.0 <4.0.0",
+    "chokidar": "^4.0.0",
     "immutable": "^4.0.0",
     "source-map-js": ">=0.6.2 <2.0.0"
   },


### PR DESCRIPTION
Chokidar v4 targets `node >=14`, which is the same as the current sass package, so there is no breaking change for end users. See: https://github.com/paulmillr/chokidar?tab=readme-ov-file#upgrading

- Closes #2345