### PR TITLE
Fix `--watch` not recompiling files modified via atomic save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.101.1-dev
+## 1.101.1
 
 * Sass stack trace entries are now always either absolute URLs, absolute paths,
   or paths relative to the current working directory. Previously, if a
@@ -6,6 +6,10 @@
   relative URL was listed even if it couldn't be resolved relative to the
   current working directory. However, this created potential ambiguities, so
   this behavior has been removed.
+
+### Command Line Interface
+
+* `--watch` mode now handles atomically-written files more gracefully.
 
 ## 1.101.0
 

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -105,7 +105,6 @@ final class _Watcher {
         }
 
         switch (event.type) {
-          // A file may be updated via ADD, when using an atomic-write approach (temp file + rename)
           case ChangeType.MODIFY || ChangeType.ADD:
             _handleModifyOrAdd(event.path);
 
@@ -126,7 +125,12 @@ final class _Watcher {
     }
   }
 
-  /// Handles a modify/add event for the stylesheet at [path].
+  /// Handles a modifyor add event for the stylesheet at [path].
+  ///
+  /// @parcel/watcher reports atomic modifications (where a tool writes a temp
+  /// file then renames it over the existing file) as adds rather than
+  /// modifications, so we treat both event types as identical and disambiguate
+  /// based on our model of the filesystem rather than the reported event.
   ///
   /// Returns whether all necessary recompilations succeeded.
   void _handleModifyOrAdd(String path) {
@@ -139,22 +143,15 @@ final class _Watcher {
       _graph.reload(url);
       _recompileDownstream([node]);
     } else {
-      _handleAdd(path);
+      var destination = _destinationFor(path);
+      if (destination != null) _toRecompile[path] = destination;
+      var downstream = _graph.addCanonical(
+        FilesystemImporter.cwd,
+        _canonicalize(path),
+        p.toUri(path),
+      );
+      _recompileDownstream(downstream);
     }
-  }
-
-  /// Adds a newly seen stylesheet at [url].
-  ///
-  /// Returns whether all necessary recompilations succeeded.
-  void _handleAdd(String path) {
-    var destination = _destinationFor(path);
-    if (destination != null) _toRecompile[path] = destination;
-    var downstream = _graph.addCanonical(
-      FilesystemImporter.cwd,
-      _canonicalize(path),
-      p.toUri(path),
-    );
-    _recompileDownstream(downstream);
   }
 
   /// Handles a remove event for the stylesheet at [url].

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -125,7 +125,7 @@ final class _Watcher {
     }
   }
 
-  /// Handles a modifyor add event for the stylesheet at [path].
+  /// Handles a modify or add event for the stylesheet at [path].
   ///
   /// @parcel/watcher reports atomic modifications (where a tool writes a temp
   /// file then renames it over the existing file) as adds rather than

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -105,11 +105,9 @@ final class _Watcher {
         }
 
         switch (event.type) {
-          case ChangeType.MODIFY:
-            _handleModify(event.path);
-
-          case ChangeType.ADD:
-            _handleAdd(event.path);
+          // A file may be updated via ADD, when using an atomic-write approach (temp file + rename)
+          case ChangeType.MODIFY || ChangeType.ADD:
+            _handleModifyOrAdd(event.path);
 
           case ChangeType.REMOVE:
             _handleRemove(event.path);
@@ -128,10 +126,10 @@ final class _Watcher {
     }
   }
 
-  /// Handles a modify event for the stylesheet at [path].
+  /// Handles a modify/add event for the stylesheet at [path].
   ///
   /// Returns whether all necessary recompilations succeeded.
-  void _handleModify(String path) {
+  void _handleModifyOrAdd(String path) {
     var url = _canonicalize(path);
 
     // It's important to access the node ahead-of-time because it's possible
@@ -145,7 +143,7 @@ final class _Watcher {
     }
   }
 
-  /// Handles an add event for the stylesheet at [url].
+  /// Adds a newly seen stylesheet at [url].
   ///
   /// Returns whether all necessary recompilations succeeded.
   void _handleAdd(String path) {

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.47-dev
+## 0.4.47
 
 * No user-visible changes.
 

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.47-dev",
+  "version": "0.4.47",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/dart-sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 17.7.1-dev
+## 17.7.1
 
 * No user-visible changes.
 

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 17.7.1-dev
+version: 17.7.1
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.101.1-dev
+version: 1.101.1
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/test/cli/shared/watch.dart
+++ b/test/cli/shared/watch.dart
@@ -2,7 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'dart:io' as io;
+import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:sass/src/io.dart';
 import 'package:test/test.dart';
@@ -1187,10 +1187,13 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
   }
 }
 
-/// Writes [contents] to [path] using atomic operation (temp file + rename)
+/// Writes [contents] to [path] atomically.
+///
+/// This matches the "atomic write" pattern used by various tools in which a
+/// temp file is written first then moved to the desired path.
 void _writeAtomic(String path, String contents) {
   var destination = p.join(d.sandbox, path);
-  io.File('$destination.tmp')
+  File('$destination.tmp')
     ..writeAsStringSync(contents)
     ..renameSync(destination);
 }

--- a/test/cli/shared/watch.dart
+++ b/test/cli/shared/watch.dart
@@ -2,6 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import 'dart:io' as io;
 import 'package:path/path.dart' as p;
 import 'package:sass/src/io.dart';
 import 'package:test/test.dart';
@@ -179,6 +180,31 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
               .validate();
         });
 
+        test("when it's modified atomically", () async {
+          await d.file("out.css", "x {y: z}").create();
+          await tick;
+          await d.file("test.scss", "a {b: c}").create();
+
+          var sass = await watch(["test.scss:out.css"]);
+          await expectLater(
+            sass.stdout,
+            emits(endsWith('Compiled test.scss to out.css.')),
+          );
+          await expectLater(sass.stdout, _watchingForChanges);
+          await tickIfPoll();
+
+          _writeAtomic("test.scss", "r {o: g}");
+          await expectLater(
+            sass.stdout,
+            emits(endsWith('Compiled test.scss to out.css.')),
+          );
+          await sass.kill();
+
+          await d
+              .file("out.css", equalsIgnoringWhitespace("r { o: g; }"))
+              .validate();
+        });
+
         test("when it's modified when watched from a directory", () async {
           await d.dir("dir", [d.file("test.scss", "a {b: c}")]).create();
 
@@ -282,6 +308,30 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
             await tickIfPoll();
 
             await d.file("_other.scss", "x {y: z}").create();
+            await expectLater(
+              sass.stdout,
+              emits(endsWith('Compiled test.scss to out.css.')),
+            );
+            await sass.kill();
+
+            await d
+                .file("out.css", equalsIgnoringWhitespace("x { y: z; }"))
+                .validate();
+          });
+
+          test("through @use atomically", () async {
+            await d.file("_other.scss", "a {b: c}").create();
+            await d.file("test.scss", "@use 'other'").create();
+
+            var sass = await watch(["test.scss:out.css"]);
+            await expectLater(
+              sass.stdout,
+              emits(endsWith('Compiled test.scss to out.css.')),
+            );
+            await expectLater(sass.stdout, _watchingForChanges);
+            await tickIfPoll();
+
+            _writeAtomic("_other.scss", "x {y: z}");
             await expectLater(
               sass.stdout,
               emits(endsWith('Compiled test.scss to out.css.')),
@@ -1135,6 +1185,14 @@ void sharedTests(Future<TestProcess> runSass(Iterable<String> arguments)) {
       });
     });
   }
+}
+
+/// Writes [contents] to [path] using atomic operation (temp file + rename)
+void _writeAtomic(String path, String contents) {
+  var destination = p.join(d.sandbox, path);
+  io.File('$destination.tmp')
+    ..writeAsStringSync(contents)
+    ..renameSync(destination);
 }
 
 /// Returns the message that Sass prints indicating that [from] was compiled to


### PR DESCRIPTION
When a watched stylesheet is edited via an atomic save (writing to a temporary file and then renaming it over the original, often called a "safe write"), `sass --watch` does not recompile it. `sed -i` does this, for example. This shows up with the npm/JavaScript sass package when watching without `--poll`, which uses `@parcel/watcher`.

I was able to consistently reproduce the bug both on my macOS machine as well as via a Docker Linux container.

I looked around as best as I could at Issues and Pull Requests and wasn't able to find this exact problem mentioned, however I feel like I was able to gain a sense of a rough timeline:

* The `add` vs `modify` file event handling was added to `--watch` in `v1.6.0` back in 2018, but the bug was latent because `chokidar` reported atomic saves of existing files as a coalesced change/modify event, so the `add` branch was not taken.
* Then `@parcel/watcher` was swapped in `v1.79.5` in October 2024. Unlike `chokidar`, it does not coalesce the rename into a modify; it reports a `create`. This is documented in parcel-bundler/watcher#98, which includes raw event logs comparing the two.
* PR #2444 reworked `--watch` and added mtime safety nets (`reloadAllModified()`) for some cases, but it preserves the `add` vs `modify` file event handling and does not cover parcel's `add`-for-existing-files event.

The existing `_handleModify` already had a branch to handle new files and calls `_handleAdd`, so I believe the minimal change to address this issue is to hand both `MODIFY` and `ADD` filesystem events to `_handleModify` (renamed to `_handleModifyOrAdd`) so it handles it first, where it can tell whether it's an existing tracked file or a newly discovered file.

I added regression tests for both an entrypoint and a dependency modified via an atomic save. On the Node (`@parcel/watcher`) backend where the bug manifests they fail without this change and pass with it.

A note on the rename: previously `_handleAdd` was called in two places: (1) directly in the filesystem event handling, and (2) in an `else` branch of the `MODIFY` event handling. After this change it's only called from `_handleModifyOrAdd`, so there is some argument that `_handleAdd` should be deleted and inlined into the `else` branch. I opted not to do that in this PR, to convey how small this change is.