### PR TITLE
Build android-ia32 on android-x64 sdk

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -92,7 +92,7 @@ jobs:
                      --workdir "$PWD" \
                      ${{ matrix.image }} <<'EOF'
           set -e
-          export DART_SDK=/system/${{ endsWith(matrix.target, '64') && 'lib64' || 'lib' }}/dart
+          export DART_SDK=/system/${{ matrix.target != 'android-arm' && 'lib64' || 'lib' }}/dart
           export PATH=$DART_SDK/bin:$PATH
           dart pub get
           dart run grinder pkg-standalone-${{ matrix.target }}


### PR DESCRIPTION
To prepare for https://github.com/dart-lang/sdk/issues/59698, I'm removing ia32 docker image for dart-musl and dart-android ahead of time. - This aligns with the official dart-docker image, which has no ia32 image to begin with.

The ia32 sdk archives for dart-musl and dart-android will continue to be built for 3.7 releases.

This PR updates the build pipeline to use android-x64 image to build android-ia32 JIT snapshot. - The linux-ia32 and linux-ia32-musl are already being built on x64 image this way, so this PR is just aligning all three platforms.

- https://github.com/dart-musl/dart/commit/8c25fad9f7cb13b625e98c0cbb5c4129cbdd7388
- https://github.com/dart-android/dart/commit/81aea364c7806f82afe0a068006ac996be10a420