### PR TITLE
Fix JS API legacy SassColor.change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.79.4
+
+### JS API
+
+* Fix a bug where passing `green` or `blue` to `color.change()` for legacy
+  colors would fail.
+
 ## 1.79.3
 
 * Update the `$channel` parameter in the suggested replacement for

--- a/lib/src/js/value/color.dart
+++ b/lib/src/js/value/color.dart
@@ -116,7 +116,9 @@ final JSClass colorClass = () {
             hasProperty(options, 'saturation') ||
             hasProperty(options, 'lightness')) {
           space = ColorSpace.hsl;
-        } else if (hasProperty(options, 'red')) {
+        } else if (hasProperty(options, 'red') ||
+            hasProperty(options, 'green') ||
+            hasProperty(options, 'blue')) {
           space = ColorSpace.rgb;
         }
         if (space != self.space) {

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+* No user-visible changes.
+
 ## 0.2.2
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.4
+
+* No user-visible changes.
+
 ## 12.0.3
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 12.0.3
+version: 12.0.4
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sass: 1.79.3
+  sass: 1.79.4
 
 dev_dependencies:
   dartdoc: ^8.0.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.79.3
+version: 1.79.4
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Changing a non-rgb legacy color's red channel works with a deprecation warning, but changing its green or blue channel fails:

```
> SassColor({ hue: 1, saturation: 1, lightness: 1 }).change({ red: 1 })
DEPRECATION WARNING: Changing a channel not in this color's space without explicitly specifying the `space` option is deprecated.
More info: https://sass-lang.com/d/color-4-api

hsl(179.9665650506, 43.2680443077%, 0.691245098%)

> SassColor({ hue: 1, saturation: 1, lightness: 1 }).change({ green: 1 })
Uncaught Error: `green` is not a valid channel in `hsl`.
```