### PR TITLE
Fix CI by pinning postcss version to 8.5.5 and disable app armor for browser tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -309,13 +309,14 @@ jobs:
 
     - run: dart run grinder pkg-npm-dev
       env: {UPDATE_SASS_SASS_REPO: false}
-    - run: sudo chmod 4755 /opt/google/chrome/chrome-sandbox
+    # See https://github.com/puppeteer/puppeteer/issues/12818
+    # Ubuntu 23+ doesn't like running puppeteer without disabling AppArmor.
+    - name: Disable AppArmor
+      run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
     - name: Run tests
       run: dart run test -p chrome -j 2
       env:
         CHROME_EXECUTABLE: chrome
-        # See https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md#option-3_the-safest-way
-        CHROME_DEVEL_SANDBOX: /opt/google/chrome/chrome-sandbox
 
   sass_parser_tests:
     name: "sass-parser Tests | Dart ${{ matrix.dart_channel }} | Node ${{ matrix.node-version }}"
@@ -328,7 +329,7 @@ jobs:
         node-version: ['lts/*']
         include:
           # Test older LTS versions
-          # 
+          #
           # TODO: Test on lts/-2 and lts/-3 once they support
           # `structuredClone()` (that is, once they're v18 or later).
           - os: ubuntu-latest

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "postcss": ">=8.4.41 <8.6.0",
+    "postcss": "8.5.5",
     "sass": "file:../../build/npm"
   },
   "devDependencies": {


### PR DESCRIPTION
Not using 8.5.6 yet because it needs additional changes for type compatibility

For whatever reason, the previous version string was trying to load 8.4.46