### PR TITLE
Remove ia32 support on dart 3.8

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,9 +22,6 @@ jobs:
             platform: linux/amd64
             target: linux-x64
           - image: docker.io/library/dart
-            platform: linux/amd64
-            target: linux-ia32
-          - image: docker.io/library/dart
             platform: linux/arm64
             target: linux-arm64
           - image: docker.io/library/dart
@@ -37,9 +34,6 @@ jobs:
             platform: linux/amd64
             target: linux-x64-musl
           - image: ghcr.io/dart-musl/dart
-            platform: linux/amd64
-            target: linux-ia32-musl
-          - image: ghcr.io/dart-musl/dart
             platform: linux/arm64
             target: linux-arm64-musl
           - image: ghcr.io/dart-musl/dart
@@ -51,9 +45,6 @@ jobs:
           - image: ghcr.io/dart-android/dart
             platform: linux/amd64
             target: android-x64
-          - image: ghcr.io/dart-android/dart
-            platform: linux/amd64
-            target: android-ia32
           - image: ghcr.io/dart-android/dart
             platform: linux/arm64
             target: android-arm64

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,8 +20,6 @@ jobs:
         include:
           - arch: x64
             runner: windows-latest
-          - arch: ia32
-            runner: windows-latest
           - arch: arm64
             runner: windows-11-arm
 


### PR DESCRIPTION
Extracted as a separate PR from #2413, as dart 3.8.0 is just released today.