### PR TITLE
Use `pwsh` instead of `powershell`

### DIFF
--- a/.github/util/initialize/action.yml
+++ b/.github/util/initialize/action.yml
@@ -29,21 +29,21 @@ runs:
     # npm trusted publisher infrastructure requires npm >=11.5.1
     - run: npm install -g npm@latest
       if: inputs.for-npm-deploy == true
-      shell: ${{ runner.os == 'Windows' && 'powershell' || 'bash' }}
+      shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
 
     # See: https://github.com/dart-lang/sdk/issues/52266
     - run: Invoke-WebRequest https://pub.dev
       if: runner.os == 'Windows'
-      shell: powershell
+      shell: pwsh
 
     # See: https://github.com/orgs/community/discussions/131594
     # The composite action requires an explict shell, but bash is not available on windows-arm64 runner.
-    # For the following commands conditionally use bash or powershell based on the runner.os:
+    # For the following commands conditionally use bash or pwsh based on the runner.os:
     - run: dart pub get
-      shell: ${{ runner.os == 'Windows' && 'powershell' || 'bash' }}
+      shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
 
     - run: npm install
-      shell: ${{ runner.os == 'Windows' && 'powershell' || 'bash' }}
+      shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
 
     - uses: bufbuild/buf-setup-action@v1.50.0
       with: {github_token: "${{ inputs.github-token }}"}
@@ -65,4 +65,4 @@ runs:
     - name: Generate Dart from protobuf
       run: dart run grinder protobuf
       env: {UPDATE_SASS_SASS_REPO: false}
-      shell: ${{ runner.os == 'Windows' && 'powershell' || 'bash' }}
+      shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}


### PR DESCRIPTION
1.97.1 release failed due to powershell issue. It turns out on GitHub Actions `powershell` runs super outdated powershell 1.0, and `pwsh` runs the latest powershell (7.0 as of writing).

It seems upgrading the powershell fixes the failed step.