### PR TITLE
Fix static analysis issues for dart 3.6

### DIFF
--- a/lib/src/callable/built_in.dart
+++ b/lib/src/callable/built_in.dart
@@ -109,7 +109,9 @@ final class BuiltInCallable implements Callable, AsyncBuiltInCallable {
         // If two overloads have the same mismatch distance, favor the overload
         // that has more arguments.
         if (mismatchDistance.abs() == minMismatchDistance.abs() &&
-            mismatchDistance < 0) continue;
+            mismatchDistance < 0) {
+          continue;
+        }
       }
 
       minMismatchDistance = mismatchDistance;

--- a/lib/src/embedded/compilation_dispatcher.dart
+++ b/lib/src/embedded/compilation_dispatcher.dart
@@ -91,7 +91,7 @@ final class CompilationDispatcher {
           case InboundMessage_Message.notSet:
             throw parseError("InboundMessage.message is not set.");
 
-          default:
+          default: // ignore: unreachable_switch_default
             throw parseError(
                 "Unknown message type: ${message.toDebugString()}");
         }


### PR DESCRIPTION
This PR fixes the following issues showing up with today's dart 3.6 release:

```
warning • lib/src/embedded/compilation_dispatcher.dart:94:11 • This default clause is covered by the previous cases. Try removing the default clause, or restructuring the preceding patterns. • unreachable_switch_default
   info • lib/src/callable/built_in.dart:112:35 • Statements in an if should be enclosed in a block. Try wrapping the statement in a block. • curly_braces_in_flow_control_structures
```