### PR TITLE
Make passing a string to `meta.call()` an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   after them, as in `$a -$b`, are now forbidden due to being highly ambiguous
   between `$a - $b` and `$a (-$b)`.
 
+* **Breaking change:** Passing a string to `meta.call()` is now an error.
+  Callers must pass a function object instead.
+
 * **Breaking change:** The current working directory is no longer ever
   implicitly added as a load path. You can add it explicitly with
   `--load-path=.` or similar options in the APIs.

--- a/lib/src/deprecation.dart
+++ b/lib/src/deprecation.dart
@@ -15,11 +15,12 @@ enum Deprecation {
   // DO NOT EDIT. This section was generated from the language repo.
   // See tool/grind/generate_deprecations.dart for details.
   //
-  // Checksum: 731d57cd17d5d00431e3bcb52213e660d1447ca1
+  // Checksum: 5864f1fa8cda0d44fd31136deb98911258e590a6
 
   /// Deprecation for passing a string directly to meta.call().
   callString('call-string',
       deprecatedIn: '0.0.0',
+      obsoleteIn: '2.0.0',
       description: 'Passing a string directly to meta.call().'),
 
   /// Deprecation for @elseif.

--- a/lib/src/value/string.dart
+++ b/lib/src/value/string.dart
@@ -216,6 +216,11 @@ final class SassString extends Value {
 
   SassString assertString([String? name]) => this;
 
+  SassFunction assertFunction([String? name]) => throw SassScriptException(
+      "$this is not a function reference.\n"
+      "Call meta.get-function() to get a reference for a function name.",
+      name);
+
   /// @nodoc
   @internal
   Value plus(Value other) => other is SassString

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -562,24 +562,6 @@ final class _EvaluateVisitor
                 ),
         );
 
-        if (function is SassString) {
-          warnForDeprecation(
-            "Passing a string to call() is deprecated and will be illegal in "
-            "Dart Sass 2.0.0.\n"
-            "\n"
-            "Recommendation: call(get-function($function))",
-            Deprecation.callString,
-          );
-
-          var callableNode = _callableNode!;
-          var expression = FunctionExpression(
-            function.text,
-            invocation,
-            callableNode.span,
-          );
-          return await expression.accept(this);
-        }
-
         var callable = function
             .assertFunction("function")
             .assertCompileContext(_compileContext)

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: 7260583650403a55b8d92fd8d935e43819370fe8
+// Checksum: c256634c1f3f03762bed8c8e4c31f1aaed06bb7b
 //
 // ignore_for_file: unused_import
 
@@ -569,24 +569,6 @@ final class _EvaluateVisitor
                   callableNode.span,
                 ),
         );
-
-        if (function is SassString) {
-          warnForDeprecation(
-            "Passing a string to call() is deprecated and will be illegal in "
-            "Dart Sass 2.0.0.\n"
-            "\n"
-            "Recommendation: call(get-function($function))",
-            Deprecation.callString,
-          );
-
-          var callableNode = _callableNode!;
-          var expression = FunctionExpression(
-            function.text,
-            invocation,
-            callableNode.span,
-          );
-          return expression.accept(this);
-        }
 
         var callable = function
             .assertFunction("function")

--- a/test/cli/shared/repl.dart
+++ b/test/cli/shared/repl.dart
@@ -250,7 +250,7 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
         ]),
       );
       await sass.kill();
-    });
+    }, skip: "Re-enable this once we have post-2.0.0 deprecations");
 
     group("with @use", () {
       test("a module load error", () async {

--- a/test/deprecations_test.dart
+++ b/test/deprecations_test.dart
@@ -10,11 +10,6 @@ import 'package:test/test.dart';
 import 'package:sass/sass.dart';
 
 void main() {
-  // Deprecated in all version of Dart Sass
-  test("callString is violated by passing a string to call", () {
-    _expectDeprecation("a { b: call(random)}", Deprecation.callString);
-  });
-
   group("compileStringRelativeUrl is violated by", () {
     test("a fully relative URL", () {
       _expectDeprecationCallback(
@@ -33,12 +28,6 @@ void main() {
     });
   });
 }
-
-/// Confirms that [source] will error if [deprecation] is fatal.
-void _expectDeprecation(String source, Deprecation deprecation) =>
-    _expectDeprecationCallback(
-        () => compileStringToResult(source, fatalDeprecations: {deprecation}),
-        deprecation);
 
 /// Confirms that [callback] will produce a fatal deprecation error for
 /// [deprecation].


### PR DESCRIPTION
See https://github.com/sass/sass/pull/4213
See https://github.com/sass/sass-spec/pull/2132