### PR TITLE
Update QEMU

### DIFF
--- a/.github/workflows/build-linux-musl.yml
+++ b/.github/workflows/build-linux-musl.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:master
 
       - name: Compile Protobuf
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:master
 
       - name: Compile Protobuf
         run: |


### PR DESCRIPTION
So far riscv64 release has been a bit flaky after we switched to native aot build on QEMU. Attempt to upgrade QEMU to see if it will help make these more stable.

https://github.com/sass/dart-sass/actions/runs/10912255003/job/30287343660
https://github.com/sass/dart-sass/actions/runs/11283989988/job/31384720406