### PR TITLE
Use gamma 2.40 for display-referred rec2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.102.0
+
+* Use the 2.4 gamma transfer function for rec2020, as specified by the latest
+  draft of CSS Color 4.
+
 ## 1.101.7
 
 * No user-visible changes.

--- a/lib/src/value/color/space/rec2020.dart
+++ b/lib/src/value/color/space/rec2020.dart
@@ -11,12 +11,6 @@ import '../conversions.dart';
 import '../space.dart';
 import 'utils.dart';
 
-/// A constant used in the rec2020 gamma encoding/decoding functions.
-const _alpha = 1.09929682680944;
-
-/// A constant used in the rec2020 gamma encoding/decoding functions.
-const _beta = 0.018053968510807;
-
 /// The rec2020 color space.
 ///
 /// https://www.w3.org/TR/css-color-4/#predefined-rec2020
@@ -34,9 +28,7 @@ final class Rec2020ColorSpace extends ColorSpace {
   double toLinear(double channel) {
     // Algorithm from https://www.w3.org/TR/css-color-4/#color-conversion-code
     var abs = channel.abs();
-    return abs < _beta * 4.5
-        ? channel / 4.5
-        : channel.sign * (math.pow((abs + _alpha - 1) / _alpha, 1 / 0.45));
+    return channel.sign * math.pow(abs, 2.40);
   }
 
   @override
@@ -44,9 +36,7 @@ final class Rec2020ColorSpace extends ColorSpace {
   double fromLinear(double channel) {
     // Algorithm from https://www.w3.org/TR/css-color-4/#color-conversion-code
     var abs = channel.abs();
-    return abs > _beta
-        ? channel.sign * (_alpha * math.pow(abs, 0.45) - (_alpha - 1))
-        : 4.5 * channel;
+    return channel.sign * math.pow(abs, 1 / 2.40);
   }
 
   @override

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.54
+
+* No user-visible changes.
+
 ## 0.4.53
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.53",
+  "version": "0.4.54",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/dart-sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.8.0
+
+* No user-visible changes.
+
 ## 17.7.7
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 17.7.7
+version: 17.8.0
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  sass: 1.101.7
+  sass: 1.102.0
 
 dev_dependencies:
   dartdoc: ">=8.0.14 <10.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.101.7
+version: 1.102.0
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
- https://github.com/w3c/csswg-drafts/issues/12574
- https://github.com/color-js/color.js/pull/672
- https://github.com/sass/sass-spec/pull/2107
- https://github.com/sass/embedded-host-node/pull/418