### PR TITLE
Clean some comments in the code

### DIFF
--- a/lib/src/async_environment.dart
+++ b/lib/src/async_environment.dart
@@ -782,8 +782,6 @@ final class AsyncEnvironment {
       var values = _variables[i];
       var nodes = _variableNodes[i];
       for (var (name, value) in values.pairs) {
-        // Implicit configurations are never invalid, making [configurationSpan]
-        // unnecessary, so we pass null here to avoid having to compute it.
         configuration[name] = ConfiguredValue.implicit(value, nodes[name]!);
       }
     }

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -46,7 +46,7 @@ final class Configuration {
   /// An implicit configuration will always return `false` because it was not
   /// created through another configuration.
   ///
-  /// [ExplicitConfiguration]s will and configurations created [throughForward]
+  /// [ExplicitConfiguration]s and configurations created [throughForward]
   /// will be considered to have the same original config if they were created
   /// as a copy from the same base configuration.
   bool sameOriginal(Configuration that) =>

--- a/lib/src/environment.dart
+++ b/lib/src/environment.dart
@@ -788,8 +788,6 @@ final class Environment {
       var values = _variables[i];
       var nodes = _variableNodes[i];
       for (var (name, value) in values.pairs) {
-        // Implicit configurations are never invalid, making [configurationSpan]
-        // unnecessary, so we pass null here to avoid having to compute it.
         configuration[name] = ConfiguredValue.implicit(value, nodes[name]!);
       }
     }


### PR DESCRIPTION
The comments in environments is not relevant since the refactoring of `ConfiguredValue` introducing the `implicit` factory. `null` is not passed to the factory (the factory does that behavior internally for all implicit values instead)