### PR TITLE
Don't generate extra `*/`s for trailing whitespace in Sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Fix a bug where Sass would add an extra `*/` after loud comments with
   whitespace after an explicit `*/` in the indented syntax.
 
-* **Potentially breaking bug fxi:** Adding text after an explicit `*/` in the
+* **Potentially breaking bug fix:** Adding text after an explicit `*/` in the
   indented syntax is now an error, rather than silently generating invalid CSS.
 
 ## 1.79.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.79.6
+
+* Fix a bug where Sass would add an extra `*/` after loud comments with
+  whitespace after an explicit `*/` in the indented syntax.
+
+* **Potentially breaking bug fxi:** Adding text after an explicit `*/` in the
+  indented syntax is now an error, rather than silently generating invalid CSS.
+
 ## 1.79.5
 
 * Changes to how `selector.unify()` and `@extend` combine selectors:

--- a/lib/src/parse/parser.dart
+++ b/lib/src/parse/parser.dart
@@ -719,14 +719,6 @@ class Parser {
 
         throwWithTrace(map.mapException(error), error, stackTrace);
       }
-    } on SourceSpanFormatException catch (error, stackTrace) {
-      var span = error.span as FileSpan;
-      if (startsWithIgnoreCase(error.message, "expected")) {
-        span = _adjustExceptionSpan(span);
-      }
-
-      throwWithTrace(
-          SassFormatException(error.message, span), error, stackTrace);
     } on MultiSourceSpanFormatException catch (error, stackTrace) {
       var span = error.span as FileSpan;
       var secondarySpans = error.secondarySpans.cast<FileSpan, String>();
@@ -743,6 +735,14 @@ class Parser {
               error.message, span, error.primaryLabel, secondarySpans),
           error,
           stackTrace);
+    } on SourceSpanFormatException catch (error, stackTrace) {
+      var span = error.span as FileSpan;
+      if (startsWithIgnoreCase(error.message, "expected")) {
+        span = _adjustExceptionSpan(span);
+      }
+
+      throwWithTrace(
+          SassFormatException(error.message, span), error, stackTrace);
     }
   }
 

--- a/lib/src/parse/sass.dart
+++ b/lib/src/parse/sass.dart
@@ -217,7 +217,6 @@ class SassParser extends StylesheetParser {
     scanner.expect("/*");
 
     var first = true;
-    var closed = false;
     var buffer = InterpolationBuffer()..write("/*");
     var parentIndentation = currentIndentation;
     while (true) {
@@ -264,25 +263,25 @@ class SassParser extends StylesheetParser {
 
               // For backwards compatibility, allow additional comments after
               // the initial comment is closed.
-                while (scanner.peekChar().isNewline && _peekIndentation() > parentIndentation) {
-                  while (_lookingAtDoubleNewline()) {
-                    _expectNewline();
-                  }
-                  _readIndentation();
-                  whitespace();
+              while (scanner.peekChar().isNewline &&
+                  _peekIndentation() > parentIndentation) {
+                while (_lookingAtDoubleNewline()) {
+                  _expectNewline();
                 }
+                _readIndentation();
+                whitespace();
+              }
 
               if (!scanner.peekChar().isNewline) {
                 var errorStart = scanner.state;
                 while (!scanner.isDone && !scanner.peekChar().isNewline) {
                   scanner.readChar();
                 }
-                throw new MultiSpanSassFormatException(
-                  "Unexpected text after end of comment",
-                  scanner.spanFrom(errorStart),
-                  "extra text",
-                  {span: "comment"}
-                );
+                throw MultiSpanSassFormatException(
+                    "Unexpected text after end of comment",
+                    scanner.spanFrom(errorStart),
+                    "extra text",
+                    {span: "comment"});
               } else {
                 return LoudComment(buffer.interpolation(span));
               }

--- a/lib/src/parse/sass.dart
+++ b/lib/src/parse/sass.dart
@@ -6,6 +6,7 @@ import 'package:charcode/charcode.dart';
 import 'package:string_scanner/string_scanner.dart';
 
 import '../ast/sass.dart';
+import '../exception.dart';
 import '../interpolation_buffer.dart';
 import '../util/character.dart';
 import '../value.dart';
@@ -216,6 +217,7 @@ class SassParser extends StylesheetParser {
     scanner.expect("/*");
 
     var first = true;
+    var closed = false;
     var buffer = InterpolationBuffer()..write("/*");
     var parentIndentation = currentIndentation;
     while (true) {
@@ -249,6 +251,41 @@ class SassParser extends StylesheetParser {
             if (scanner.peekChar(1) == $lbrace) {
               var (expression, span) = singleInterpolation();
               buffer.add(expression, span);
+            } else {
+              buffer.writeCharCode(scanner.readChar());
+            }
+
+          case $asterisk:
+            if (scanner.peekChar(1) == $slash) {
+              buffer.writeCharCode(scanner.readChar());
+              buffer.writeCharCode(scanner.readChar());
+              var span = scanner.spanFrom(start);
+              whitespace();
+
+              // For backwards compatibility, allow additional comments after
+              // the initial comment is closed.
+                while (scanner.peekChar().isNewline && _peekIndentation() > parentIndentation) {
+                  while (_lookingAtDoubleNewline()) {
+                    _expectNewline();
+                  }
+                  _readIndentation();
+                  whitespace();
+                }
+
+              if (!scanner.peekChar().isNewline) {
+                var errorStart = scanner.state;
+                while (!scanner.isDone && !scanner.peekChar().isNewline) {
+                  scanner.readChar();
+                }
+                throw new MultiSpanSassFormatException(
+                  "Unexpected text after end of comment",
+                  scanner.spanFrom(errorStart),
+                  "extra text",
+                  {span: "comment"}
+                );
+              } else {
+                return LoudComment(buffer.interpolation(span));
+              }
             } else {
               buffer.writeCharCode(scanner.readChar());
             }

--- a/lib/src/parse/sass.dart
+++ b/lib/src/parse/sass.dart
@@ -272,7 +272,7 @@ class SassParser extends StylesheetParser {
                 whitespace();
               }
 
-              if (!scanner.peekChar().isNewline) {
+              if (!scanner.isDone && !scanner.peekChar().isNewline) {
                 var errorStart = scanner.state;
                 while (!scanner.isDone && !scanner.peekChar().isNewline) {
                   scanner.readChar();

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.6
+
+* No user-visible changes.
+
 ## 0.2.5
 
 * Add support for parsing the `@supports` rule.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 13.0.1
+
+* Fix a bug where `LoudComment`s parsed from the indented syntax would include
+  whitespace after the closing `*/`.
+
 ## 13.0.0
 
 * The `Interpolation()` constructor now takes an additional `List<FileSpan?>`

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 13.0.0
+version: 13.0.1
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sass: 1.79.5
+  sass: 1.79.6
 
 dev_dependencies:
   dartdoc: ^8.0.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.79.5
+version: 1.79.6-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Closes #2381
See sass/sass-spec#2029