### PR TITLE
Expose Expression.isCalculationSafe to sass_api

### DIFF
--- a/lib/src/ast/sass/expression.dart
+++ b/lib/src/ast/sass/expression.dart
@@ -26,9 +26,6 @@ abstract class Expression implements SassNode {
   Expression();
 
   /// Whether this expression can be used in a calculation context.
-  ///
-  /// @nodoc
-  @internal
   bool get isCalculationSafe => accept(const IsCalculationSafeVisitor());
 
   /// If this expression is valid interpolated plain CSS, returns the equivalent

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.1-dev",
+  "version": "0.4.1",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 14.0.1
+## 14.1.0
 
-* No user-visible changes.
+* Add `Expression.isCalculationSafe`, which returns true when this expression
+  can safely be used in a calcuation.
 
 ## 14.0.0
 

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 14.0.1-dev
+version: 14.1.0
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  sass: 1.80.4-dev
+  sass: 1.80.4
 
 dev_dependencies:
   dartdoc: ^8.0.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.80.4-dev
+version: 1.80.4
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This is necessary to fix sass/migrator#262.