### PR TITLE
Expand dependency constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   meta: ^1.3.0
   native_synchronization: ^0.3.0
   node_interop: ^2.2.0
-  package_config: ^2.0.0
+  package_config: ">=2.0.0 <4.0.0"
   path: ^1.8.0
   pool: ^1.5.1
   protobuf: ">=4.0.0 <7.0.0"
@@ -38,11 +38,11 @@ dependencies:
   watcher: ^1.0.0
 
 dev_dependencies:
-  analyzer: ">=10.0.1 <14.0.0"
+  analyzer: ">=10.0.1 <15.0.0"
   archive: ">=3.1.2 <5.0.0"
   crypto: ^3.0.0
   dartdoc: ">=8.0.14 <10.0.0"
-  grinder: ^0.9.0
+  grinder: ">=0.9.0 <0.11.0"
   node_preamble: ^2.0.2
   lints: ">=4.0.0 <7.0.0"
   protoc_plugin: ">=22.0.1 <26.0.0"
@@ -52,4 +52,4 @@ dev_dependencies:
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
   yaml: ^3.1.0
-  cli_util: ^0.4.0
+  cli_util: ">=0.4.0 <0.6.0"


### PR DESCRIPTION
We can't simultaneously resolve all of these to the latest versions because upstream packages haven't been fully expanded, but each of the latest versions seems to work individually.