### PR TITLE
Fix GitHub Actions config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,6 @@ updates:
       - "/package"
       - "/pkg/sass-parser"
     ignore:
-      dependency-name: "sass"
+      - dependency-name: "sass"
     schedule:
       interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,9 +304,10 @@ jobs:
       with:
         dart-sdk: ${{ matrix.dart_channel }}
         github-token: ${{ github.token }}
-
+    
     - run: dart run grinder pkg-npm-dev
       env: {UPDATE_SASS_SASS_REPO: false}
+    - run: sudo chmod 4755 /opt/google/chrome/chrome-sandbox
     - name: Run tests
       run: dart run test -p chrome -j 2
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,7 +304,7 @@ jobs:
       with:
         dart-sdk: ${{ matrix.dart_channel }}
         github-token: ${{ github.token }}
-    
+
     - run: dart run grinder pkg-npm-dev
       env: {UPDATE_SASS_SASS_REPO: false}
     - run: sudo chmod 4755 /opt/google/chrome/chrome-sandbox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -312,6 +312,7 @@ jobs:
       run: dart run test -p chrome -j 2
       env:
         CHROME_EXECUTABLE: chrome
+        # See https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md#option-3_the-safest-way
         CHROME_DEVEL_SANDBOX: /opt/google/chrome/chrome-sandbox
 
   sass_parser_tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -311,6 +311,7 @@ jobs:
       run: dart run test -p chrome -j 2
       env:
         CHROME_EXECUTABLE: chrome
+        CHROME_DEVEL_SANDBOX: /opt/google/chrome/chrome-sandbox
 
   sass_parser_tests:
     name: "sass-parser Tests | Dart ${{ matrix.dart_channel }} | Node ${{ matrix.node-version }}"


### PR DESCRIPTION
This updates our dependabot config to be compatible with new format restrictions and passes `CHROME_DEVEL_SANDBOX` when running browser tests to avoid a new sandbox that's incompatible with Ubuntu (see [here](https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md#option-3_the-safest-way))