### PR TITLE
Remove useless `_currentCallable` property in the evaluate visitor

### DIFF
--- a/lib/src/deprecation.dart
+++ b/lib/src/deprecation.dart
@@ -18,167 +18,118 @@ enum Deprecation {
   // Checksum: c57ab2eb07ab1df48581b8484ef9bdbad0ddceaa
 
   /// Deprecation for passing a string directly to meta.call().
-  callString(
-    'call-string',
-    deprecatedIn: '0.0.0',
-    description: 'Passing a string directly to meta.call().',
-  ),
+  callString('call-string',
+      deprecatedIn: '0.0.0',
+      description: 'Passing a string directly to meta.call().'),
 
   /// Deprecation for @elseif.
   elseif('elseif', deprecatedIn: '1.3.2', description: '@elseif.'),
 
   /// Deprecation for @-moz-document.
-  mozDocument(
-    'moz-document',
-    deprecatedIn: '1.7.2',
-    description: '@-moz-document.',
-  ),
+  mozDocument('moz-document',
+      deprecatedIn: '1.7.2', description: '@-moz-document.'),
 
   /// Deprecation for imports using relative canonical URLs.
-  relativeCanonical(
-    'relative-canonical',
-    deprecatedIn: '1.14.2',
-    description: 'Imports using relative canonical URLs.',
-  ),
+  relativeCanonical('relative-canonical',
+      deprecatedIn: '1.14.2',
+      description: 'Imports using relative canonical URLs.'),
 
   /// Deprecation for declaring new variables with !global.
-  newGlobal(
-    'new-global',
-    deprecatedIn: '1.17.2',
-    description: 'Declaring new variables with !global.',
-  ),
+  newGlobal('new-global',
+      deprecatedIn: '1.17.2',
+      description: 'Declaring new variables with !global.'),
 
   /// Deprecation for using color module functions in place of plain CSS functions.
-  colorModuleCompat(
-    'color-module-compat',
-    deprecatedIn: '1.23.0',
-    description:
-        'Using color module functions in place of plain CSS functions.',
-  ),
+  colorModuleCompat('color-module-compat',
+      deprecatedIn: '1.23.0',
+      description:
+          'Using color module functions in place of plain CSS functions.'),
 
   /// Deprecation for / operator for division.
-  slashDiv(
-    'slash-div',
-    deprecatedIn: '1.33.0',
-    description: '/ operator for division.',
-  ),
+  slashDiv('slash-div',
+      deprecatedIn: '1.33.0', description: '/ operator for division.'),
 
   /// Deprecation for leading, trailing, and repeated combinators.
-  bogusCombinators(
-    'bogus-combinators',
-    deprecatedIn: '1.54.0',
-    description: 'Leading, trailing, and repeated combinators.',
-  ),
+  bogusCombinators('bogus-combinators',
+      deprecatedIn: '1.54.0',
+      description: 'Leading, trailing, and repeated combinators.'),
 
   /// Deprecation for ambiguous + and - operators.
-  strictUnary(
-    'strict-unary',
-    deprecatedIn: '1.55.0',
-    description: 'Ambiguous + and - operators.',
-  ),
+  strictUnary('strict-unary',
+      deprecatedIn: '1.55.0', description: 'Ambiguous + and - operators.'),
 
   /// Deprecation for passing invalid units to built-in functions.
-  functionUnits(
-    'function-units',
-    deprecatedIn: '1.56.0',
-    description: 'Passing invalid units to built-in functions.',
-  ),
+  functionUnits('function-units',
+      deprecatedIn: '1.56.0',
+      description: 'Passing invalid units to built-in functions.'),
 
   /// Deprecation for using !default or !global multiple times for one variable.
-  duplicateVarFlags(
-    'duplicate-var-flags',
-    deprecatedIn: '1.62.0',
-    description: 'Using !default or !global multiple times for one variable.',
-  ),
+  duplicateVarFlags('duplicate-var-flags',
+      deprecatedIn: '1.62.0',
+      description:
+          'Using !default or !global multiple times for one variable.'),
 
   /// Deprecation for passing null as alpha in the ${isJS ? 'JS': 'Dart'} API.
-  nullAlpha(
-    'null-alpha',
-    deprecatedIn: '1.62.3',
-    description: 'Passing null as alpha in the ${isJS ? 'JS' : 'Dart'} API.',
-  ),
+  nullAlpha('null-alpha',
+      deprecatedIn: '1.62.3',
+      description: 'Passing null as alpha in the ${isJS ? 'JS' : 'Dart'} API.'),
 
   /// Deprecation for passing percentages to the Sass abs() function.
-  absPercent(
-    'abs-percent',
-    deprecatedIn: '1.65.0',
-    description: 'Passing percentages to the Sass abs() function.',
-  ),
+  absPercent('abs-percent',
+      deprecatedIn: '1.65.0',
+      description: 'Passing percentages to the Sass abs() function.'),
 
   /// Deprecation for using the current working directory as an implicit load path.
-  fsImporterCwd(
-    'fs-importer-cwd',
-    deprecatedIn: '1.73.0',
-    description:
-        'Using the current working directory as an implicit load path.',
-  ),
+  fsImporterCwd('fs-importer-cwd',
+      deprecatedIn: '1.73.0',
+      description:
+          'Using the current working directory as an implicit load path.'),
 
   /// Deprecation for function and mixin names beginning with --.
-  cssFunctionMixin(
-    'css-function-mixin',
-    deprecatedIn: '1.76.0',
-    description: 'Function and mixin names beginning with --.',
-  ),
+  cssFunctionMixin('css-function-mixin',
+      deprecatedIn: '1.76.0',
+      description: 'Function and mixin names beginning with --.'),
 
   /// Deprecation for declarations after or between nested rules.
-  mixedDecls(
-    'mixed-decls',
-    deprecatedIn: '1.77.7',
-    description: 'Declarations after or between nested rules.',
-  ),
+  mixedDecls('mixed-decls',
+      deprecatedIn: '1.77.7',
+      description: 'Declarations after or between nested rules.'),
 
   /// Deprecation for meta.feature-exists
-  featureExists(
-    'feature-exists',
-    deprecatedIn: '1.78.0',
-    description: 'meta.feature-exists',
-  ),
+  featureExists('feature-exists',
+      deprecatedIn: '1.78.0', description: 'meta.feature-exists'),
 
   /// Deprecation for certain uses of built-in sass:color functions.
-  color4Api(
-    'color-4-api',
-    deprecatedIn: '1.79.0',
-    description: 'Certain uses of built-in sass:color functions.',
-  ),
+  color4Api('color-4-api',
+      deprecatedIn: '1.79.0',
+      description: 'Certain uses of built-in sass:color functions.'),
 
   /// Deprecation for using global color functions instead of sass:color.
-  colorFunctions(
-    'color-functions',
-    deprecatedIn: '1.79.0',
-    description: 'Using global color functions instead of sass:color.',
-  ),
+  colorFunctions('color-functions',
+      deprecatedIn: '1.79.0',
+      description: 'Using global color functions instead of sass:color.'),
 
   /// Deprecation for legacy JS API.
-  legacyJsApi(
-    'legacy-js-api',
-    deprecatedIn: '1.79.0',
-    description: 'Legacy JS API.',
-  ),
+  legacyJsApi('legacy-js-api',
+      deprecatedIn: '1.79.0', description: 'Legacy JS API.'),
 
   /// Deprecation for @import rules.
   import('import', deprecatedIn: '1.80.0', description: '@import rules.'),
 
   /// Deprecation for global built-in functions that are available in sass: modules.
-  globalBuiltin(
-    'global-builtin',
-    deprecatedIn: '1.80.0',
-    description:
-        'Global built-in functions that are available in sass: modules.',
-  ),
+  globalBuiltin('global-builtin',
+      deprecatedIn: '1.80.0',
+      description:
+          'Global built-in functions that are available in sass: modules.'),
 
   /// Deprecation for functions named "type".
-  typeFunction(
-    'type-function',
-    deprecatedIn: '1.86.0',
-    description: 'Functions named "type".',
-  ),
+  typeFunction('type-function',
+      deprecatedIn: '1.86.0', description: 'Functions named "type".'),
 
   /// Deprecation for passing a relative url to compileString().
-  compileStringRelativeUrl(
-    'compile-string-relative-url',
-    deprecatedIn: '1.88.0',
-    description: 'Passing a relative url to compileString().',
-  ),
+  compileStringRelativeUrl('compile-string-relative-url',
+      deprecatedIn: '1.88.0',
+      description: 'Passing a relative url to compileString().'),
 
   // END AUTOGENERATED CODE
 

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -210,9 +210,6 @@ final class _EvaluateVisitor
   /// The human-readable name of the current stack frame.
   var _member = "root stylesheet";
 
-  /// The innermost user-defined callable that's being invoked.
-  UserDefinedCallable<AsyncEnvironment>? _currentCallable;
-
   /// The node for the innermost callable that's being invoked.
   ///
   /// This is used to produce warnings for function calls. It's stored as an
@@ -3383,9 +3380,7 @@ final class _EvaluateVisitor
     var name = callable.name;
     if (name != "@content") name += "()";
 
-    var oldCallable = _currentCallable;
     var oldInDependency = _inDependency;
-    _currentCallable = callable;
     _inDependency = callable.inDependency;
     var result = await _withStackFrame(name, nodeWithSpan, () {
       // Add an extra closure() call so that modifications to the environment
@@ -3473,7 +3468,6 @@ final class _EvaluateVisitor
         });
       });
     });
-    _currentCallable = oldCallable;
     _inDependency = oldInDependency;
     return result;
   }

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 607745b48d0737b3be112d0a8753dd87492fcc31
+// Checksum: 05d8589b401932198e1f52434066ea4d6cbf3756
 //
 // ignore_for_file: unused_import
 
@@ -217,9 +217,6 @@ final class _EvaluateVisitor
 
   /// The human-readable name of the current stack frame.
   var _member = "root stylesheet";
-
-  /// The innermost user-defined callable that's being invoked.
-  UserDefinedCallable<Environment>? _currentCallable;
 
   /// The node for the innermost callable that's being invoked.
   ///
@@ -3384,9 +3381,7 @@ final class _EvaluateVisitor
     var name = callable.name;
     if (name != "@content") name += "()";
 
-    var oldCallable = _currentCallable;
     var oldInDependency = _inDependency;
-    _currentCallable = callable;
     _inDependency = callable.inDependency;
     var result = _withStackFrame(name, nodeWithSpan, () {
       // Add an extra closure() call so that modifications to the environment
@@ -3474,7 +3469,6 @@ final class _EvaluateVisitor
         });
       });
     });
-    _currentCallable = oldCallable;
     _inDependency = oldInDependency;
     return result;
   }


### PR DESCRIPTION
Since https://github.com/sass/dart-sass/pull/2474, the `_currentCallable` property is not used anymore (except for restoring its state)