### PR TITLE
Track offsets instead of locations in InterpolationMap

### DIFF
--- a/lib/src/interpolation_map.dart
+++ b/lib/src/interpolation_map.dart
@@ -16,27 +16,27 @@ final class InterpolationMap {
   /// The interpolation from which this map was generated.
   final Interpolation _interpolation;
 
-  /// Locations in the generated string.
+  /// Location offsets in the generated string.
   ///
   /// Each of these indicates the location in the generated string that
   /// corresponds to the end of the component at the same index of
   /// [_interpolation.contents]. Its length is always one less than
   /// [_interpolation.contents] because the last element always ends the string.
-  final List<SourceLocation> _targetLocations;
+  final List<int> _targetOffsets;
 
-  /// Creates a new interpolation map that maps the given [targetLocations] in
-  /// the generated string to the contents of the interpolation.
+  /// Creates a new interpolation map that maps the given [targetOffsets] in the
+  /// generated string to the contents of the interpolation.
   ///
-  /// Each target location at index `i` corresponds to the character in the
+  /// Each target offset at index `i` corresponds to the character in the
   /// generated string after `interpolation.contents[i]`.
   InterpolationMap(
     this._interpolation,
-    Iterable<SourceLocation> targetLocations,
-  ) : _targetLocations = List.unmodifiable(targetLocations) {
+    Iterable<int> targetOffsets,
+  ) : _targetOffsets = List.unmodifiable(targetOffsets) {
     var expectedLocations = math.max(0, _interpolation.contents.length - 1);
-    if (_targetLocations.length != expectedLocations) {
+    if (_targetOffsets.length != expectedLocations) {
       throw ArgumentError(
-        "InterpolationMap must have $expectedLocations targetLocations if the "
+        "InterpolationMap must have $expectedLocations targetOffsets if the "
         "interpolation has ${_interpolation.contents.length} components.",
       );
     }
@@ -122,7 +122,7 @@ final class InterpolationMap {
             ),
           );
     var offsetInString =
-        target.offset - (index == 0 ? 0 : _targetLocations[index - 1].offset);
+        target.offset - (index == 0 ? 0 : _targetOffsets[index - 1]);
 
     // This produces slightly incorrect mappings if there are _unnecessary_
     // escapes in the source file, but that's unlikely enough that it's probably
@@ -134,8 +134,8 @@ final class InterpolationMap {
 
   /// Return the index in [_interpolation.contents] at which [target] points.
   int _indexInContents(SourceLocation target) {
-    for (var i = 0; i < _targetLocations.length; i++) {
-      if (target.offset < _targetLocations[i].offset) return i;
+    for (var i = 0; i < _targetOffsets.length; i++) {
+      if (target.offset < _targetOffsets[i]) return i;
     }
 
     return _interpolation.contents.length - 1;

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -4233,13 +4233,13 @@ final class _EvaluateVisitor
     required bool sourceMap,
     bool warnForColor = false,
   }) async {
-    var targetLocations = sourceMap ? <SourceLocation>[] : null;
+    var targetOffsets = sourceMap ? <int>[] : null;
     var oldInSupportsDeclaration = _inSupportsDeclaration;
     _inSupportsDeclaration = false;
     var buffer = StringBuffer();
     var first = true;
     for (var value in interpolation.contents) {
-      if (!first) targetLocations?.add(SourceLocation(buffer.length));
+      if (!first) targetOffsets?.add(buffer.length);
       first = false;
 
       if (value is String) {
@@ -4277,8 +4277,8 @@ final class _EvaluateVisitor
 
     return (
       buffer.toString(),
-      targetLocations.andThen(
-        (targetLocations) => InterpolationMap(interpolation, targetLocations),
+      targetOffsets.andThen(
+        (targetOffsets) => InterpolationMap(interpolation, targetOffsets),
       ),
     );
   }

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 02a6149a29eca1d21306e9582a6b7df86f4cd2f2
+// Checksum: deb9d00931542dae02ed23607cb17f1273849432
 //
 // ignore_for_file: unused_import
 
@@ -4234,13 +4234,13 @@ final class _EvaluateVisitor
     required bool sourceMap,
     bool warnForColor = false,
   }) {
-    var targetLocations = sourceMap ? <SourceLocation>[] : null;
+    var targetOffsets = sourceMap ? <int>[] : null;
     var oldInSupportsDeclaration = _inSupportsDeclaration;
     _inSupportsDeclaration = false;
     var buffer = StringBuffer();
     var first = true;
     for (var value in interpolation.contents) {
-      if (!first) targetLocations?.add(SourceLocation(buffer.length));
+      if (!first) targetOffsets?.add(buffer.length);
       first = false;
 
       if (value is String) {
@@ -4278,8 +4278,8 @@ final class _EvaluateVisitor
 
     return (
       buffer.toString(),
-      targetLocations.andThen(
-        (targetLocations) => InterpolationMap(interpolation, targetLocations),
+      targetOffsets.andThen(
+        (targetOffsets) => InterpolationMap(interpolation, targetOffsets),
       ),
     );
   }


### PR DESCRIPTION
This is semantically identical, but a little more efficient and easier
to construct in situations without actual `SourceLocation`s.