### PR TITLE
Expose `NodePackageImporter` in sass_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.81.1
+
+* No user-visible changes.
+
 ## 1.81.0
 
 * Fix a few cases where deprecation warnings weren't being emitted for global

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.6
+
+* No user-visible changes.
+
 ## 0.4.5
 
 * Add support for parsing the `@forward` rule.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 14.2.1
+
+* Add `NodePackageImporter`, which loads `pkg:` URLs from `node_modules` within
+  the provided `entryPointDirectory`.
+
 ## 14.2.0
 
 * No user-visible changes.
@@ -17,7 +22,7 @@
 ## 14.1.0
 
 * Add `Expression.isCalculationSafe`, which returns true when this expression
-  can safely be used in a calcuation.
+  can safely be used in a calculation.
 
 ## 14.0.0
 

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 14.2.1
+## 14.3.0
 
 * Add `NodePackageImporter`, which loads `pkg:` URLs from `node_modules` within
   the provided `entryPointDirectory`.

--- a/pkg/sass_api/lib/sass_api.dart
+++ b/pkg/sass_api/lib/sass_api.dart
@@ -16,6 +16,7 @@ export 'package:sass/src/ast/selector.dart';
 export 'package:sass/src/async_import_cache.dart';
 export 'package:sass/src/exception.dart' show SassFormatException;
 export 'package:sass/src/import_cache.dart';
+export 'package:sass/src/importer/node_package.dart';
 export 'package:sass/src/interpolation_map.dart';
 export 'package:sass/src/value.dart' hide ColorFormat, SpanColorFormat;
 export 'package:sass/src/visitor/find_dependencies.dart';

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 14.2.0
+version: 14.2.1
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
-  sass: 1.81.0
+  sass: 1.81.1
 
 dev_dependencies:
   dartdoc: ^8.0.14

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 14.2.1
+version: 14.3.0
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.81.0
+version: 1.81.1
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This will allow the Sass migrator to support `pkg:` URLs.