### PR TITLE
Use thread-safe writeln from dart sdk >=3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.85.2-dev
 
-* No user-visible changes.
+### Dart API
+
+* Increase the minimum Dart SDK to 3.6.0.
 
 ## 1.85.1
 

--- a/lib/src/io/vm.dart
+++ b/lib/src/io/vm.dart
@@ -32,20 +32,11 @@ bool get supportsAnsiEscapes {
 }
 
 void safePrint(Object? message) {
-  _threadSafeWriteLn(io.stdout, message);
+  print(message);
 }
 
 void printError(Object? message) {
-  _threadSafeWriteLn(io.stderr, message);
-}
-
-void _threadSafeWriteLn(io.IOSink sink, Object? message) {
-  // This does have performance penality of copying buffer
-  // if message is already a StringBuffer.
-  // https://github.com/dart-lang/sdk/issues/53471.
-  var buffer = StringBuffer(message.toString());
-  buffer.writeln();
-  sink.write(buffer);
+  io.stderr.writeln(message);
 }
 
 String readFile(String path) {

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -7,7 +7,7 @@ description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
   sass: 1.85.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ executables:
   sass: sass
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
   args: ^2.0.0


### PR DESCRIPTION
This PR bumps the sdk requirement to >=3.6.0 so that we can use the thread-safe `writeln` from the following:

https://github.com/dart-lang/sdk/commit/e8c035308bec001af477d644f3a5c396dedc94ff