### PR TITLE
Drop support for bogus combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
   parsing associated with it. It is now parsed like any other unknown plain CSS
   at-rule, where Sass features are only allowed within `#{}` interpolation.
 
+### Dart API
+
+* Remove `Value.assertSelector()`, `.assertSimpleSelector()`,
+  `.assertCompoundSelector()`, and `.assertComplexSelector()`. This is now only
+  available through the expanded `sass_api` package, since that package also
+  exposes the selector AST that it returns.
+
 ## 1.85.2-dev
 
 * No user-visible changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 * **Breaking change:** The `@-moz-document` rule no longer has any special
   parsing associated with it. It is now parsed like any other unknown plain CSS
   at-rule, where Sass features are only allowed within `#{}` interpolation.
+  
+### Bogus Combinators
+
+* **Breaking change:** Selectors with more than one combinator in a row, such as
+  `.foo + ~ a`, are now syntax errors.
+
+* **Breaking change:** It's now an error for a selector at the root of the
+  document or in a psuedo selector to have a leading combinator, such as
+  `+ .foo`. These are still allowed in nested selectors and in `:has()`.
+
+* **Breaking change:** It's now an error for selectors with trailing
+  combinators, such as `.foo +`, to contain declarations, non-bubbling plain-CSS
+  at rules, or `@extend` rules.
+
+* **Breaking change:** It's now an error for `@extend` rules to extend selectors
+  with leading or trailing combinators.
+
+* **Breaking change:** The `$extender` and `$extendee` arguments of
+  `selector.extend()` and `selector.replace()`, as well as the `$super` and
+  `$sub` arguments of `selector.is-superselector()`, no longer allow selectors
+  with leading or trailing combinators.
+
+* **Breaking change:** The `$selector` arguments of `selector.extend()` and
+  `selector.replace()`, as well as the `$selector1` and `$selector2` arguments
+  of `selector.unify()`, no longer allow selectors with trailing combinators.
+  Leading combinators are still allowed for these functions because they may
+  appear in a plain CSS nesting context.
 
 ### Dart API
 

--- a/lib/src/ast/css/node.dart
+++ b/lib/src/ast/css/node.dart
@@ -35,16 +35,6 @@ abstract class CssNode implements AstNode {
         const _IsInvisibleVisitor(includeBogus: true, includeComments: false),
       );
 
-  // Whether this node would be invisible even if style rule selectors within it
-  // didn't have bogus combinators.
-  ///
-  /// Note that this doesn't consider nodes that contain loud comments to be
-  /// invisible even though they're omitted in compressed mode.
-  @internal
-  bool get isInvisibleOtherThanBogusCombinators => accept(
-        const _IsInvisibleVisitor(includeBogus: false, includeComments: false),
-      );
-
   // Whether this node will be invisible when loud comments are stripped.
   @internal
   bool get isInvisibleHidingComments => accept(
@@ -92,8 +82,5 @@ class _IsInvisibleVisitor with EveryCssVisitor {
       includeComments && !comment.isPreserved;
 
   bool visitCssStyleRule(CssStyleRule rule) =>
-      (includeBogus
-          ? rule.selector.isInvisible
-          : rule.selector.isInvisibleOtherThanBogusCombinators) ||
-      super.visitCssStyleRule(rule);
+      rule.selector.isInvisible || super.visitCssStyleRule(rule);
 }

--- a/lib/src/ast/sass/parameter_list.dart
+++ b/lib/src/ast/sass/parameter_list.dart
@@ -12,7 +12,7 @@ import '../../utils.dart';
 import 'parameter.dart';
 import 'node.dart';
 
-/// An parameter declaration, as for a function or mixin definition.
+/// A parameter declaration, as for a function or mixin definition.
 ///
 /// {@category AST}
 /// {@category Parsing}

--- a/lib/src/ast/selector.dart
+++ b/lib/src/ast/selector.dart
@@ -5,14 +5,10 @@
 import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
 
-import '../deprecation.dart';
-import '../evaluation_context.dart';
-import '../exception.dart';
 import '../visitor/any_selector.dart';
 import '../visitor/interface/selector.dart';
 import '../visitor/serialize.dart';
 import 'node.dart';
-import 'selector/complex.dart';
 import 'selector/list.dart';
 import 'selector/placeholder.dart';
 import 'selector/pseudo.dart';
@@ -47,57 +43,11 @@ abstract base class Selector implements AstNode {
   ///
   /// @nodoc
   @internal
-  bool get isInvisible => accept(const _IsInvisibleVisitor(includeBogus: true));
-
-  // Whether this selector would be invisible even if it didn't have bogus
-  // combinators.
-  ///
-  /// @nodoc
-  @internal
-  bool get isInvisibleOtherThanBogusCombinators =>
-      accept(const _IsInvisibleVisitor(includeBogus: false));
-
-  /// Whether this selector is not valid CSS.
-  ///
-  /// This includes both selectors that are useful exclusively for build-time
-  /// nesting (`> .foo)` and selectors with invalid combiantors that are still
-  /// supported for backwards-compatibility reasons (`.foo + ~ .bar`).
-  bool get isBogus =>
-      accept(const _IsBogusVisitor(includeLeadingCombinator: true));
-
-  /// Whether this selector is bogus other than having a leading combinator.
-  ///
-  /// @nodoc
-  @internal
-  bool get isBogusOtherThanLeadingCombinator =>
-      accept(const _IsBogusVisitor(includeLeadingCombinator: false));
-
-  /// Whether this is a useless selector (that is, it's bogus _and_ it can't be
-  /// transformed into valid CSS by `@extend` or nesting).
-  ///
-  /// @nodoc
-  @internal
-  bool get isUseless => accept(const _IsUselessVisitor());
+  bool get isInvisible => accept(const _IsInvisibleVisitor());
 
   final FileSpan span;
 
   Selector(this.span);
-
-  /// Prints a warning if `this` is a bogus selector.
-  ///
-  /// This may only be called from within a custom Sass function. This will
-  /// throw a [SassException] in Dart Sass 2.0.0.
-  void assertNotBogus({String? name}) {
-    if (!isBogus) return;
-    warnForDeprecation(
-      (name == null ? '' : '\$$name: ') +
-          '$this is not valid CSS.\n'
-              'This will be an error in Dart Sass 2.0.0.\n'
-              '\n'
-              'More info: https://sass-lang.com/d/bogus-combinators',
-      Deprecation.bogusCombinators,
-    );
-  }
 
   /// Calls the appropriate visit method on [visitor].
   T accept<T>(SelectorVisitor<T> visitor);
@@ -107,17 +57,10 @@ abstract base class Selector implements AstNode {
 
 /// The visitor used to implement [Selector.isInvisible].
 class _IsInvisibleVisitor with AnySelectorVisitor {
-  /// Whether to consider selectors with bogus combinators invisible.
-  final bool includeBogus;
-
-  const _IsInvisibleVisitor({required this.includeBogus});
+  const _IsInvisibleVisitor();
 
   bool visitSelectorList(SelectorList list) =>
       list.components.every(visitComplexSelector);
-
-  bool visitComplexSelector(ComplexSelector complex) =>
-      super.visitComplexSelector(complex) ||
-      (includeBogus && complex.isBogusOtherThanLeadingCombinator);
 
   bool visitPlaceholderSelector(PlaceholderSelector placeholder) => true;
 
@@ -127,58 +70,9 @@ class _IsInvisibleVisitor with AnySelectorVisitor {
       // it means "doesn't match this selector that matches nothing", so it's
       // equivalent to *. If the entire compound selector is composed of `:not`s
       // with invisible lists, the serializer emits it as `*`.
-      return pseudo.name == 'not'
-          ? (includeBogus && selector.isBogus)
-          : selector.accept(this);
+      return pseudo.name != 'not' && selector.accept(this);
     } else {
       return false;
     }
   }
-}
-
-/// The visitor used to implement [Selector.isBogus].
-class _IsBogusVisitor with AnySelectorVisitor {
-  /// Whether to consider selectors with leading combinators as bogus.
-  final bool includeLeadingCombinator;
-
-  const _IsBogusVisitor({required this.includeLeadingCombinator});
-
-  bool visitComplexSelector(ComplexSelector complex) {
-    if (complex.components.isEmpty) {
-      return complex.leadingCombinators.isNotEmpty;
-    } else {
-      return complex.leadingCombinators.length >
-              (includeLeadingCombinator ? 0 : 1) ||
-          complex.components.last.combinators.isNotEmpty ||
-          complex.components.any(
-            (component) =>
-                component.combinators.length > 1 ||
-                component.selector.accept(this),
-          );
-    }
-  }
-
-  bool visitPseudoSelector(PseudoSelector pseudo) {
-    var selector = pseudo.selector;
-    if (selector == null) return false;
-
-    // The CSS spec specifically allows leading combinators in `:has()`.
-    return pseudo.name == 'has'
-        ? selector.isBogusOtherThanLeadingCombinator
-        : selector.isBogus;
-  }
-}
-
-/// The visitor used to implement [Selector.isUseless]
-class _IsUselessVisitor with AnySelectorVisitor {
-  const _IsUselessVisitor();
-
-  bool visitComplexSelector(ComplexSelector complex) =>
-      complex.leadingCombinators.length > 1 ||
-      complex.components.any(
-        (component) =>
-            component.combinators.length > 1 || component.selector.accept(this),
-      );
-
-  bool visitPseudoSelector(PseudoSelector pseudo) => pseudo.isBogus;
 }

--- a/lib/src/ast/selector/complex_component.dart
+++ b/lib/src/ast/selector/complex_component.dart
@@ -5,7 +5,6 @@
 import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
 
-import '../../utils.dart';
 import '../css/value.dart';
 import '../selector.dart';
 
@@ -18,47 +17,39 @@ final class ComplexSelectorComponent {
   /// This component's compound selector.
   final CompoundSelector selector;
 
-  /// This selector's combinators.
+  /// This selector's trailing combinator, if it has one.
   ///
-  /// If this is empty, that indicates that it has an implicit descendent
-  /// combinator. If it's more than one element, that means it's invalid CSS;
-  /// however, we still support this for backwards-compatibility purposes.
-  final List<CssValue<Combinator>> combinators;
+  /// If this is null, that indicates that it has an implicit descendent
+  /// combinator.
+  final CssValue<Combinator>? combinator;
 
   final FileSpan span;
 
-  ComplexSelectorComponent(
-    this.selector,
-    Iterable<CssValue<Combinator>> combinators,
-    this.span,
-  ) : combinators = List.unmodifiable(combinators);
+  ComplexSelectorComponent(this.selector, this.span, {this.combinator});
 
-  /// Returns a copy of `this` with [combinators] added to the end of
-  /// [this.combinators].
+  /// Returns a copy of `this` with [combinator] added to the end.
+  ///
+  /// Returns `null` if this already has a combinator.
   ///
   /// @nodoc
   @internal
-  ComplexSelectorComponent withAdditionalCombinators(
-    List<CssValue<Combinator>> combinators,
+  ComplexSelectorComponent? withAdditionalCombinator(
+    CssValue<Combinator>? combinator,
   ) =>
-      combinators.isEmpty
-          ? this
-          : ComplexSelectorComponent(
-              selector,
-              [
-                ...this.combinators,
-                ...combinators,
-              ],
-              span);
+      switch ((this.combinator, combinator)) {
+        (_, null) => this,
+        (null, var combinator?) =>
+          ComplexSelectorComponent(selector, span, combinator: combinator),
+        _ => null,
+      };
 
-  int get hashCode => selector.hashCode ^ listHash(combinators);
+  int get hashCode => selector.hashCode ^ combinator.hashCode;
 
   bool operator ==(Object other) =>
       other is ComplexSelectorComponent &&
       selector == other.selector &&
-      listEquals(combinators, other.combinators);
+      combinator == other.combinator;
 
   String toString() =>
-      selector.toString() +
-      combinators.map((combinator) => ' $combinator').join('');
+      selector.toString() + (combinator == null ? '' : ' $combinator');
 }

--- a/lib/src/ast/selector/pseudo.dart
+++ b/lib/src/ast/selector/pseudo.dart
@@ -144,13 +144,27 @@ final class PseudoSelector extends SimpleSelector {
 
   /// Returns a new [PseudoSelector] based on this, but with the selector
   /// replaced with [selector].
-  PseudoSelector withSelector(SelectorList selector) => PseudoSelector(
-        name,
-        span,
-        element: isElement,
-        argument: argument,
-        selector: selector,
-      );
+  ///
+  /// Returns `null` if this wouldn't produce a valid selector.
+  PseudoSelector? withSelector(SelectorList selector) {
+    // :has() allows selectors with leading combinators
+    var has = equalsIgnoreCase(name, "has");
+    if (has ? !selector.isRelative : !selector.isStandAlone) {
+      var validComplex = [
+        for (var complex in selector.components)
+          if (has ? complex.isRelative : complex.isStandAlone) complex,
+      ];
+      if (validComplex.isEmpty) return null;
+      selector = SelectorList(validComplex, selector.span);
+    }
+    return PseudoSelector(
+      name,
+      span,
+      element: isElement,
+      argument: argument,
+      selector: selector,
+    );
+  }
 
   /// @nodoc
   @internal

--- a/lib/src/deprecation.dart
+++ b/lib/src/deprecation.dart
@@ -15,7 +15,7 @@ enum Deprecation {
   // DO NOT EDIT. This section was generated from the language repo.
   // See tool/grind/generate_deprecations.dart for details.
   //
-  // Checksum: 8f593fa3dcf8de884b25a82e4625a8bc9effef50
+  // Checksum: b715850a96d4d346e09fecb54444ccec6dc69610
 
   /// Deprecation for passing a string directly to meta.call().
   callString('call-string',
@@ -27,7 +27,9 @@ enum Deprecation {
 
   /// Deprecation for @-moz-document.
   mozDocument('moz-document',
-      deprecatedIn: '1.7.2', description: '@-moz-document.'),
+      deprecatedIn: '1.7.2',
+      obsoleteIn: '2.0.0',
+      description: '@-moz-document.'),
 
   /// Deprecation for imports using relative canonical URLs.
   relativeCanonical('relative-canonical',

--- a/lib/src/deprecation.dart
+++ b/lib/src/deprecation.dart
@@ -15,7 +15,7 @@ enum Deprecation {
   // DO NOT EDIT. This section was generated from the language repo.
   // See tool/grind/generate_deprecations.dart for details.
   //
-  // Checksum: b715850a96d4d346e09fecb54444ccec6dc69610
+  // Checksum: f34f224d924705c05c56bfc57a398706597f6c64
 
   /// Deprecation for passing a string directly to meta.call().
   callString('call-string',
@@ -54,6 +54,7 @@ enum Deprecation {
   /// Deprecation for leading, trailing, and repeated combinators.
   bogusCombinators('bogus-combinators',
       deprecatedIn: '1.54.0',
+      obsoleteIn: '2.0.0',
       description: 'Leading, trailing, and repeated combinators.'),
 
   /// Deprecation for ambiguous + and - operators.

--- a/lib/src/deprecation.dart
+++ b/lib/src/deprecation.dart
@@ -15,7 +15,7 @@ enum Deprecation {
   // DO NOT EDIT. This section was generated from the language repo.
   // See tool/grind/generate_deprecations.dart for details.
   //
-  // Checksum: 47c97f7824eb25d7f1e64e3230938b88330d40b4
+  // Checksum: 8f593fa3dcf8de884b25a82e4625a8bc9effef50
 
   /// Deprecation for passing a string directly to meta.call().
   callString('call-string',

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -9,6 +9,7 @@ import 'package:stack_trace/stack_trace.dart';
 import 'package:term_glyph/term_glyph.dart' as term_glyph;
 
 import 'util/nullable.dart';
+import 'util/span.dart';
 import 'utils.dart';
 import 'value.dart';
 
@@ -32,6 +33,13 @@ class SassException extends SourceSpanException {
       : loadedUrls =
             loadedUrls == null ? const {} : Set.unmodifiable(loadedUrls);
 
+  /// Creates a copy of this exception associated with the given [message].
+  ///
+  /// @nodoc
+  @internal
+  SassException withMessage(String message) =>
+      SassFormatException(message, span, loadedUrls);
+
   /// Converts this to a [MultiSpanSassException] with the additional [span] and
   /// [label].
   ///
@@ -52,6 +60,11 @@ class SassException extends SourceSpanException {
   @internal
   SassException withLoadedUrls(Iterable<Uri> loadedUrls) =>
       SassException(message, span, loadedUrls);
+
+  /// Returns whether any of the spans associated with this exception exactly
+  /// match [span].
+  @internal
+  bool hasSpan(FileSpan span) => this.span.equals(span);
 
   String toString({Object? color}) {
     var buffer = StringBuffer()
@@ -128,6 +141,20 @@ class MultiSpanSassException extends SassException
   ])  : secondarySpans = Map.unmodifiable(secondarySpans),
         super(message, span, loadedUrls);
 
+  @internal
+  bool hasSpan(FileSpan span) =>
+      super.hasSpan(span) || secondarySpans.keys.any((key) => key.equals(span));
+
+  /// Creates a copy of this exception with the given [message].
+  ///
+  /// @nodoc
+  @internal
+  MultiSpanSassException withMessage(String message) =>
+      MultiSpanSassFormatException(
+          message, span, primaryLabel, secondarySpans, loadedUrls);
+
+  /// @nodoc
+  @internal
   MultiSpanSassException withAdditionalSpan(FileSpan span, String label) =>
       MultiSpanSassException(
           message,
@@ -139,6 +166,8 @@ class MultiSpanSassException extends SassException
           },
           loadedUrls);
 
+  /// @nodoc
+  @internal
   MultiSpanSassRuntimeException withTrace(Trace trace) =>
       MultiSpanSassRuntimeException(
         message,
@@ -149,6 +178,8 @@ class MultiSpanSassException extends SassException
         loadedUrls,
       );
 
+  /// @nodoc
+  @internal
   MultiSpanSassException withLoadedUrls(Iterable<Uri> loadedUrls) =>
       MultiSpanSassException(
         message,
@@ -193,6 +224,13 @@ class MultiSpanSassException extends SassException
 class SassRuntimeException extends SassException {
   final Trace trace;
 
+  /// @nodoc
+  @internal
+  SassRuntimeException withMessage(String message) =>
+      SassRuntimeException(message, span, trace, loadedUrls);
+
+  /// @nodoc
+  @internal
   MultiSpanSassRuntimeException withAdditionalSpan(
     FileSpan span,
     String label,
@@ -206,6 +244,8 @@ class SassRuntimeException extends SassException {
         loadedUrls,
       );
 
+  /// @nodoc
+  @internal
   SassRuntimeException withLoadedUrls(Iterable<Uri> loadedUrls) =>
       SassRuntimeException(message, span, trace, loadedUrls);
 
@@ -231,6 +271,14 @@ class MultiSpanSassRuntimeException extends MultiSpanSassException
     Iterable<Uri>? loadedUrls,
   ]) : super(message, span, primaryLabel, secondarySpans, loadedUrls);
 
+  /// @nodoc
+  @internal
+  MultiSpanSassRuntimeException withMessage(String message) =>
+      MultiSpanSassRuntimeException(
+          message, span, primaryLabel, secondarySpans, trace, loadedUrls);
+
+  /// @nodoc
+  @internal
   MultiSpanSassRuntimeException withAdditionalSpan(
     FileSpan span,
     String label,
@@ -244,6 +292,8 @@ class MultiSpanSassRuntimeException extends MultiSpanSassException
         loadedUrls,
       );
 
+  /// @nodoc
+  @internal
   MultiSpanSassRuntimeException withLoadedUrls(Iterable<Uri> loadedUrls) =>
       MultiSpanSassRuntimeException(
         message,
@@ -264,6 +314,11 @@ class SassFormatException extends SassException
   String get source => span.file.getText(0);
 
   int get offset => span.start.offset;
+
+  /// @nodoc
+  @internal
+  SassFormatException withMessage(String message) =>
+      SassFormatException(message, span, loadedUrls);
 
   /// @nodoc
   @internal
@@ -297,6 +352,14 @@ class MultiSpanSassFormatException extends MultiSpanSassException
 
   int get offset => span.start.offset;
 
+  /// @nodoc
+  @internal
+  MultiSpanSassFormatException withMessage(String message) =>
+      MultiSpanSassFormatException(
+          message, span, primaryLabel, secondarySpans, loadedUrls);
+
+  /// @nodoc
+  @internal
   MultiSpanSassFormatException withAdditionalSpan(
     FileSpan span,
     String label,
@@ -311,6 +374,8 @@ class MultiSpanSassFormatException extends MultiSpanSassException
           },
           loadedUrls);
 
+  /// @nodoc
+  @internal
   MultiSpanSassFormatException withLoadedUrls(Iterable<Uri> loadedUrls) =>
       MultiSpanSassFormatException(
         message,

--- a/lib/src/util/map.dart
+++ b/lib/src/util/map.dart
@@ -21,5 +21,6 @@ extension MapExtensions<K, V> on Map<K, V> {
 
   /// Returns an option that contains the value at [key] if one exists and null
   /// otherwise.
-  Option<V> getOption(K key) => containsKey(key) ? (this[key] as V,) : null;
+  Option<V> getOption(K key) =>
+      containsKey(key) ? some(this[key] as V) : none();
 }

--- a/lib/src/util/option.dart
+++ b/lib/src/util/option.dart
@@ -5,8 +5,14 @@
 /// A type that represents either the presence of a value of type `T` or its
 /// absence.
 ///
-/// When the option is present, this will be a single-element tuple that
-/// contains the value. If it's absent, it will be null. This allows callers to
-/// distinguish between a present null value and a value that's absent
-/// altogether.
+/// When the option is present (also known as "some"), this will be a
+/// single-element tuple that contains the value. If it's absent (also known as
+/// "none"), it will be null. This allows callers to distinguish between a
+/// present null value and a value that's absent altogether.
 typedef Option<T> = (T,)?;
+
+/// Creates a present option with the given [value].
+Option<T> some<T>(T value) => (value,);
+
+/// Creates an absent option.
+Option<T> none<T>() => null;

--- a/lib/src/util/span.dart
+++ b/lib/src/util/span.dart
@@ -136,6 +136,12 @@ extension SpanExtensions on FileSpan {
       file.url == target.file.url &&
       start.offset <= target.start.offset &&
       end.offset >= target.end.offset;
+
+  /// Whether this [FileSpan] covers the same region as [other].
+  bool equals(FileSpan other) =>
+      file.url == other.file.url &&
+      start.offset == other.start.offset &&
+      end.offset == other.end.offset;
 }
 
 /// Consumes an identifier from [scanner].

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 25aa2d050126950ea37dc1c53539f0b041356e8e
+// Checksum: 6954fd19b9353445b3cf014505a4f3552cf6b0f0
 //
 // ignore_for_file: unused_import
 
@@ -485,7 +485,7 @@ final class _EvaluateVisitor
             );
             if (local != null || namespace != null) return local;
             return _builtInFunctions[normalizedName];
-          });
+          }, label: "function call");
           if (callable == null) throw "Function not found: $name";
 
           return SassFunction(callable);
@@ -505,6 +505,7 @@ final class _EvaluateVisitor
             name.text.replaceAll("_", "-"),
             namespace: module?.text,
           ),
+          label: "mixin include",
         );
         if (callable == null) throw "Mixin not found: $name";
 
@@ -775,6 +776,8 @@ final class _EvaluateVisitor
         );
       }
 
+      // TODO: Is this exception span necessary?
+
       // Always consider built-in stylesheets to be "already loaded", since they
       // never require additional execution to load and never produce CSS.
       _addExceptionSpan(
@@ -827,6 +830,7 @@ final class _EvaluateVisitor
         _inDependency = oldInDependency;
       }
 
+      // TODO: Is this exception span necessary?
       _addExceptionSpan(
         nodeWithSpan,
         () => callback(module, firstLoad),
@@ -1480,18 +1484,13 @@ final class _EvaluateVisitor
     }
 
     for (var complex in styleRule.originalSelector.components) {
-      if (!complex.isBogus) continue;
-      _warn(
-        'The selector "${complex.toString().trim()}" is invalid CSS and ' +
-            (complex.isUseless ? "can't" : "shouldn't") +
-            ' be an extender.\n'
-                'This will be an error in Dart Sass 2.0.0.\n'
-                '\n'
-                'More info: https://sass-lang.com/d/bogus-combinators',
-        MultiSpan(complex.span.trimRight(), 'invalid selector', {
-          node.span: '@extend rule',
-        }),
-        Deprecation.bogusCombinators,
+      if (complex.isStandAlone) continue;
+      throw MultiSpanSassRuntimeException(
+        "This selector is invalid CSS and can't be an extender.",
+        complex.span.trimRight(),
+        'invalid selector',
+        {node.span: '@extend rule'},
+        _stackTrace(complex.span),
       );
     }
 
@@ -2160,6 +2159,7 @@ final class _EvaluateVisitor
     var mixin = _addExceptionSpan(
       node,
       () => _environment.getMixin(node.name, namespace: node.namespace),
+      label: "mixin include",
     );
     if (node.originalName.startsWith('--') &&
         mixin is UserDefinedCallable &&
@@ -2384,14 +2384,11 @@ final class _EvaluateVisitor
     if (nest) {
       if (_stylesheet.plainCss) {
         for (var complex in parsedSelector.components) {
-          if (complex.leadingCombinators
-              case [
-                var first,
-                ...,
-              ] when _stylesheet.plainCss) {
+          if (complex.leadingCombinator case var combinator?
+              when _stylesheet.plainCss) {
             throw _exception(
               "Top-level leading combinators aren't allowed in plain CSS.",
-              first.span,
+              combinator.span,
             );
           }
         }
@@ -2427,7 +2424,7 @@ final class _EvaluateVisitor
     );
     _atRootExcludingStyleRule = oldAtRootExcludingStyleRule;
 
-    _warnForBogusCombinators(rule);
+    _checkBogusCombinators(rule);
 
     if (_styleRule == null && _parent.children.isNotEmpty) {
       var lastChild = _parent.children.last;
@@ -2437,54 +2434,37 @@ final class _EvaluateVisitor
     return null;
   }
 
-  /// Emits deprecation warnings for any bogus combinators in [rule].
-  void _warnForBogusCombinators(CssStyleRule rule) {
-    if (!rule.isInvisibleOtherThanBogusCombinators) {
-      for (var complex in rule.selector.components) {
-        if (!complex.isBogus) continue;
+  /// Throw errors for any bogus combinators in [rule].
+  void _checkBogusCombinators(CssStyleRule rule) {
+    if (rule.isInvisible) return;
 
-        if (complex.isUseless) {
-          _warn(
-            'The selector "${complex.toString().trim()}" is invalid CSS. It '
-            'will be omitted from the generated CSS.\n'
-            'This will be an error in Dart Sass 2.0.0.\n'
-            '\n'
-            'More info: https://sass-lang.com/d/bogus-combinators',
-            complex.span.trimRight(),
-            Deprecation.bogusCombinators,
-          );
-        } else if (complex.leadingCombinators.isNotEmpty) {
-          if (!_stylesheet.plainCss) {
-            _warn(
-              'The selector "${complex.toString().trim()}" is invalid CSS.\n'
-              'This will be an error in Dart Sass 2.0.0.\n'
-              '\n'
-              'More info: https://sass-lang.com/d/bogus-combinators',
-              complex.span.trimRight(),
-              Deprecation.bogusCombinators,
-            );
-          }
-        } else {
-          _warn(
-            'The selector "${complex.toString().trim()}" is only valid for '
-                    "nesting and shouldn't\n"
-                    'have children other than style rules.' +
-                (complex.isBogusOtherThanLeadingCombinator
-                    ? ' It will be omitted from the generated CSS.'
-                    : '') +
-                '\n'
-                    'This will be an error in Dart Sass 2.0.0.\n'
-                    '\n'
-                    'More info: https://sass-lang.com/d/bogus-combinators',
-            MultiSpan(complex.span.trimRight(), 'invalid selector', {
-              rule.children.first.span: "this is not a style rule" +
-                  (rule.children.every((child) => child is CssComment)
-                      ? '\n(try converting to a //-style comment)'
-                      : ''),
-            }),
-            Deprecation.bogusCombinators,
+    for (var complex in rule.selector.components) {
+      if (complex.isStandAlone) continue;
+
+      if (complex.leadingCombinator != null) {
+        if (!_stylesheet.plainCss) {
+          var span = complex.span.trimRight();
+          throw SassRuntimeException(
+            'This selector is invalid CSS.',
+            span,
+            _stackTrace(span),
           );
         }
+      } else {
+        throw MultiSpanSassRuntimeException(
+          "This selector is only valid for nesting and shouldn't have "
+              "children other than\n"
+              'style rules.',
+          complex.span.trimRight(),
+          'invalid selector',
+          {
+            rule.children.first.span: "this is not a style rule" +
+                (rule.children.every((child) => child is CssComment)
+                    ? '\n(try converting to a //-style comment)'
+                    : ''),
+          },
+          _stackTrace(complex.span),
+        );
       }
     }
   }
@@ -2601,7 +2581,7 @@ final class _EvaluateVisitor
               override.assignmentNode,
               global: true,
             );
-          });
+          }, label: "variable declaration");
           return null;
         }
       }
@@ -2609,6 +2589,7 @@ final class _EvaluateVisitor
       var value = _addExceptionSpan(
         node,
         () => _environment.getVariable(node.name, namespace: node.namespace),
+        label: "variable declaration",
       );
       if (value != null && value != sassNull) return null;
     }
@@ -2644,7 +2625,7 @@ final class _EvaluateVisitor
         namespace: node.namespace,
         global: node.isGlobal,
       );
-    });
+    }, label: "variable declaration");
     return null;
   }
 
@@ -2676,10 +2657,7 @@ final class _EvaluateVisitor
   }
 
   Value? visitWarnRule(WarnRule node) {
-    var value = _addExceptionSpan(
-      node,
-      () => node.expression.accept(this),
-    );
+    var value = node.expression.accept(this);
     _logger.warn(
       value is SassString ? value.text : _serialize(value, node.expression),
       trace: _stackTrace(node.span),
@@ -2818,6 +2796,7 @@ final class _EvaluateVisitor
     var result = _addExceptionSpan(
       node,
       () => _environment.getVariable(node.name, namespace: node.namespace),
+      label: "variable use",
     );
     if (result != null) return result;
     throw _exception("Undefined variable.", node.span);
@@ -2842,7 +2821,7 @@ final class _EvaluateVisitor
 
   Value visitIfExpression(IfExpression node) {
     var (positional, named) = _evaluateMacroArguments(node);
-    _verifyArguments(positional.length, named, IfExpression.declaration, node);
+    _verifyParameters(positional.length, named, IfExpression.declaration, node);
 
     // ignore: prefer_is_empty
     var condition = positional.elementAtOrNull(0) ?? named["condition"]!;
@@ -2908,6 +2887,7 @@ final class _EvaluateVisitor
               node.name,
               namespace: node.namespace,
             ),
+            label: "function call",
           );
     if (function == null) {
       if (node.namespace != null) {
@@ -3389,7 +3369,7 @@ final class _EvaluateVisitor
       // don't affect the underlying environment closure.
       return _withEnvironment(callable.environment.closure(), () {
         return _environment.scope(() {
-          _verifyArguments(
+          _verifyParameters(
             evaluated.positional.length,
             evaluated.named,
             callable.declaration.parameters,
@@ -3565,10 +3545,9 @@ final class _EvaluateVisitor
       evaluated.positional.length,
       namedSet,
     );
-    _addExceptionSpan(
-      nodeWithSpan,
-      () => overload.verify(evaluated.positional.length, namedSet),
-    );
+    _addExceptionSpan(nodeWithSpan,
+        () => overload.verify(evaluated.positional.length, namedSet),
+        label: "invocation");
 
     var parameters = overload.parameters;
     for (var i = evaluated.positional.length; i < parameters.length; i++) {
@@ -3608,6 +3587,7 @@ final class _EvaluateVisitor
       result = _addExceptionSpan(
         nodeWithSpan,
         () => callback(evaluated.positional),
+        label: "invocation",
       );
     } on SassException {
       rethrow;
@@ -3835,16 +3815,14 @@ final class _EvaluateVisitor
 
   /// Throws a [SassRuntimeException] if [positional] and [named] aren't valid
   /// when applied to [parameters].
-  void _verifyArguments(
+  void _verifyParameters(
     int positional,
     Map<String, dynamic> named,
     ParameterList parameters,
     AstNode nodeWithSpan,
   ) =>
       _addExceptionSpan(
-        nodeWithSpan,
-        () => parameters.verify(positional, MapKeySet(named)),
-      );
+          nodeWithSpan, () => parameters.verify(positional, MapKeySet(named)));
 
   Value visitSelectorExpression(SelectorExpression node) =>
       _styleRuleIgnoringAtRoot?.originalSelector.asSassList ?? sassNull;
@@ -4325,6 +4303,7 @@ final class _EvaluateVisitor
               expression.name,
               namespace: expression.namespace,
             ),
+            label: "variable",
           ) ??
           expression;
     } else {
@@ -4548,11 +4527,15 @@ final class _EvaluateVisitor
   /// [AstNode.span] if the span isn't required, since some nodes need to do
   /// real work to manufacture a source span.
   ///
+  /// The [label] is used for [nodeWithSpan]'s span if the error already has a
+  /// source span.
+  ///
   /// If [addStackFrame] is true (the default), this will add an innermost stack
   /// frame for [nodeWithSpan]. Otherwise, it will use the existing stack as-is.
   T _addExceptionSpan<T>(
     AstNode nodeWithSpan,
     T callback(), {
+    String? label,
     bool addStackFrame = true,
   }) {
     try {
@@ -4565,7 +4548,30 @@ final class _EvaluateVisitor
         error,
         stackTrace,
       );
+    } on SassException catch (error, stackTrace) {
+      throwWithTrace(_adjustException(error, nodeWithSpan.span, label: label),
+          error, stackTrace);
     }
+  }
+
+  /// Adjusts [exception] for [_addExceptionSpan].
+  SassException _adjustException(
+    SassException error,
+    FileSpan span, {
+    String? label,
+  }) {
+    // Don't add a duplicate span. This can happen when using `meta.call()` or
+    // `meta.include()`, since those involve two nested calls to
+    // [_addExceptionSpan] with the same span.
+    if (label != null && !error.hasSpan(span)) {
+      error = error.withAdditionalSpan(span, label);
+    }
+
+    if (error is! SassRuntimeException) {
+      error = error.withTrace(_stackTrace(error.span));
+    }
+
+    return error;
   }
 
   /// Runs [callback], and converts any [SassException]s that aren't already

--- a/lib/src/visitor/serialize.dart
+++ b/lib/src/visitor/serialize.dart
@@ -1598,10 +1598,12 @@ final class _SerializeVisitor
   }
 
   void visitComplexSelector(ComplexSelector complex) {
-    _writeCombinators(complex.leadingCombinators);
+    if (complex.leadingCombinator case var combinator?) {
+      _buffer.write(combinator);
+    }
     if (complex
         case ComplexSelector(
-          leadingCombinators: [_, ...],
+          leadingCombinator: var _?,
           components: [_, ...],
         )) {
       _writeOptionalSpace();
@@ -1610,19 +1612,18 @@ final class _SerializeVisitor
     for (var i = 0; i < complex.components.length; i++) {
       var component = complex.components[i];
       visitCompoundSelector(component.selector);
-      if (component.combinators.isNotEmpty) _writeOptionalSpace();
-      _writeCombinators(component.combinators);
+
+      if (component.combinator case var combinator?) {
+        _writeOptionalSpace();
+        _buffer.write(combinator);
+      }
+
       if (i != complex.components.length - 1 &&
-          (!_isCompressed || component.combinators.isEmpty)) {
+          (!_isCompressed || component.combinator == null)) {
         _buffer.writeCharCode($space);
       }
     }
   }
-
-  /// Writes [combinators] to [_buffer], with spaces in between in expanded
-  /// mode.
-  void _writeCombinators(List<CssValue<Combinator>> combinators) =>
-      _writeBetween(combinators, _isCompressed ? '' : ' ', _buffer.write);
 
   void visitCompoundSelector(CompoundSelector compound) {
     var start = _buffer.length;

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,6 +1,33 @@
 ## 16.0.0
 
-* No user-visible changes.
+### Bogus Selectors
+
+* Drop support for bogus selectors that can never become valid CSS through
+  nesting, including complex selectors with multiple combinators in a row and
+  selector pseudos whose selectors contain leading and trailing combinators
+  (except for `:has()`, which explicitly allows a leading combinator).
+
+* Replace `ComplexSelector.leadingCombinators` with a nullable
+  `ComplexSelector.leadingCombinator`.
+
+* Remove the `leadingCombinators` argument from `ComplexSelector()` and replace
+  it with a named `leadingCombinator` argument.
+
+* Replace `ComplexSelectorComponent.combinators` with a nullable
+  `ComplexSelectorComponent.combinator`.
+
+* Remove the `combinators` argument from `ComplexSelectorComponent()` and replace
+  it with a named `combinator` argument.
+
+* Replace `Selector.isBogus` with `SelectorList.isStandAlone`,
+  `SelectorList.isRelative`, `ComplexSelector.isStandAlone`, and
+  `ComplexSelector.isRelative`.
+
+* Replace `Selector.assertNotBogus()` with `SelectorList.assertValid()` and
+  `ComplexSelector.assertValid()`.
+
+* `Value.assertSelector()` and `Value.assertComplexSelector()` now forbid
+  selectors with leading or trailing combinators by default.
 
 ## 15.2.2-dev
 

--- a/test/deprecations_test.dart
+++ b/test/deprecations_test.dart
@@ -54,21 +54,6 @@ void main() {
     _expectDeprecation(r"a {b: (4/2)}", Deprecation.slashDiv);
   });
 
-  // Deprecated in 1.54.0
-  group("bogusCombinators is violated by", () {
-    test("adjacent combinators", () {
-      _expectDeprecation("a > > a {b: c}", Deprecation.bogusCombinators);
-    });
-
-    test("leading combinators", () {
-      _expectDeprecation("a > {b: c}", Deprecation.bogusCombinators);
-    });
-
-    test("trailing combinators", () {
-      _expectDeprecation("> a {b: c}", Deprecation.bogusCombinators);
-    });
-  });
-
   // Deprecated in 1.55.0
   group("strictUnary is violated by", () {
     test("an ambiguous + operator", () {


### PR DESCRIPTION
This also improves the way SassExceptions thrown from within custom
functions are handled. If the wrapped exception already has a span,
it's turned into a MultiSpanSassException with an additional span
pointing to the function invocation.

Closes https://github.com/sass/dart-sass/issues/1727

[see sass/sass#4040]
[see sass/sass-spec#2049]