### PR TITLE
Always limit the repetition of loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.80.1
+
+* Fix a bug where repeated deprecation warnings were not automatically limited.
+
 ## 1.80.0
 
 * `@import` is now officially deprecated, as are global built-in functions that

--- a/lib/src/async_import_cache.dart
+++ b/lib/src/async_import_cache.dart
@@ -380,6 +380,9 @@ final class AsyncImportCache {
         silenceDeprecations: {...?silenceDeprecations},
         fatalDeprecations: {...?fatalDeprecations},
         futureDeprecations: {...?futureDeprecations},
-        limitRepetition: false);
+        // TODO - sass/dart-sass#2390: We should limit repetition within a given
+        // compilation while allowing it across different compilations (such as
+        // with `--watch`).
+        limitRepetition: true);
   }
 }

--- a/lib/src/import_cache.dart
+++ b/lib/src/import_cache.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_import_cache.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: e043f2a3dafb741a6f053a7c1785b1c9959242f5
+// Checksum: f459089f21fcbfca2d073ba73a5bcf4e98ecab1b
 //
 // ignore_for_file: unused_import
 
@@ -375,6 +375,9 @@ final class ImportCache {
         silenceDeprecations: {...?silenceDeprecations},
         fatalDeprecations: {...?fatalDeprecations},
         futureDeprecations: {...?futureDeprecations},
-        limitRepetition: false);
+        // TODO - sass/dart-sass#2390: We should limit repetition within a given
+        // compilation while allowing it across different compilations (such as
+        // with `--watch`).
+        limitRepetition: true);
   }
 }

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* No user-visible changes.
+
 ## 0.3.0
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,6 +1,14 @@
+## 13.1.1
+
+* Make `AsyncImporterCache.wrapLogger()` and `ImporterCache.wrapLogger()` always
+  limit the repetition of deprecations. this is unlikely to be the long-term
+  behavior, but it's necessary to avoid flooding users with deprecations in the
+  short term.
+
 ## 13.1.0
 
-* No user-visible changes.
+* Add `AsyncImporterCache.wrapLogger()` and `ImporterCache.wrapLogger()`
+  methods, which wrap a given logger to apply deprecation options to it.
 
 ## 13.0.1
 

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 13.1.0
+version: 13.1.1
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sass: 1.80.0
+  sass: 1.80.1
 
 dev_dependencies:
   dartdoc: ^8.0.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.80.0
+version: 1.80.1
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
See sass/dart-sass#2390. This is definitely not the correct long-term
solution—we only want to limit repetition in the context of a single
batch of compilations, and this doesn't always respect `--verbose`—but
it's way better to display too few deprecations than too many.

See https://github.com/sass/sass-spec/pull/2030