### PR TITLE
Don't emit warnings for plain-CSS `invert()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.80.2
+
+* Fix a bug where deprecation warnings were incorrectly emitted for the
+  plain-CSS `invert()` function.
+
 ## 1.80.1
 
 * Fix a bug where repeated deprecation warnings were not automatically limited.

--- a/lib/src/functions/color.dart
+++ b/lib/src/functions/color.dart
@@ -55,9 +55,12 @@ final global = UnmodifiableListView([
         space: ColorSpace.rgb, name: 'channels')
   }),
 
-  _function("invert", r"$color, $weight: 100%, $space: null",
-          (arguments) => _invert(arguments, global: true))
-      .withDeprecationWarning("color"),
+  _function("invert", r"$color, $weight: 100%, $space: null", (arguments) {
+    if (arguments[0] is! SassNumber && !arguments[0].isSpecialNumber) {
+      warnForGlobalBuiltIn("color", "invert");
+    }
+    return _invert(arguments, global: true);
+  }),
 
   // ### HSL
   _channelFunction("hue", ColorSpace.hsl, (color) => color.hue,

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+* No user-visible changes.
+
 ## 0.3.1
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 13.1.2
+
+* No user-visible changes.
+
 ## 13.1.1
 
 * Make `AsyncImporterCache.wrapLogger()` and `ImporterCache.wrapLogger()` always

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 13.1.1
+version: 13.1.2
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sass: 1.80.1
+  sass: 1.80.2
 
 dev_dependencies:
   dartdoc: ^8.0.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.80.1
+version: 1.80.2
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Fixes sass/sass#3963.
Fixes #2393.

See https://github.com/sass/sass-spec/pull/2031