### PR TITLE
Remove `FilesystemImporter.cwd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   after them, as in `$a -$b`, are now forbidden due to being highly ambiguous
   between `$a - $b` and `$a (-$b)`.
 
+* **Breaking change:** The current working directory is no longer ever
+  implicitly added as a load path. You can add it explicitly with
+  `--load-path=.` or similar options in the APIs.
+
 * **Potentially breaking bug fix:** In some cases involving a `:has()` selector
   with a leading combinator being `@extend`ed by a selector that contained its
   own combinators, `@extend` used to generate incorrect selectors. This has been
@@ -85,7 +89,11 @@
 * **Breaking change:** Remove the unnamed `Callable()` and `AsyncCallable()`
   constructors. Use `Callable.function()` and `AsyncCallable.function()`
   instead.
-  
+
+* **Breaking change:** Remove `FilesystemImporter.cwd`. Instead use
+  `FilesystemImporter.noLoadPath` if you don't need to add the current working
+  directory as a load path, or `FilesystemImporter('.')` if you do.
+
 * **Breaking change:** Remove `Deprecation.calcInterp`. This was never actually
   emitted as a deprecation.
 

--- a/lib/src/async_compile.dart
+++ b/lib/src/async_compile.dart
@@ -65,7 +65,7 @@ Future<CompileResult> compileAsync(
       (syntax == null || syntax == Syntax.forPath(path))) {
     importCache ??= AsyncImportCache.none();
     stylesheet = (await importCache.importCanonical(
-      FilesystemImporter.cwd,
+      FilesystemImporter.noLoadPath,
       p.toUri(canonicalize(path)),
       originalUrl: p.toUri(path),
     ))!;
@@ -82,7 +82,7 @@ Future<CompileResult> compileAsync(
     logger,
     importCache,
     nodeImporter,
-    FilesystemImporter.cwd,
+    FilesystemImporter.noLoadPath,
     functions,
     style,
     useSpaces,
@@ -151,7 +151,7 @@ Future<CompileResult> compileStringAsync(
     logger,
     importCache,
     nodeImporter,
-    importer ?? (isBrowser ? NoOpImporter() : FilesystemImporter.cwd),
+    importer ?? (isBrowser ? NoOpImporter() : FilesystemImporter.noLoadPath),
     functions,
     style,
     useSpaces,

--- a/lib/src/compile.dart
+++ b/lib/src/compile.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_compile.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 59e8cdc72511ce8e0ffac284e4b6fcbeca720b25
+// Checksum: 8182bc2216558397b116ff0d3231a86ac42bf7a7
 //
 // ignore_for_file: unused_import
 
@@ -74,7 +74,7 @@ CompileResult compile(
       (syntax == null || syntax == Syntax.forPath(path))) {
     importCache ??= ImportCache.none();
     stylesheet = importCache.importCanonical(
-      FilesystemImporter.cwd,
+      FilesystemImporter.noLoadPath,
       p.toUri(canonicalize(path)),
       originalUrl: p.toUri(path),
     )!;
@@ -91,7 +91,7 @@ CompileResult compile(
     logger,
     importCache,
     nodeImporter,
-    FilesystemImporter.cwd,
+    FilesystemImporter.noLoadPath,
     functions,
     style,
     useSpaces,
@@ -160,7 +160,7 @@ CompileResult compileString(
     logger,
     importCache,
     nodeImporter,
-    importer ?? (isBrowser ? NoOpImporter() : FilesystemImporter.cwd),
+    importer ?? (isBrowser ? NoOpImporter() : FilesystemImporter.noLoadPath),
     functions,
     style,
     useSpaces,

--- a/lib/src/embedded/importer/file.dart
+++ b/lib/src/embedded/importer/file.dart
@@ -18,7 +18,9 @@ final class FileImporter extends ImporterBase {
   FileImporter(super.dispatcher, this._importerId);
 
   Uri? canonicalize(Uri url) {
-    if (url.scheme == 'file') return FilesystemImporter.cwd.canonicalize(url);
+    if (url.scheme == 'file') {
+      return FilesystemImporter.noLoadPath.canonicalize(url);
+    }
 
     var request = OutboundMessage_FileImportRequest()
       ..importerId = _importerId
@@ -38,7 +40,7 @@ final class FileImporter extends ImporterBase {
           throw 'The file importer must return a file: URL, was "$url"';
         }
 
-        return FilesystemImporter.cwd.canonicalize(url);
+        return FilesystemImporter.noLoadPath.canonicalize(url);
 
       case InboundMessage_FileImportResponse_Result.error:
         throw response.error;
@@ -48,7 +50,7 @@ final class FileImporter extends ImporterBase {
     }
   }
 
-  ImporterResult? load(Uri url) => FilesystemImporter.cwd.load(url);
+  ImporterResult? load(Uri url) => FilesystemImporter.noLoadPath.load(url);
 
   bool isNonCanonicalScheme(String scheme) => scheme != 'file';
 

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -88,7 +88,7 @@ Future<void> _compileStylesheetWithoutErrorHandling(
   String? destination, {
   bool ifModified = false,
 }) async {
-  var importer = FilesystemImporter.cwd;
+  var importer = FilesystemImporter.noLoadPath;
   if (ifModified) {
     try {
       if (source != null &&
@@ -128,7 +128,7 @@ Future<void> _compileStylesheetWithoutErrorHandling(
               syntax: syntax,
               logger: options.logger,
               importCache: importCache,
-              importer: FilesystemImporter.cwd,
+              importer: FilesystemImporter.noLoadPath,
               style: options.style,
               quietDeps: options.quietDeps,
               verbose: options.verbose,
@@ -163,7 +163,7 @@ Future<void> _compileStylesheetWithoutErrorHandling(
               syntax: syntax,
               logger: options.logger,
               importCache: graph.importCache,
-              importer: FilesystemImporter.cwd,
+              importer: FilesystemImporter.noLoadPath,
               style: options.style,
               quietDeps: options.quietDeps,
               verbose: options.verbose,

--- a/lib/src/executable/repl.dart
+++ b/lib/src/executable/repl.dart
@@ -44,7 +44,7 @@ Future<void> repl(ExecutableOptions options) async {
   }
 
   var evaluator = Evaluator(
-    importer: FilesystemImporter.cwd,
+    importer: FilesystemImporter('.'),
     importCache: ImportCache(
       importers: options.pkgImporters,
       loadPaths: options.loadPaths,

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -43,7 +43,7 @@ Future<void> watch(ExecutableOptions options, StylesheetGraph graph) async {
   var sourcesToDestinations = _sourcesToDestinations(options);
   for (var source in sourcesToDestinations.keys) {
     graph.addCanonical(
-      FilesystemImporter.cwd,
+      FilesystemImporter.noLoadPath,
       p.toUri(canonicalize(source)),
       p.toUri(source),
       recanonicalize: false,
@@ -154,7 +154,7 @@ final class _Watcher {
     var destination = _destinationFor(path);
     if (destination != null) _toRecompile[path] = destination;
     var downstream = _graph.addCanonical(
-      FilesystemImporter.cwd,
+      FilesystemImporter.noLoadPath,
       _canonicalize(path),
       p.toUri(path),
     );
@@ -174,7 +174,7 @@ final class _Watcher {
       }
     }
 
-    var downstream = _graph.remove(FilesystemImporter.cwd, url);
+    var downstream = _graph.remove(FilesystemImporter.noLoadPath, url);
     _recompileDownstream(downstream);
   }
 

--- a/lib/src/importer/filesystem.dart
+++ b/lib/src/importer/filesystem.dart
@@ -35,32 +35,14 @@ final class FilesystemImporter extends Importer {
       : _loadPath = p.absolute(loadPath),
         _loadPathDeprecated = false;
 
-  FilesystemImporter._deprecated(String loadPath)
-      : _loadPath = p.absolute(loadPath),
-        _loadPathDeprecated = true;
-
   /// Creates an importer that _only_ loads absolute `file:` URLs and URLs
   /// relative to the current file.
   FilesystemImporter._noLoadPath()
       : _loadPath = null,
         _loadPathDeprecated = false;
 
-  /// A [FilesystemImporter] that loads files relative to the current working
-  /// directory.
-  ///
-  /// Historically, this was the best default for supporting `file:` URL loads
-  /// when the load path didn't matter. However, adding the current working
-  /// directory to the load path wasn't always desirable, so it's no longer
-  /// recommended. Instead, either use [FilesystemImporter.noLoadPath] if the
-  /// load path doesn't matter, or `FilesystemImporter('.')` to explicitly
-  /// preserve the existing behavior.
-  @Deprecated(
-    "Use FilesystemImporter.noLoadPath or FilesystemImporter('.') instead.",
-  )
-  static final cwd = FilesystemImporter._deprecated('.');
-
-  /// Creates an importer that _only_ loads absolute `file:` URLs and URLs
-  /// relative to the current file.
+  /// An importer that _only_ loads absolute `file:` URLs and URLs relative to
+  /// the current file.
   static final noLoadPath = FilesystemImporter._noLoadPath();
 
   Uri? canonicalize(Uri url) {

--- a/lib/src/importer/js_to_dart/async_file.dart
+++ b/lib/src/importer/js_to_dart/async_file.dart
@@ -27,7 +27,9 @@ final class JSToDartAsyncFileImporter extends AsyncImporter {
   JSToDartAsyncFileImporter(this._findFileUrl);
 
   FutureOr<Uri?> canonicalize(Uri url) async {
-    if (url.scheme == 'file') return FilesystemImporter.cwd.canonicalize(url);
+    if (url.scheme == 'file') {
+      return FilesystemImporter.noLoadPath.canonicalize(url);
+    }
 
     var result = wrapJSExceptions(
       () => _findFileUrl(url.toString(), canonicalizeContext),
@@ -48,16 +50,16 @@ final class JSToDartAsyncFileImporter extends AsyncImporter {
       );
     }
 
-    return FilesystemImporter.cwd.canonicalize(resultUrl);
+    return FilesystemImporter.noLoadPath.canonicalize(resultUrl);
   }
 
-  ImporterResult? load(Uri url) => FilesystemImporter.cwd.load(url);
+  ImporterResult? load(Uri url) => FilesystemImporter.noLoadPath.load(url);
 
   DateTime modificationTime(Uri url) =>
-      FilesystemImporter.cwd.modificationTime(url);
+      FilesystemImporter.noLoadPath.modificationTime(url);
 
   bool couldCanonicalize(Uri url, Uri canonicalUrl) =>
-      FilesystemImporter.cwd.couldCanonicalize(url, canonicalUrl);
+      FilesystemImporter.noLoadPath.couldCanonicalize(url, canonicalUrl);
 
   bool isNonCanonicalScheme(String scheme) => scheme != 'file';
 }

--- a/lib/src/importer/js_to_dart/file.dart
+++ b/lib/src/importer/js_to_dart/file.dart
@@ -22,7 +22,9 @@ final class JSToDartFileImporter extends Importer {
   JSToDartFileImporter(this._findFileUrl);
 
   Uri? canonicalize(Uri url) {
-    if (url.scheme == 'file') return FilesystemImporter.cwd.canonicalize(url);
+    if (url.scheme == 'file') {
+      return FilesystemImporter.noLoadPath.canonicalize(url);
+    }
 
     var result = wrapJSExceptions(
       () => _findFileUrl(url.toString(), canonicalizeContext),
@@ -50,16 +52,16 @@ final class JSToDartFileImporter extends Importer {
       );
     }
 
-    return FilesystemImporter.cwd.canonicalize(resultUrl);
+    return FilesystemImporter.noLoadPath.canonicalize(resultUrl);
   }
 
-  ImporterResult? load(Uri url) => FilesystemImporter.cwd.load(url);
+  ImporterResult? load(Uri url) => FilesystemImporter.noLoadPath.load(url);
 
   DateTime modificationTime(Uri url) =>
-      FilesystemImporter.cwd.modificationTime(url);
+      FilesystemImporter.noLoadPath.modificationTime(url);
 
   bool couldCanonicalize(Uri url, Uri canonicalUrl) =>
-      FilesystemImporter.cwd.couldCanonicalize(url, canonicalUrl);
+      FilesystemImporter.noLoadPath.couldCanonicalize(url, canonicalUrl);
 
   bool isNonCanonicalScheme(String scheme) => scheme != 'file';
 }

--- a/lib/src/importer/node_package.dart
+++ b/lib/src/importer/node_package.dart
@@ -30,7 +30,9 @@ final class NodePackageImporter extends Importer {
 
   @override
   Uri? canonicalize(Uri url) {
-    if (url.scheme == 'file') return FilesystemImporter.cwd.canonicalize(url);
+    if (url.scheme == 'file') {
+      return FilesystemImporter.noLoadPath.canonicalize(url);
+    }
     if (url.scheme != 'pkg') return null;
 
     if (url.hasAuthority) {
@@ -98,11 +100,11 @@ final class NodePackageImporter extends Importer {
     // If there is a subpath, attempt to resolve the path relative to the
     // package root, and resolve for file extensions and partials.
     var subpathInRoot = p.join(packageRoot, subpath);
-    return FilesystemImporter.cwd.canonicalize(p.toUri(subpathInRoot));
+    return FilesystemImporter.noLoadPath.canonicalize(p.toUri(subpathInRoot));
   }
 
   @override
-  ImporterResult? load(Uri url) => FilesystemImporter.cwd.load(url);
+  ImporterResult? load(Uri url) => FilesystemImporter.noLoadPath.load(url);
 
   /// Splits a [bare import
   /// specifier](https://nodejs.org/api/esm.html#import-specifiers) `specifier`

--- a/lib/src/importer/package.dart
+++ b/lib/src/importer/package.dart
@@ -21,7 +21,9 @@ final class PackageImporter extends Importer {
   PackageImporter(PackageConfig packageConfig) : _packageConfig = packageConfig;
 
   Uri? canonicalize(Uri url) {
-    if (url.scheme == 'file') return FilesystemImporter.cwd.canonicalize(url);
+    if (url.scheme == 'file') {
+      return FilesystemImporter.noLoadPath.canonicalize(url);
+    }
     if (url.scheme != 'package') return null;
 
     var resolved = _packageConfig.resolve(url);
@@ -31,17 +33,17 @@ final class PackageImporter extends Importer {
       throw "Unsupported URL $resolved.";
     }
 
-    return FilesystemImporter.cwd.canonicalize(resolved);
+    return FilesystemImporter.noLoadPath.canonicalize(resolved);
   }
 
-  ImporterResult? load(Uri url) => FilesystemImporter.cwd.load(url);
+  ImporterResult? load(Uri url) => FilesystemImporter.noLoadPath.load(url);
 
   DateTime modificationTime(Uri url) =>
-      FilesystemImporter.cwd.modificationTime(url);
+      FilesystemImporter.noLoadPath.modificationTime(url);
 
   bool couldCanonicalize(Uri url, Uri canonicalUrl) =>
       (url.scheme == 'file' || url.scheme == 'package' || url.scheme == '') &&
-      FilesystemImporter.cwd.couldCanonicalize(
+      FilesystemImporter.noLoadPath.couldCanonicalize(
         Uri(path: url.path),
         canonicalUrl,
       );


### PR DESCRIPTION
This also removes the implicit addition of the current working
directory as a load path in various circumstances.