### PR TITLE
Fix srgb to linear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
       selector, regardless of which selector they came from. Previously, this
       reordering only applied to pseudo-selectors in the second selector.
 
+* Fix a slight inaccuracy case when converting to `srgb-linear` and
+  `display-p3`.
+
 ### JS API
 
 * Fix `SassColor.interpolate()` to allow an undefined `options` parameter, as

--- a/lib/src/value/color/space/utils.dart
+++ b/lib/src/value/color/space/utils.dart
@@ -52,7 +52,7 @@ double hueToRgb(double m1, double m2, double hue) {
 double srgbAndDisplayP3ToLinear(double channel) {
   // Algorithm from https://www.w3.org/TR/css-color-4/#color-conversion-code
   var abs = channel.abs();
-  return abs < 0.04045
+  return abs <= 0.04045
       ? channel / 12.92
       : channel.sign * math.pow((abs + 0.055) / 1.055, 2.4);
 }


### PR DESCRIPTION
In the edge case of `channel = 0.04045` the error is more than 1e⁻⁹, much higher than the required precision in Sass.

https://www.w3.org/TR/css-color-4/#color-conversion-code
https://github.com/color-js/color.js/blob/40e7a059c639bafde14504627e62791588c63100/src/spaces/srgb.js#L38