### PR TITLE
chore: Add VS Code's config folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist/
 
 # Generated protocol buffer files.
 *.pb*.dart
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ dist/
 
 # Generated protocol buffer files.
 *.pb*.dart
-.vscode
+.vscode/


### PR DESCRIPTION
The title says it all. Allows VS Code users to manage their configs w/o interfering with the repo.