### PR TITLE
Update the repository URL for sass-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.94.1
+
+* No user-visible changes.
+
 ## 1.94.0
 
 * **Potentially breaking compatibility fix:** `@function` rules whose names

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.34
+
+* No user-visible changes.
+
 ## 0.4.33
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,8 +1,8 @@
 {
   "name": "sass-parser",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
-  "repository": "sass/sass",
+  "repository": "sass/dart-sass",
   "author": "Google Inc.",
   "license": "MIT",
   "exports": {

--- a/pkg/sass-types/package.json
+++ b/pkg/sass-types/package.json
@@ -2,7 +2,7 @@
   "name": "@sass/types",
   "version": "auto",
   "description": "A standalone types package for the Sass JS API",
-  "repository": "sass/sass",
+  "repository": "sass/dart-sass",
   "author": "Google Inc.",
   "license": "MIT",
   "exports": {

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 16.0.1
+
+* No user-visible changes.
+
 ## 16.0.0
 
 * **Breaking change:** `InterpolationMap` now takes a list of integer offsets

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 16.0.0
+version: 16.0.1
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  sass: 1.94.0
+  sass: 1.94.1
 
 dev_dependencies:
   dartdoc: ">=8.0.14 <10.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.94.0
+version: 1.94.1
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This has to match the repo it's published from or npm's new publishing
workflow will complain.