### PR TITLE
Fix: Error checking of `@use/@forward ... with...` is too strict

### DIFF
--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -63,6 +63,8 @@ final class Configuration {
 
   bool get isEmpty => values.isEmpty;
 
+  int get length => values.length;
+
   /// Removes a variable with [name] from this configuration, returning it.
   ///
   /// If no such variable exists in this configuration, returns null.

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: a3068d04660dd2bed34b884aa6e1a21d423dc4e5
+// Checksum: cc8b7436b02c3f2fbd6763aa19514ca706c0fbe5
 //
 // ignore_for_file: unused_import
 
@@ -163,6 +163,9 @@ final class _EvaluateVisitor
 
   /// The first [Configuration] used to load a module [Uri].
   final _moduleConfigurations = <Uri, Configuration>{};
+
+  // Track whether a module used one of the variables passed in a "with" clause
+  final _moduleUsedConfigVars = <Uri, bool>{};
 
   /// A map from canonical module URLs to the nodes whose spans indicate where
   /// those modules were originally loaded.
@@ -862,9 +865,17 @@ final class _EvaluateVisitor
   }) {
     var url = stylesheet.span.sourceUrl;
 
+    // set up variables to determine if the module accessed (& consumed) any configuration variables.
+    var startingConfigPropVars =
+        _configuration.length; // number of this._config vars upon entry.
+    var startingConfigVars = (configuration?.length ??
+        0); // number of config vars passed in as a function arg.
+
     if (_modules[url] case var alreadyLoaded?) {
       var currentConfiguration = configuration ?? _configuration;
-      if (!_moduleConfigurations[url]!.sameOriginal(currentConfiguration) &&
+      // note: if module didn't use any of the config vars, treat it as if it was called without them.
+      if (_moduleUsedConfigVars[url]! &&
+          !_moduleConfigurations[url]!.sameOriginal(currentConfiguration) &&
           currentConfiguration is ExplicitConfiguration) {
         var message = namesInErrors
             ? "${p.prettyUri(url)} was already loaded, so it can't be "
@@ -955,6 +966,13 @@ final class _EvaluateVisitor
     if (url != null) {
       _modules[url] = module;
       _moduleConfigurations[url] = _configuration;
+      // determine if the module accessed (& consumed) any configuration variables.
+      // Sometimes this._configuration changes and sometime the value passed to the function shows the change
+      //  so test both: if the number of remaining variables has gone down, then the module used them.
+      _moduleUsedConfigVars[url] =
+          (startingConfigPropVars > _configuration.length) ||
+              (startingConfigVars >
+                  (configuration?.length ?? 0)); //module consumed config vars
       if (nodeWithSpan != null) _moduleNodes[url] = nodeWithSpan;
     }
 


### PR DESCRIPTION
This PR resolves issue #2601

Sass does not allow a previously-loaded module to be subsequently loaded using a `with` configuration. When numerous interdependent modules are loaded in one `@use` call, as in CoreUI, this can lead to spurious errors from modules whose contents do not include the specified variables.  This commit limits `Error: This module was already loaded, so it can't be configured using "with"` errors to modules that actually are overriden by the supplied variables.

As a side-effect this also improves error-reporting when the cause of the error is due to "overriding" a non-existent variable. See examples in Issue #2598