### PR TITLE
Always convert printed objects to strings in JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Fix a crash when manually constructing a `SassCalculation` for `'calc'` with
   an argument that can't be simplified.
 
+* Properly emit deprecation warnings as text rather than `StringBuffer` objects
+  when running in a browser.
+
 ## 1.97.3
 
 * Fix a bug where nesting an at-rule within multiple style rules in plain CSS

--- a/lib/src/io/js.dart
+++ b/lib/src/io/js.dart
@@ -39,7 +39,7 @@ void safePrint(Object? message) {
   if (_process case var process?) {
     process.stdout.write("${message ?? ''}\n");
   } else {
-    console.log(message ?? '');
+    console.log(message?.toString() ?? '');
   }
 }
 
@@ -47,7 +47,7 @@ void printError(Object? message) {
   if (_process case var process?) {
     process.stderr.write("${message ?? ''}\n");
   } else {
-    console.error(message ?? '');
+    console.error(message?.toString() ?? '');
   }
 }
 


### PR DESCRIPTION
This makes browsers match the behavior in Dart and Node, and
specifically fixes a bug where warnings were emitted as `StringBuffer`
objects rather than console messages.