### PR TITLE
unifyComound() and unifyComplex() no longer move pseudo-classes across pseudo-element boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 ## 1.79.4
 
-* `selector.unify()` now preserves the original order of pseudo-classes and
-  pseudo-elements within individual selectors when combining them.
+* Changes to how `selector.unify()` and `@extend` combine selectors:
+
+    * The relative order of pseudo-classes (like `:hover`) and pseudo-elements
+      (like `::before`) within each original selector is now preserved when
+      they're combined.
+
+    * Pseudo selectors are now consistently placed at the end of the combined
+      selector, regardless of which selector they came from. Previously, this
+      reordering only applied to pseudo-selectors in the second selector.
+
+    * Prioritizes components from the first selector in the output.
 
 ### JS API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
       selector, regardless of which selector they came from. Previously, this
       reordering only applied to pseudo-selectors in the second selector.
 
-    * Prioritizes components from the first selector in the output.
-
 ### JS API
 
 * Fix a bug where passing `green` or `blue` to `color.change()` for legacy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.79.4
+## 1.79.5
 
 * Changes to how `selector.unify()` and `@extend` combine selectors:
 
@@ -9,6 +9,8 @@
     * Pseudo selectors are now consistently placed at the end of the combined
       selector, regardless of which selector they came from. Previously, this
       reordering only applied to pseudo-selectors in the second selector.
+
+## 1.79.4
 
 ### JS API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.79.4
 
+* `selector.unify()` now preserves the original order of pseudo-classes and
+  pseudo-elements within individual selectors when combining them.
+
 ### JS API
 
 * Fix a bug where passing `green` or `blue` to `color.change()` for legacy

--- a/lib/src/ast/selector/type.dart
+++ b/lib/src/ast/selector/type.dart
@@ -32,7 +32,7 @@ final class TypeSelector extends SimpleSelector {
   /// @nodoc
   @internal
   List<SimpleSelector>? unify(List<SimpleSelector> compound) {
-    if (compound.first case UniversalSelector() || TypeSelector()) {
+    if (compound.firstOrNull case UniversalSelector() || TypeSelector()) {
       var unified = unifyUniversalAndElement(this, compound.first);
       if (unified == null) return null;
       return [unified, ...compound.skip(1)];

--- a/lib/src/extend/functions.dart
+++ b/lib/src/extend/functions.dart
@@ -12,7 +12,6 @@
 library;
 
 import 'dart:collection';
-import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:source_span/source_span.dart';

--- a/lib/src/extend/functions.dart
+++ b/lib/src/extend/functions.dart
@@ -122,30 +122,11 @@ List<ComplexSelector>? unifyComplex(
 /// If no such selector can be produced, returns `null`.
 CompoundSelector? unifyCompound(
     CompoundSelector compound1, CompoundSelector compound2) {
-  var result = <SimpleSelector>[];
+  var result = compound1.components;
   var pseudoResult = <SimpleSelector>[];
   var pseudoElementFound = false;
 
-  // Compound selectors may not contain more than one pseudo-element selectors.
-  if (compound1.components
-          .followedBy(compound2.components)
-          .whereType<PseudoSelector>()
-          .where((pseudo) => pseudo.isElement)
-          .toSet()
-          .length >
-      1) {
-    return null;
-  }
-
-  for (var simple in [...compound1.components, null, ...compound2.components]) {
-    // The relative order of pseudo selectors is preserved only in the original
-    // selector. We use `null` as a signal to know when we transition from the
-    // first components into the second components.
-    if (simple == null) {
-      pseudoElementFound = false;
-      continue;
-    }
-
+  for (var simple in compound2.components) {
     // All pseudo-classes are unified separately after a pseudo-element to
     // preserve their relative order with the pseudo-element.
     if (pseudoElementFound && simple is PseudoSelector) {

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+* No user-visible changes.
+
 ## 0.2.3
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.5
+
+* No user-visible changes.
+
 ## 12.0.4
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 12.0.4
+version: 12.0.5
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sass: 1.79.4
+  sass: 1.79.5
 
 dev_dependencies:
   dartdoc: ^8.0.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.79.4
+version: 1.79.5
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Fixes https://github.com/sass/dart-sass/issues/2335

See https://github.com/sass/sass-spec/pull/2018