### PR TITLE
Bump node engine requirement to >=20.19.0 and chokidar requirement to ^5.0.0 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,9 +96,6 @@ jobs:
           - os: ubuntu-latest
             dart_channel: stable
             node-version: lts/-2
-          - os: ubuntu-latest
-            dart_channel: stable
-            node-version: lts/-3
           # Test LTS version with dart dev channel
           - os: ubuntu-latest
             dart_channel: dev
@@ -145,9 +142,6 @@ jobs:
           - os: ubuntu-latest
             dart_channel: stable
             node-version: lts/-2
-          - os: ubuntu-latest
-            dart_channel: stable
-            node-version: lts/-3
 
     steps:
       - uses: actions/checkout@v6
@@ -263,9 +257,6 @@ jobs:
           - os: ubuntu-latest
             dart_channel: stable
             node-version: lts/-2
-          - os: ubuntu-latest
-            dart_channel: stable
-            node-version: lts/-3
           # Test LTS version with dart dev channel
           - os: ubuntu-latest
             dart_channel: dev
@@ -323,12 +314,12 @@ jobs:
         node-version: ['lts/*']
         include:
           # Test older LTS versions
-          #
-          # TODO: Test on lts/-2 and lts/-3 once they support
-          # `structuredClone()` (that is, once they're v18 or later).
           - os: ubuntu-latest
             dart_channel: stable
             node-version: lts/-1
+          - os: ubuntu-latest
+            dart_channel: stable
+            node-version: lts/-2
           # Test LTS version with dart dev channel
           - os: ubuntu-latest
             dart_channel: dev

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "name": "sass",
   "devDependencies": {
     "@parcel/watcher": "^2.4.1",
-    "chokidar": "^4.0.0",
+    "chokidar": "^5.0.0",
     "immutable": "^5.1.5",
     "intercept-stdout": "^0.1.2"
   }

--- a/package/package.json
+++ b/package/package.json
@@ -17,7 +17,7 @@
     "node": ">=20.19.0"
   },
   "dependencies": {
-    "chokidar": "^4.0.0",
+    "chokidar": "^5.0.0",
     "immutable": "^5.1.5",
     "source-map-js": ">=0.6.2 <2.0.0"
   },

--- a/package/package.json
+++ b/package/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/nex3"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "chokidar": "^4.0.0",


### PR DESCRIPTION
- Closes #2768