### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you use [the Homebrew package manager](https://brew.sh/), you
 can install Dart Sass by running
 
 ```sh
-brew install sass/sass/sass
+brew install dart-sass
 ```
 
 That'll give you a `sass` executable on your command line that will run Dart


### PR DESCRIPTION
Remove the instructions for a using a custom tap. Dart Sass can now be installed [directly](https://github.com/Homebrew/homebrew-core/commit/c075650426acbd202670e168ff5ce46da06bddb6) via Homebrew.