### PR TITLE
Fix the sass_api release

### DIFF
--- a/.github/workflows/release-sass-api.yml
+++ b/.github/workflows/release-sass-api.yml
@@ -1,0 +1,29 @@
+# This has to be a separate workflow to satisfy pub.dev's somewhat draconian
+# requirements for when and how GitHub actions are allowed publish packages.
+# Specifically, it requires that each publish action be triggered by a tag that
+# contains the version number for that action, so we can't just publish sass_api
+# as part of the standard sass release flow because that was triggered by a tag
+# with the sass version number.
+name: Release sass-api
+
+on:
+  push:
+    tags: ['sass-api-[0-9]+.[0-9]+.*']
+
+jobs:
+  deploy_sass_api:
+    if: github.event.repository.fork == false
+    name: Deploy sass_api
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/util/initialize
+        with: {github-token: "${{ github.token }}"}
+
+      - name: Deploy
+        run: dart run grinder deploy-sass-api
+        env:
+          PUB_CREDENTIALS: "${{ secrets.PUB_CREDENTIALS }}"
+          GH_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GH_USER: sassbot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # We have to use this rather than the implicit GitHub token so that
+          # pushing a new tag triggers another action.
+          token: ${{ secrets.GH_TOKEN }}
       - uses: ./.github/util/initialize
         with: {github-token: "${{ github.token }}"}
 
@@ -102,22 +106,14 @@ jobs:
         run: dart run grinder protobuf pkg-pub-deploy
         env: {PUB_CREDENTIALS: "${{ secrets.PUB_CREDENTIALS }}"}
 
-  deploy_sass_api:
-    name: Deploy sass_api
-    runs-on: ubuntu-latest
-    needs: [deploy_pub]
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/util/initialize
-        with: {github-token: "${{ github.token }}"}
-
-      - name: Deploy
-        run: dart run grinder deploy-sass-api
-        env:
-          PUB_CREDENTIALS: "${{ secrets.PUB_CREDENTIALS }}"
-          GH_TOKEN: "${{ secrets.GH_TOKEN }}"
-          GH_USER: sassbot
+      - name: Get Sass API version
+        id: sass-api-version
+        run: |
+          echo "version=$(cat pkg/sass_api/pubspec.yaml | sed -nE 's/version: (.*)/\1/p')" | tee --append "$GITHUB_OUTPUT"
+      # This should be /-separated rather than hyphenated, but pub.dev doesn't
+      # currently allow that (dart-lang/pub-dev#8690).
+      - run: git tag sass-api-${{ steps.sass-api-version.outputs.version }}
+      - run: git push --tag
 
   deploy_sass_parser:
     name: Deploy sass-parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.86.2
+
+* No user-visible changes.
+
 ## 1.86.1
 
 * Improve the performance of `file:` URL case canonicalization on Windows and

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.18
+
+* No user-visible changes.
+
 ## 0.4.17
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 15.3.2
+
+* No user-visible changes.
+
 ## 15.3.1
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 15.3.1
+version: 15.3.2
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  sass: 1.86.1
+  sass: 1.86.2
 
 dev_dependencies:
   dartdoc: ^8.0.14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.86.1
+version: 1.86.2
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/tool/grind/sass_api.dart
+++ b/tool/grind/sass_api.dart
@@ -71,6 +71,8 @@ Future<void> deploySassApi() async {
     fail("dart pub publish ${pubspec.name} failed");
   }
 
+  // TODO(nweiz): Remove this when we use this tag to trigger the release
+  // (blocked by dart-lang/pub-dev#8690).
   var response = await client.post(
     Uri.parse("https://api.github.com/repos/sass/dart-sass/git/refs"),
     headers: {


### PR DESCRIPTION
Pub.dev just launched an update that requires GitHub publish actions
to be run from a tag that matches the version number of the published
package.