### PR TITLE
Emit deprecation warning for case-insensitive function names

### DIFF
--- a/lib/src/parse/stylesheet.dart
+++ b/lib/src/parse/stylesheet.dart
@@ -976,7 +976,14 @@ abstract class StylesheetParser extends Parser {
         spanFrom(start),
       );
     }
-
+    else if (caseInsensitiveFunction(name)) {
+  warnings.add((
+    deprecation: Deprecation.caseInsensitiveFunction,
+    message:
+        'Function names that differ from reserved names only by case are deprecated.',
+    span: spanFrom(beforeName),
+  ));
+}
     if (unvendor(name)
         case "calc" ||
             "element" ||

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -260,7 +260,21 @@ bool equalsIgnoreCase(String? string1, String? string2) {
   }
   return true;
 }
+/// Returns true if [name] differs from a reserved function name only by case.
+bool caseInsensitiveFunction(String? name) {
+  if (name == null) return false;
 
+  const reservedNames = ["url", "expression"];
+
+  for (final reserved in reservedNames) {
+    if (equalsIgnoreCase(name, reserved) &&
+        name != reserved) {
+      return true;
+    }
+  }
+
+  return false;
+}
 /// Returns whether [string] starts with [prefix], ignoring ASCII case.
 bool startsWithIgnoreCase(String string, String prefix) {
   if (string.length < prefix.length) return false;


### PR DESCRIPTION
Emits warning for case-insensitive function names:

- Deprecation entry: https://github.com/sass/sass/pull/4175
- Tests: https://github.com/sass/sass-spec/pull/2100