### PR TITLE
Bump the sass-parser version

### DIFF
--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 0.4.36
+## 0.4.37
 
 * Add support for the CSS `if()` expression and its Sass extensions.
+
+## 0.4.36
+
+* No user-visible changes.
 
 ## 0.4.35
 

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.36",
+  "version": "0.4.37",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/dart-sass",
   "author": "Google Inc.",


### PR DESCRIPTION
Due to a versioning mixup, the if() changes didn't actually get
released as part of 0.4.36.