### PR TITLE
Add support for CSS `round()` with one unitless argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.81.0
+
+* Fix a few cases where deprecation warnings weren't being emitted for global
+  built-in functions whose names overlap with CSS calculations.
+
+* Add support for the CSS `round()` calculation with a single argument, as long
+  as that argument might be a unitless number.
+
 ## 1.80.7
 
 ### Embedded Host

--- a/lib/src/ast/css/style_rule.dart
+++ b/lib/src/ast/css/style_rule.dart
@@ -21,7 +21,7 @@ abstract interface class CssStyleRule implements CssParentNode {
 
   /// Whether this style rule was originally defined in a plain CSS stylesheet.
   ///
-  /// :nodoc:
+  /// @nodoc
   @internal
   bool get fromPlainCss;
 }

--- a/lib/src/js/value/calculation.dart
+++ b/lib/src/js/value/calculation.dart
@@ -88,7 +88,7 @@ final JSClass calculationOperationClass = () {
     _assertCalculationValue(left);
     _assertCalculationValue(right);
     return SassCalculation.operateInternal(operator, left, right,
-        inLegacySassFunction: false, simplify: false);
+        inLegacySassFunction: null, simplify: false, warn: null);
   });
 
   jsClass.defineMethods({
@@ -104,7 +104,7 @@ final JSClass calculationOperationClass = () {
 
   getJSClass(SassCalculation.operateInternal(
           CalculationOperator.plus, SassNumber(1), SassNumber(1),
-          inLegacySassFunction: false, simplify: false))
+          inLegacySassFunction: null, simplify: false, warn: null))
       .injectSuperclass(jsClass);
   return jsClass;
 }();

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -2555,12 +2555,12 @@ final class _EvaluateVisitor
       // Note that the list of calculation functions is also tracked in
       // lib/src/visitor/is_plain_css_safe.dart.
       switch (node.name.toLowerCase()) {
-        case "min" || "max" || "round" || "abs"
+        case ("min" || "max" || "round" || "abs") && var name
             when node.arguments.named.isEmpty &&
                 node.arguments.rest == null &&
                 node.arguments.positional
                     .every((argument) => argument.isCalculationSafe):
-          return await _visitCalculation(node, inLegacySassFunction: true);
+          return await _visitCalculation(node, inLegacySassFunction: name);
 
         case "calc" ||
               "clamp" ||
@@ -2607,8 +2607,15 @@ final class _EvaluateVisitor
     return result;
   }
 
+  /// Evaluates [node] as a calculation.
+  ///
+  /// If [inLegacySassFunction] isn't null, this allows unitless numbers to be
+  /// added and subtracted with numbers with units, for backwards-compatibility
+  /// with the old global `min()`, `max()`, `round()`, and `abs()` functions.
+  /// The parameter is the name of the function, which is used for reporting
+  /// deprecation warnings.
   Future<Value> _visitCalculation(FunctionExpression node,
-      {bool inLegacySassFunction = false}) async {
+      {String? inLegacySassFunction}) async {
     if (node.arguments.named.isNotEmpty) {
       throw _exception(
           "Keyword arguments can't be used with calculations.", node.span);
@@ -2656,8 +2663,12 @@ final class _EvaluateVisitor
           SassCalculation.mod(arguments[0], arguments.elementAtOrNull(1)),
         "rem" =>
           SassCalculation.rem(arguments[0], arguments.elementAtOrNull(1)),
-        "round" => SassCalculation.round(arguments[0],
-            arguments.elementAtOrNull(1), arguments.elementAtOrNull(2)),
+        "round" => SassCalculation.roundInternal(arguments[0],
+            arguments.elementAtOrNull(1), arguments.elementAtOrNull(2),
+            span: node.span,
+            inLegacySassFunction: inLegacySassFunction,
+            warn: (message, [deprecation]) =>
+                _warn(message, node.span, deprecation)),
         "clamp" => SassCalculation.clamp(arguments[0],
             arguments.elementAtOrNull(1), arguments.elementAtOrNull(2)),
         _ => throw UnsupportedError('Unknown calculation name "${node.name}".')
@@ -2753,11 +2764,13 @@ final class _EvaluateVisitor
 
   /// Evaluates [node] as a component of a calculation.
   ///
-  /// If [inLegacySassFunction] is `true`, this allows unitless numbers to be added and
-  /// subtracted with numbers with units, for backwards-compatibility with the
-  /// old global `min()`, `max()`, `round()`, and `abs()` functions.
+  /// If [inLegacySassFunction] isn't null, this allows unitless numbers to be
+  /// added and subtracted with numbers with units, for backwards-compatibility
+  /// with the old global `min()`, `max()`, `round()`, and `abs()` functions.
+  /// The parameter is the name of the function, which is used for reporting
+  /// deprecation warnings.
   Future<Object> _visitCalculationExpression(Expression node,
-      {required bool inLegacySassFunction}) async {
+      {required String? inLegacySassFunction}) async {
     switch (node) {
       case ParenthesizedExpression(expression: var inner):
         var result = await _visitCalculationExpression(inner,
@@ -2788,7 +2801,9 @@ final class _EvaluateVisitor
                 await _visitCalculationExpression(right,
                     inLegacySassFunction: inLegacySassFunction),
                 inLegacySassFunction: inLegacySassFunction,
-                simplify: !_inSupportsDeclaration));
+                simplify: !_inSupportsDeclaration,
+                warn: (message, [deprecation]) =>
+                    _warn(message, node.span, deprecation)));
 
       case NumberExpression() ||
             VariableExpression() ||

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5
+
+* No user-visible changes.
+
 ## 0.4.4
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 14.2.0
+
+* No user-visible changes.
+
 ## 14.1.3
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 14.1.3
+version: 14.2.0
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
-  sass: 1.80.7
+  sass: 1.81.0
 
 dev_dependencies:
   dartdoc: ^8.0.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.80.7
+version: 1.81.0
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/test/double_check_test.dart
+++ b/test/double_check_test.dart
@@ -161,12 +161,23 @@ void _checkVersionIncrementsAlong(
   // because we don't have access to the prior version.
   if (sassVersion.patch != 0) return;
 
+  var pkgMajor = pkgVersion.major;
+  var pkgMinor = pkgVersion.minor;
+  var pkgPatch = pkgVersion.patch;
+  if (pkgMajor == 0) {
+    // Before 1.0.0, the semantics of each version number are moved up by one
+    // place.
+    pkgMajor = pkgMinor;
+    pkgMinor = pkgPatch;
+    pkgPatch = 0;
+  }
+
   if (sassVersion.minor != 0) {
-    expect(pkgVersion.patch, equals(0),
+    expect(pkgPatch, equals(0),
         reason: "sass minor version was incremented, $pkgName must increment "
             "at least its minor version");
   } else {
-    expect(pkgVersion.minor, equals(0),
+    expect(pkgMinor, equals(0),
         reason: "sass major version was incremented, $pkgName must increment "
             "at its major version as well");
   }


### PR DESCRIPTION
This also adds deprecation warnings for cases where a CSS calculation
is determined to need to mimic a global Sass function, to match the
global Sass function deprecation.

See sass/sass#3803
Closes #2433

See sass/sass-spec#2037