### PR TITLE
Enhance security for release pipeline

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -10,6 +10,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      attestations: write
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -126,6 +130,12 @@ jobs:
           dart pub get
           dart run grinder pkg-standalone-${{ matrix.target }}
           EOF
+
+      - name: Generate artifact attestation
+        if: github.ref_type == 'tag'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: build/*.tar.gz
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -10,6 +10,10 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      attestations: write
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -27,6 +31,12 @@ jobs:
 
       - name: Build
         run: dart run grinder pkg-standalone-macos-${{ matrix.arch }}
+
+      - name: Generate artifact attestation
+        if: github.ref_type == 'tag'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: build/*.tar.gz
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -10,6 +10,10 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      attestations: write
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +33,12 @@ jobs:
 
       - name: Build
         run: dart run grinder pkg-standalone-windows-${{ matrix.arch }}
+
+      - name: Generate artifact attestation
+        if: github.ref_type == 'tag'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: build/*.zip
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Double-check
     runs-on: ubuntu-latest
     needs: [test]
-    if: "startsWith(github.ref, 'refs/tags/') && github.event.repository.fork == false"
+    if: "github.ref_type == 'tag' && github.event.repository.fork == false"
 
     steps:
       - uses: actions/checkout@v4
@@ -27,14 +27,16 @@ jobs:
 
   test_vendor:
     needs: [double_check]
-    if: "startsWith(github.ref, 'refs/tags/') && github.event.repository.fork == false"
+    if: "github.ref_type == 'tag' && github.event.repository.fork == false"
     uses: ./.github/workflows/test-vendor.yml
     secrets: inherit
 
   release:
     needs: [test_vendor]
-    if: "startsWith(github.ref, 'refs/tags/') && github.event.repository.fork == false"
+    if: "github.ref_type == 'tag' && github.event.repository.fork == false"
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     uses: ./.github/workflows/release.yml
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,9 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            build-*/*
+        run: gh release upload ${{ github.ref_name }} build-*/* --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   deploy_npm:
     name: Deploy npm
@@ -131,7 +130,7 @@ jobs:
         # a real dependency on the released version of Sass.
       - name: Get Dart Sass version
         id: dart-sass-version
-        run: echo "version=${GITHUB_REF##*/}" | tee --append "$GITHUB_OUTPUT"
+        run: echo "version=${{ github.ref_name }}" | tee --append "$GITHUB_OUTPUT"
       - run: npm install sass@${{ steps.dart-sass-version.outputs.version }}
         working-directory: pkg/sass-parser/
 
@@ -190,7 +189,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=${GITHUB_REF##*/}" | tee --append "$GITHUB_OUTPUT"
+        run: echo "version=${{ github.ref_name }}" | tee --append "$GITHUB_OUTPUT"
 
       - name: Wait for npm registry's CDN to catch up on replications
         run: sleep 600
@@ -219,7 +218,7 @@ jobs:
       - name: Get version
         id: version
         run: |
-          echo "version=${GITHUB_REF##*/}" | tee --append "$GITHUB_OUTPUT"
+          echo "version=${{ github.ref_name }}" | tee --append "$GITHUB_OUTPUT"
           echo "protocol_version=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" https://raw.githubusercontent.com/sass/sass/HEAD/spec/EMBEDDED_PROTOCOL_VERSION)" | tee --append "$GITHUB_OUTPUT"
 
       - name: Update version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,23 @@ on:
 
 jobs:
   build_linux:
+    permissions:
+      attestations: write
+      id-token: write
     uses: ./.github/workflows/build-linux.yml
     secrets: inherit
 
   build_macos:
+    permissions:
+      attestations: write
+      id-token: write
     uses: ./.github/workflows/build-macos.yml
     secrets: inherit
 
   build_windows:
+    permissions:
+      attestations: write
+      id-token: write
     uses: ./.github/workflows/build-windows.yml
     secrets: inherit
 


### PR DESCRIPTION
Recently supply chain attack on GitHub actions has been on the news.

Although the action this PR is removing has nothing to do with the attack on the news, removing unnecessary external dependency should improve the overall security of the pipeline.

This PR also adds artifact attestations: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds 