### PR TITLE
Remove the reference to Deprecation.fsImporterCwd

### DIFF
--- a/lib/src/deprecation.dart
+++ b/lib/src/deprecation.dart
@@ -15,7 +15,7 @@ enum Deprecation {
   // DO NOT EDIT. This section was generated from the language repo.
   // See tool/grind/generate_deprecations.dart for details.
   //
-  // Checksum: 5864f1fa8cda0d44fd31136deb98911258e590a6
+  // Checksum: b38dc90a88100115387107be01ce55256c0e77f7
 
   /// Deprecation for passing a string directly to meta.call().
   callString('call-string',
@@ -96,6 +96,7 @@ enum Deprecation {
   /// Deprecation for using the current working directory as an implicit load path.
   fsImporterCwd('fs-importer-cwd',
       deprecatedIn: '1.73.0',
+      obsoleteIn: '2.0.0',
       description:
           'Using the current working directory as an implicit load path.'),
 

--- a/lib/src/importer/filesystem.dart
+++ b/lib/src/importer/filesystem.dart
@@ -4,8 +4,6 @@
 
 import 'package:path/path.dart' as p;
 
-import '../deprecation.dart';
-import '../evaluation_context.dart';
 import '../importer.dart';
 import '../io.dart' as io;
 import '../syntax.dart';
@@ -27,47 +25,24 @@ final class FilesystemImporter extends Importer {
   /// and URLs relative to the current file.
   final String? _loadPath;
 
-  /// Whether loading from files from this importer's [_loadPath] is deprecated.
-  final bool _loadPathDeprecated;
-
   /// Creates an importer that loads files relative to [loadPath].
-  FilesystemImporter(String loadPath)
-      : _loadPath = p.absolute(loadPath),
-        _loadPathDeprecated = false;
+  FilesystemImporter(String loadPath) : _loadPath = p.absolute(loadPath);
 
   /// Creates an importer that _only_ loads absolute `file:` URLs and URLs
   /// relative to the current file.
-  FilesystemImporter._noLoadPath()
-      : _loadPath = null,
-        _loadPathDeprecated = false;
+  FilesystemImporter._noLoadPath() : _loadPath = null;
 
   /// An importer that _only_ loads absolute `file:` URLs and URLs relative to
   /// the current file.
   static final noLoadPath = FilesystemImporter._noLoadPath();
 
-  Uri? canonicalize(Uri url) {
-    String? resolved;
-    if (url.scheme == 'file') {
-      resolved = resolveImportPath(p.fromUri(url));
-    } else if (url.scheme != '') {
-      return null;
-    } else if (_loadPath case var loadPath?) {
-      resolved = resolveImportPath(p.join(loadPath, p.fromUri(url)));
-
-      if (resolved != null && _loadPathDeprecated) {
-        warnForDeprecation(
-          "Using the current working directory as an implicit load path is "
-          "deprecated. Either add it as an explicit load path or importer, or "
-          "load this stylesheet from a different URL.",
-          Deprecation.fsImporterCwd,
-        );
+  Uri? canonicalize(Uri url) => switch ((url, _loadPath)) {
+        (Uri(scheme: 'file'), _) => resolveImportPath(p.fromUri(url)),
+        (Uri(scheme: ''), var loadPath?) =>
+          resolveImportPath(p.join(loadPath, p.fromUri(url))),
+        _ => null,
       }
-    } else {
-      return null;
-    }
-
-    return resolved.andThen((resolved) => p.toUri(io.canonicalize(resolved)));
-  }
+          .andThen((resolved) => p.toUri(io.canonicalize(resolved)));
 
   ImporterResult? load(Uri url) {
     var path = p.fromUri(url);


### PR DESCRIPTION
PR #2726 already made this unused, but it wasn't yet officially marked as obsolete.

See https://github.com/sass/sass/pull/4229