### PR TITLE
Lazy load @parcel/watcher and fallback to chokidar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 1.80.6-dev
+## 1.80.6
 
-* No user-visible changes.
+### Command-Line Interface
+
+* Make `@parcel/watcher` an optional dependency so this can still be installed
+  on operating systems where it's unavailable.
 
 ## 1.80.5
 

--- a/lib/src/io/js.dart
+++ b/lib/src/io/js.dart
@@ -257,8 +257,8 @@ Future<Stream<WatchEvent>> watchDir(String path, {bool poll = false}) async {
   // Don't assign the controller until after the ready event fires. Otherwise,
   // Chokidar will give us a bunch of add events for files that already exist.
   StreamController<WatchEvent>? controller;
-  if (poll) {
-    var watcher = chokidar.watch(path, ChokidarOptions(usePolling: true));
+  if (poll || parcelWatcher == null) {
+    var watcher = chokidar.watch(path, ChokidarOptions(usePolling: poll));
     watcher
       ..on(
           'add',
@@ -287,7 +287,7 @@ Future<Stream<WatchEvent>> watchDir(String path, {bool poll = false}) async {
 
     return completer.future;
   } else {
-    var subscription = await ParcelWatcher.subscribeFuture(path,
+    var subscription = await parcelWatcher!.subscribe(path,
         (Object? error, List<ParcelWatcherEvent> events) {
       if (error != null) {
         controller?.addError(error);

--- a/lib/src/js/parcel_watcher.dart
+++ b/lib/src/js/parcel_watcher.dart
@@ -2,17 +2,15 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'package:js/js.dart';
-import 'package:node_interop/js.dart';
-import 'package:node_interop/util.dart';
+import 'dart:js_interop';
 
 @JS()
-class ParcelWatcherSubscription {
+extension type ParcelWatcherSubscription(JSObject _) implements JSObject {
   external void unsubscribe();
 }
 
 @JS()
-class ParcelWatcherEvent {
+extension type ParcelWatcherEvent(JSObject _) implements JSObject {
   external String get type;
   external String get path;
 }
@@ -20,25 +18,32 @@ class ParcelWatcherEvent {
 /// The @parcel/watcher module.
 ///
 /// See [the docs on npm](https://www.npmjs.com/package/@parcel/watcher).
-@JS('parcel_watcher')
-class ParcelWatcher {
-  external static Promise subscribe(String path, Function callback);
-  static Future<ParcelWatcherSubscription> subscribeFuture(String path,
+@JS()
+extension type ParcelWatcher(JSObject _) implements JSObject {
+  @JS('subscribe')
+  external JSPromise<ParcelWatcherSubscription> _subscribe(
+      String path, JSFunction callback);
+  Future<ParcelWatcherSubscription> subscribe(String path,
           void Function(Object? error, List<ParcelWatcherEvent>) callback) =>
-      promiseToFuture(
-          subscribe(path, allowInterop((Object? error, List<dynamic> events) {
-        callback(error, events.cast<ParcelWatcherEvent>());
-      })));
+      _subscribe(
+              path,
+              (JSObject? error, JSArray<ParcelWatcherEvent> events) {
+                callback(error, events.toDart);
+              }.toJS)
+          .toDart;
 
-  external static Promise getEventsSince(String path, String snapshotPath);
-  static Future<List<ParcelWatcherEvent>> getEventsSinceFuture(
-      String path, String snapshotPath) async {
-    List<dynamic> events =
-        await promiseToFuture(getEventsSince(path, snapshotPath));
-    return events.cast<ParcelWatcherEvent>();
-  }
+  @JS('getEventsSince')
+  external JSPromise<JSArray<ParcelWatcherEvent>> _getEventsSince(
+      String path, String snapshotPath);
+  Future<List<ParcelWatcherEvent>> getEventsSince(
+          String path, String snapshotPath) async =>
+      (await _getEventsSince(path, snapshotPath).toDart).toDart;
 
-  external static Promise writeSnapshot(String path, String snapshotPath);
-  static Future<void> writeSnapshotFuture(String path, String snapshotPath) =>
-      promiseToFuture(writeSnapshot(path, snapshotPath));
+  @JS('writeSnapshot')
+  external JSPromise<JSAny> _writeSnapshot(String path, String snapshotPath);
+  Future<void> writeSnapshot(String path, String snapshotPath) =>
+      _writeSnapshot(path, snapshotPath).toDart;
 }
+
+@JS('parcel_watcher')
+external ParcelWatcher? get parcelWatcher;

--- a/lib/src/parse/parser.dart
+++ b/lib/src/parse/parser.dart
@@ -651,7 +651,7 @@ class Parser {
     var span = scanner.spanFrom(state);
     return _interpolationMap == null
         ? span
-        : LazyFileSpan(() => _interpolationMap!.mapSpan(span));
+        : LazyFileSpan(() => _interpolationMap.mapSpan(span));
   }
 
   /// Throws an error associated with [span].

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -1812,7 +1812,7 @@ final class _EvaluateVisitor
     if (result != null) {
       isDependency = _inDependency;
     } else {
-      result = await _nodeImporter!.loadAsync(originalUrl, previous, forImport);
+      result = await _nodeImporter.loadAsync(originalUrl, previous, forImport);
       if (result == null) return null;
       isDependency = true;
     }

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 396c8f169d95c601598b8c3be1f4b948ca22effa
+// Checksum: 3986f5db33dd220dcd971a39e8587ca4e52d9a3f
 //
 // ignore_for_file: unused_import
 
@@ -1808,7 +1808,7 @@ final class _EvaluateVisitor
     if (result != null) {
       isDependency = _inDependency;
     } else {
-      result = _nodeImporter!.load(originalUrl, previous, forImport);
+      result = _nodeImporter.load(originalUrl, previous, forImport);
       if (result == null) return null;
       isDependency = true;
     }

--- a/package/package.json
+++ b/package/package.json
@@ -17,10 +17,12 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@parcel/watcher": "^2.4.1",
     "chokidar": "^4.0.0",
     "immutable": "^4.0.0",
     "source-map-js": ">=0.6.2 <2.0.0"
+  },
+  "optionalDependencies": {
+    "@parcel/watcher": "^2.4.1"
   },
   "keywords": [
     "style",

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.3-dev
+## 0.4.3
 
 * Add support for parsing the `@while` rule.
 

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.3-dev",
+  "version": "0.4.3",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 14.1.2-dev
+## 14.1.2
 
 * No user-visible changes.
 

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 14.1.2-dev
+version: 14.1.2
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -7,7 +7,7 @@ description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   sass: 1.80.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,14 @@ executables:
   sass: sass
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   args: ^2.0.0
   async: ^2.5.0
   charcode: ^1.2.0
-  cli_pkg: ^2.8.0
+  cli_pkg:
+    git: https://github.com/google/dart_cli_pkg.git
   cli_repl: ^0.2.1
   collection: ^1.16.0
   http: ^1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.80.6-dev
+version: 1.80.6
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,7 @@ dependencies:
   args: ^2.0.0
   async: ^2.5.0
   charcode: ^1.2.0
-  cli_pkg:
-    git: https://github.com/google/dart_cli_pkg.git
+  cli_pkg: ^2.11.0
   cli_repl: ^0.2.1
   collection: ^1.16.0
   http: ^1.1.0

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -35,7 +35,8 @@ void main(List<String> args) {
   pkg.homebrewFormula.value = "Formula/sass.rb";
   pkg.homebrewEditFormula.value = _updateHomebrewLanguageRevision;
   pkg.jsRequires.value = [
-    pkg.JSRequire("@parcel/watcher", target: pkg.JSRequireTarget.cli),
+    pkg.JSRequire("@parcel/watcher",
+        target: pkg.JSRequireTarget.cli, lazy: true, optional: true),
     pkg.JSRequire("immutable", target: pkg.JSRequireTarget.all),
     pkg.JSRequire("chokidar", target: pkg.JSRequireTarget.cli),
     pkg.JSRequire("readline", target: pkg.JSRequireTarget.cli),


### PR DESCRIPTION
- Fixes #2409.

Depends on https://github.com/google/dart_cli_pkg/pull/169

With this change, it no longer fails on loading `sass` on CLI or API if `@parcel/watcher`'s optional dependency is not available. The error about missing optional dependency is printed once per execution only if user actually used `--watch` flag on CLI, and then it fallbacks to chokidar for that whole execution.

To test the new behavior, run `npm install --omit optional` to remove `@parcel/watcher`'s optional depenency. Then run `node build/npm/sass.js` or `node build/npm/sass.js --watch [...]` to see it in action.

I'm bumping dart-sdk requirement to 3.3.0 in order to use new `dart:js_interop`, as the legacy `package:js_interop/js_interop.dart` is giving me lots of troubles. E.g. cannot add non-static helper methods to an `@JS` class etc.