### PR TITLE
Switch to OSS windows-11-arm runner

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,7 +23,7 @@ jobs:
           - arch: ia32
             runner: windows-latest
           - arch: arm64
-            runner: windows-arm64
+            runner: windows-11-arm
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/