### PR TITLE
Enable useDefineForClassFields and fix affected TS files.

### DIFF
--- a/pkg/sass-parser/lib/src/configured-variable.ts
+++ b/pkg/sass-parser/lib/src/configured-variable.ts
@@ -100,7 +100,7 @@ export class ConfiguredVariable extends Node {
    * This is the parsed and normalized value, with underscores converted to
    * hyphens and escapes resolved to the characters they represent.
    */
-  name!: string;
+  declare name: string;
 
   /** The expresison whose value the variable is assigned. */
   get expression(): Expression {
@@ -112,10 +112,10 @@ export class ConfiguredVariable extends Node {
     if (value) value.parent = this;
     this._expression = value;
   }
-  private _expression!: Expression;
+  private declare _expression: Expression;
 
   /** Whether this has a `!default` guard. */
-  guarded!: boolean;
+  declare guarded: boolean;
 
   constructor(defaults: ConfiguredVariableProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/expression/binary-operation.ts
+++ b/pkg/sass-parser/lib/src/expression/binary-operation.ts
@@ -76,7 +76,7 @@ export class BinaryOperationExpression extends Expression {
     // TODO - postcss/postcss#1957: Mark this as dirty
     this._operator = operator;
   }
-  private _operator!: BinaryOperator;
+  private declare _operator: BinaryOperator;
 
   /** The expression on the left-hand side of this operation. */
   get left(): Expression {
@@ -89,7 +89,7 @@ export class BinaryOperationExpression extends Expression {
     left.parent = this;
     this._left = left;
   }
-  private _left!: Expression;
+  private declare _left: Expression;
 
   /** The expression on the right-hand side of this operation. */
   get right(): Expression {
@@ -102,7 +102,7 @@ export class BinaryOperationExpression extends Expression {
     right.parent = this;
     this._right = right;
   }
-  private _right!: Expression;
+  private declare _right: Expression;
 
   constructor(defaults: BinaryOperationExpressionProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/expression/boolean.ts
+++ b/pkg/sass-parser/lib/src/expression/boolean.ts
@@ -44,7 +44,7 @@ export class BooleanExpression extends Expression {
     // TODO - postcss/postcss#1957: Mark this as dirty
     this._value = value;
   }
-  private _value!: boolean;
+  private declare _value: boolean;
 
   constructor(defaults: BooleanExpressionProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/expression/number.ts
+++ b/pkg/sass-parser/lib/src/expression/number.ts
@@ -54,7 +54,7 @@ export class NumberExpression extends Expression {
     // TODO - postcss/postcss#1957: Mark this as dirty
     this._value = value;
   }
-  private _value!: number;
+  private declare _value: number;
 
   /** The denominator units of this number. */
   get unit(): string | null {
@@ -64,7 +64,7 @@ export class NumberExpression extends Expression {
     // TODO - postcss/postcss#1957: Mark this as dirty
     this._unit = unit;
   }
-  private _unit!: string | null;
+  private declare _unit: string | null;
 
   /** Whether the number is unitless. */
   isUnitless(): boolean {

--- a/pkg/sass-parser/lib/src/expression/string.ts
+++ b/pkg/sass-parser/lib/src/expression/string.ts
@@ -55,7 +55,7 @@ export class StringExpression extends Expression {
     text.parent = this;
     this._text = text;
   }
-  private _text!: Interpolation;
+  private declare _text: Interpolation;
 
   // TODO: provide a utility asPlainIdentifier method that returns the value of
   // an identifier with any escapes resolved, if this is indeed a valid unquoted
@@ -75,7 +75,7 @@ export class StringExpression extends Expression {
     // TODO - postcss/postcss#1957: Mark this as dirty
     this._quotes = quotes;
   }
-  private _quotes!: boolean;
+  private declare _quotes: boolean;
 
   constructor(defaults: StringExpressionProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/interpolation.ts
+++ b/pkg/sass-parser/lib/src/interpolation.ts
@@ -104,7 +104,7 @@ export class Interpolation
     // This *should* only ever be called by the superclass constructor.
     this._nodes = nodes;
   }
-  private _nodes?: Array<string | Expression>;
+  private declare _nodes?: Array<string | Expression>;
 
   /** Returns whether this contains no interpolated expressions. */
   get isPlain(): boolean {

--- a/pkg/sass-parser/lib/src/parameter-list.ts
+++ b/pkg/sass-parser/lib/src/parameter-list.ts
@@ -97,7 +97,7 @@ export class ParameterList
     // This *should* only ever be called by the superclass constructor.
     this._nodes = nodes;
   }
-  private _nodes?: Array<Parameter>;
+  private declare _nodes?: Array<Parameter>;
 
   /**
    * The name of the rest parameter (such as `args` in `...$args`) in this

--- a/pkg/sass-parser/lib/src/statement/css-comment.ts
+++ b/pkg/sass-parser/lib/src/statement/css-comment.ts
@@ -78,7 +78,7 @@ export class CssComment
     textInterpolation.parent = this;
     this._textInterpolation = textInterpolation;
   }
-  private _textInterpolation?: Interpolation;
+  private declare _textInterpolation?: Interpolation;
 
   constructor(defaults: CssCommentProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/statement/debug-rule.ts
+++ b/pkg/sass-parser/lib/src/statement/debug-rule.ts
@@ -78,7 +78,7 @@ export class DebugRule
     if (debugExpression) debugExpression.parent = this;
     this._debugExpression = debugExpression;
   }
-  private _debugExpression?: Expression;
+  private declare _debugExpression?: Expression;
 
   constructor(defaults: DebugRuleProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/statement/each-rule.ts
+++ b/pkg/sass-parser/lib/src/statement/each-rule.ts
@@ -107,7 +107,7 @@ export class EachRule
     if (eachExpression) eachExpression.parent = this;
     this._eachExpression = eachExpression;
   }
-  private _eachExpression?: Expression;
+  private declare _eachExpression?: Expression;
 
   constructor(defaults: EachRuleProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/statement/error-rule.ts
+++ b/pkg/sass-parser/lib/src/statement/error-rule.ts
@@ -78,7 +78,7 @@ export class ErrorRule
     if (errorExpression) errorExpression.parent = this;
     this._errorExpression = errorExpression;
   }
-  declare private _errorExpression?: Expression;
+  private declare _errorExpression?: Expression;
 
   constructor(defaults: ErrorRuleProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/statement/error-rule.ts
+++ b/pkg/sass-parser/lib/src/statement/error-rule.ts
@@ -78,7 +78,7 @@ export class ErrorRule
     if (errorExpression) errorExpression.parent = this;
     this._errorExpression = errorExpression;
   }
-  private _errorExpression?: Expression;
+  declare private _errorExpression?: Expression;
 
   constructor(defaults: ErrorRuleProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/statement/for-rule.ts
+++ b/pkg/sass-parser/lib/src/statement/for-rule.ts
@@ -114,7 +114,7 @@ export class ForRule
     if (fromExpression) fromExpression.parent = this;
     this._fromExpression = fromExpression;
   }
-  private _fromExpression?: Expression;
+  private declare _fromExpression?: Expression;
 
   /** The expresison whose value is the ending point of the iteration. */
   get toExpression(): Expression {
@@ -128,7 +128,7 @@ export class ForRule
     if (toExpression) toExpression.parent = this;
     this._toExpression = toExpression;
   }
-  private _toExpression?: Expression;
+  private declare _toExpression?: Expression;
 
   constructor(defaults: ForRuleProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/statement/forward-rule.ts
+++ b/pkg/sass-parser/lib/src/statement/forward-rule.ts
@@ -78,7 +78,7 @@ export interface ForwardRuleRaws extends Omit<AtRuleRaws, 'params'> {
   afterWith?: string;
 }
 
-/** The initilaizer properties for {@link ForwardMemberList}. */
+/** The initializer properties for {@link ForwardMemberList}. */
 export interface ForwardMemberProps {
   mixinsAndFunctions?: Iterable<string>;
   variables?: Iterable<string>;
@@ -229,7 +229,7 @@ export class ForwardRule
         : new Configuration(configuration);
     this._configuration.parent = this;
   }
-  private _configuration!: Configuration;
+  private declare _configuration: Configuration;
 
   constructor(defaults: ForwardRuleProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/statement/generic-at-rule.ts
+++ b/pkg/sass-parser/lib/src/statement/generic-at-rule.ts
@@ -95,7 +95,7 @@ export class GenericAtRule
     nameInterpolation.parent = this;
     this._nameInterpolation = nameInterpolation;
   }
-  private _nameInterpolation?: Interpolation;
+  private declare _nameInterpolation?: Interpolation;
 
   get params(): string {
     if (this.name !== 'media' || !this.paramsInterpolation) {
@@ -145,7 +145,7 @@ export class GenericAtRule
     if (paramsInterpolation) paramsInterpolation.parent = this;
     this._paramsInterpolation = paramsInterpolation;
   }
-  private _paramsInterpolation: Interpolation | undefined;
+  private declare _paramsInterpolation: Interpolation | undefined;
 
   constructor(defaults: GenericAtRuleProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/statement/rule.ts
+++ b/pkg/sass-parser/lib/src/statement/rule.ts
@@ -79,7 +79,7 @@ export class Rule extends _Rule implements Statement {
     selectorInterpolation.parent = this;
     this._selectorInterpolation = selectorInterpolation;
   }
-  private _selectorInterpolation?: Interpolation;
+  private declare _selectorInterpolation?: Interpolation;
 
   constructor(defaults: RuleProps);
   constructor(_: undefined, inner: sassInternal.StyleRule);

--- a/pkg/sass-parser/lib/src/statement/use-rule.ts
+++ b/pkg/sass-parser/lib/src/statement/use-rule.ts
@@ -151,7 +151,7 @@ export class UseRule
         : new Configuration(configuration);
     this._configuration.parent = this;
   }
-  private _configuration!: Configuration;
+  private declare _configuration: Configuration;
 
   constructor(defaults: UseRuleProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/statement/variable-declaration.ts
+++ b/pkg/sass-parser/lib/src/statement/variable-declaration.ts
@@ -106,7 +106,7 @@ export class VariableDeclaration
     if (value) value.parent = this;
     this._expression = value;
   }
-  private _expression!: Expression;
+  private declare _expression: Expression;
 
   /** Whether the variable has a `!default` flag. */
   declare guarded: boolean;

--- a/pkg/sass-parser/lib/src/statement/warn-rule.ts
+++ b/pkg/sass-parser/lib/src/statement/warn-rule.ts
@@ -78,7 +78,7 @@ export class WarnRule
     if (warnExpression) warnExpression.parent = this;
     this._warnExpression = warnExpression;
   }
-  private _warnExpression?: Expression;
+  private declare _warnExpression?: Expression;
 
   constructor(defaults: WarnRuleProps);
   /** @hidden */

--- a/pkg/sass-parser/lib/src/statement/while-rule.ts
+++ b/pkg/sass-parser/lib/src/statement/while-rule.ts
@@ -83,7 +83,7 @@ export class WhileRule
     if (whileCondition) whileCondition.parent = this;
     this._whileCondition = whileCondition;
   }
-  private _whileCondition?: Expression;
+  private declare _whileCondition?: Expression;
 
   constructor(defaults: WhileRuleProps);
   /** @hidden */

--- a/pkg/sass-parser/tsconfig.json
+++ b/pkg/sass-parser/tsconfig.json
@@ -7,13 +7,7 @@
     "resolveJsonModule": true,
     "rootDir": ".",
     "useUnknownInCatchVariables": false,
-    "useDefineForClassFields": false,
     "declaration": true
   },
-  "include": [
-    "*.ts",
-    "lib/**/*.ts",
-    "tool/**/*.ts",
-    "test/**/*.ts"
-  ]
+  "include": ["*.ts", "lib/**/*.ts", "tool/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
Fixes #2419

Turning off this TS compiler option is deprecated, and it will be removed "soon". It's annoying.. but oh well.