### PR TITLE
Fix JS API `color.interpolate(color2)` without options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
       selector, regardless of which selector they came from. Previously, this
       reordering only applied to pseudo-selectors in the second selector.
 
+### JS API
+
+* Fix `SassColor.interpolate()` to allow an undefined `options` parameter, as
+  the types indicate.
+
 ### Embedded Sass
 
 * Properly pass missing color channel values to and from custom functions.

--- a/lib/src/js/value/color.dart
+++ b/lib/src/js/value/color.dart
@@ -307,11 +307,11 @@ final JSClass colorClass = () {
 
       return changedColor.toSpace(self.space);
     },
-    'interpolate':
-        (SassColor self, SassColor color2, _InterpolationOptions options) {
+    'interpolate': (SassColor self, SassColor color2,
+        [_InterpolationOptions? options]) {
       InterpolationMethod interpolationMethod;
 
-      if (options.method case var method?) {
+      if (options?.method case var method?) {
         var hue = HueInterpolationMethod.values.byName(method);
         interpolationMethod = InterpolationMethod(self.space, hue);
       } else if (!self.space.isPolar) {
@@ -322,7 +322,7 @@ final JSClass colorClass = () {
       }
 
       return self.interpolate(color2, interpolationMethod,
-          weight: options.weight);
+          weight: options?.weight);
     }
   });
 


### PR DESCRIPTION
The typescript definition says `options` is an optional positional argument:

``` typescript
  interpolate(
    color2: SassColor,
    options?: {
      weight?: number;
      method?: HueInterpolationMethod;
    }
  ): SassColor;
```

However, calling `color.interpolate(color2)` without passing option throws the following error:
```
Uncaught NoSuchMethodError: method not found: 'call'
Receiver: Closure 'colorClass__closure9'
Arguments: [Instance of 'SassColor0', Instance of 'SassColor0']
```

See https://github.com/sass/sass-spec/pull/2025