### PR TITLE
Make several changes to improve the reliability of `--watch` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.81.1
+
+### Command-Line Interface
+
+* Improve `--watch` mode reliability when making multiple changes at once, such
+  as checking out a different Git branch.
+
 ## 1.81.0
 
 * Fix a few cases where deprecation warnings weren't being emitted for global

--- a/lib/src/async_import_cache.dart
+++ b/lib/src/async_import_cache.dart
@@ -69,6 +69,10 @@ final class AsyncImportCache {
   /// The import results for each canonicalized import URL.
   final _resultsCache = <Uri, ImporterResult>{};
 
+  /// A map from canonical URLs to the most recent time at which those URLs were
+  /// loaded from their importers.
+  final _loadTimes = <Uri, DateTime>{};
+
   /// Creates an import cache that resolves imports using [importers].
   ///
   /// Imports are resolved by trying, in order:
@@ -282,9 +286,11 @@ final class AsyncImportCache {
   Future<Stylesheet?> importCanonical(AsyncImporter importer, Uri canonicalUrl,
       {Uri? originalUrl}) async {
     return await putIfAbsentAsync(_importCache, canonicalUrl, () async {
+      var loadTime = DateTime.now();
       var result = await importer.load(canonicalUrl);
       if (result == null) return null;
 
+      _loadTimes[canonicalUrl] = loadTime;
       _resultsCache[canonicalUrl] = result;
       return Stylesheet.parse(result.contents, result.syntax,
           // For backwards-compatibility, relative canonical URLs are resolved
@@ -320,17 +326,31 @@ final class AsyncImportCache {
   Uri sourceMapUrl(Uri canonicalUrl) =>
       _resultsCache[canonicalUrl]?.sourceMapUrl ?? canonicalUrl;
 
-  /// Clears the cached canonical version of the given non-canonical [url].
-  ///
-  /// Has no effect if the canonical version of [url] has not been cached.
+  /// Returns the most recent time the stylesheet at [canonicalUrl] was loaded
+  /// from its importer, or `null` if it has never been loaded.
+  @internal
+  DateTime? loadTime(Uri canonicalUrl) => _loadTimes[canonicalUrl];
+
+  /// Clears all cached canonicalizations that could potentially produce
+  /// [canonicalUrl].
   ///
   /// @nodoc
   @internal
-  void clearCanonicalize(Uri url) {
-    _canonicalizeCache.remove((url, forImport: false));
-    _canonicalizeCache.remove((url, forImport: true));
-    _perImporterCanonicalizeCache.removeWhere(
-        (key, _) => key.$2 == url || _nonCanonicalRelativeUrls[key] == url);
+  Future<void> clearCanonicalize(Uri canonicalUrl) async {
+    for (var key in [..._canonicalizeCache.keys]) {
+      for (var importer in _importers) {
+        if (await importer.couldCanonicalize(key.$1, canonicalUrl)) {
+          _canonicalizeCache.remove(key);
+          break;
+        }
+      }
+    }
+
+    for (var key in [..._perImporterCanonicalizeCache.keys]) {
+      if (await key.$1.couldCanonicalize(key.$2, canonicalUrl)) {
+        _perImporterCanonicalizeCache.remove(key);
+      }
+    }
   }
 
   /// Clears the cached parse tree for the stylesheet with the given

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -124,6 +124,10 @@ Future<void> _compileStylesheetWithoutErrorHandling(ExecutableOptions options,
               fatalDeprecations: options.fatalDeprecations,
               futureDeprecations: options.futureDeprecations);
     } else {
+      // Double-check that all modified files (according to mtime) are actually
+      // reloaded in the graph so we don't end up with stale ASTs.
+      graph.reloadAllModified();
+
       result = source == null
           ? compileString(await readStdin(),
               syntax: syntax,

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.6
+
+* No user-visible changes.
+
 ## 0.4.5
 
 * Add support for parsing the `@forward` rule.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 14.2.1
+
+* No user-visible changes.
+
 ## 14.2.0
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 14.2.0
+version: 14.2.1
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
-  sass: 1.81.0
+  sass: 1.81.1
 
 dev_dependencies:
   dartdoc: ^8.0.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.81.0
+version: 1.81.1
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
1. The import cache now tracks the most recent time it actually loaded
   a stylesheet, so that `--watch` mode can invalidate cached data
   if it's older than the mtime on disk. This should help catch some
   cases where the watcher information doesn't match the filesystem.

2. Rather than eagerly recompiling as soon as it knows it needs to,
   the stylesheet graph now only starts recompiling once it's finished
   processing a batch of events. This ensures that any cache
   invalidation is finished before the recompilation happens.

3. The stylesheet graph and import cache now eagerly invalidate all
   canonicalize results that could be changed by an added or removed
   file, rather than only those that are implicated by the in-memory
   ASTs. This avoids issues when the in-memory AST is stale.

Closes #2440