### PR TITLE
Support analogous sets of missing channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.102.0
+
+* **Potentially breaking compatibility fix:** Colors now preserve "analogous
+  sets" of missing channels during conversions, per the CSS spec. For example,
+  `color.to-space(lch(50% none none), lab)` now returns `lab(50% none none)`
+  instead of `lab(50% 0 0)`.
+
 ## 1.101.4
 
 * Avoid emitting `rgb()` or `rgba()` functions with non-percent decimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.103.0
+
+* **Potentially breaking compatibility fix:** Colors now preserve "analogous
+  sets" of missing channels during conversions, per the CSS spec. For example,
+  `color.to-space(lch(50% none none), lab)` now returns `lab(50% none none)`
+  instead of `lab(50% 0 0)`.
+
 ## 1.102.0
 
 * Use the 2.4 gamma transfer function for rec2020, as specified by the latest

--- a/lib/src/value/color.dart
+++ b/lib/src/value/color.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
 
@@ -1000,21 +999,12 @@ class SassColor extends Value {
       throw RangeError.range(weight, 0, 1, 'weight');
     }
 
-    // If either color is missing a channel _and_ that channel is analogous with
-    // one in the output space, then the output channel should take on the other
-    // color's value.
-    var missing1_0 = _isAnalogousChannelMissing(this, color1, 0);
-    var missing1_1 = _isAnalogousChannelMissing(this, color1, 1);
-    var missing1_2 = _isAnalogousChannelMissing(this, color1, 2);
-    var missing2_0 = _isAnalogousChannelMissing(other, color2, 0);
-    var missing2_1 = _isAnalogousChannelMissing(other, color2, 1);
-    var missing2_2 = _isAnalogousChannelMissing(other, color2, 2);
-    var channel1_0 = (missing1_0 ? color2 : color1).channel0;
-    var channel1_1 = (missing1_1 ? color2 : color1).channel1;
-    var channel1_2 = (missing1_2 ? color2 : color1).channel2;
-    var channel2_0 = (missing2_0 ? color1 : color2).channel0;
-    var channel2_1 = (missing2_1 ? color1 : color2).channel1;
-    var channel2_2 = (missing2_2 ? color1 : color2).channel2;
+    var channel1_0 = color1.channel0OrNull ?? color2.channel0OrNull;
+    var channel1_1 = color1.channel1OrNull ?? color2.channel1OrNull;
+    var channel1_2 = color1.channel2OrNull ?? color2.channel2OrNull;
+    var channel2_0 = color2.channel0OrNull ?? color1.channel0OrNull;
+    var channel2_1 = color2.channel1OrNull ?? color1.channel1OrNull;
+    var channel2_2 = color2.channel2OrNull ?? color1.channel2OrNull;
     var alpha1 = alphaOrNull ?? other.alpha;
     var alpha2 = other.alphaOrNull ?? alpha;
 
@@ -1023,25 +1013,25 @@ class SassColor extends Value {
     var mixedAlpha = isAlphaMissing && other.isAlphaMissing
         ? null
         : alpha1 * weight + alpha2 * (1 - weight);
-    var mixed0 = missing1_0 && missing2_0
+    var mixed0 = channel1_0 == null
         ? null
-        : (channel1_0 * thisMultiplier + channel2_0 * otherMultiplier) /
+        : (channel1_0 * thisMultiplier + channel2_0! * otherMultiplier) /
             (mixedAlpha ?? 1);
-    var mixed1 = missing1_1 && missing2_1
+    var mixed1 = channel1_1 == null
         ? null
-        : (channel1_1 * thisMultiplier + channel2_1 * otherMultiplier) /
+        : (channel1_1 * thisMultiplier + channel2_1! * otherMultiplier) /
             (mixedAlpha ?? 1);
-    var mixed2 = missing1_2 && missing2_2
+    var mixed2 = channel1_2 == null
         ? null
-        : (channel1_2 * thisMultiplier + channel2_2 * otherMultiplier) /
+        : (channel1_2 * thisMultiplier + channel2_2! * otherMultiplier) /
             (mixedAlpha ?? 1);
 
     return switch (method.space) {
       ColorSpace.hsl || ColorSpace.hwb => SassColor.forSpaceInternal(
           method.space,
-          missing1_0 && missing2_0
+          channel1_0 == null
               ? null
-              : _interpolateHues(channel1_0, channel2_0, method.hue!, weight),
+              : _interpolateHues(channel1_0, channel2_0!, method.hue!, weight),
           mixed1,
           mixed2,
           mixedAlpha,
@@ -1050,9 +1040,9 @@ class SassColor extends Value {
           method.space,
           mixed0,
           mixed1,
-          missing1_2 && missing2_2
+          channel1_2 == null
               ? null
-              : _interpolateHues(channel1_2, channel2_2, method.hue!, weight),
+              : _interpolateHues(channel1_2, channel2_2!, method.hue!, weight),
           mixedAlpha,
         ),
       _ => SassColor.forSpaceInternal(
@@ -1064,29 +1054,6 @@ class SassColor extends Value {
         ),
     }
         .toSpace(space, legacyMissing: legacyMissing);
-  }
-
-  /// Returns whether [output], which was converted to its color space from
-  /// [original], should be considered to have a missing channel at
-  /// [outputChannelIndex].
-  ///
-  /// This includes channels that are analogous to missing channels in
-  /// [original].
-  bool _isAnalogousChannelMissing(
-    SassColor original,
-    SassColor output,
-    int outputChannelIndex,
-  ) {
-    if (output.channelsOrNull[outputChannelIndex] == null) return true;
-    if (identical(original, output)) return false;
-
-    var outputChannel = output.space.channels[outputChannelIndex];
-    var originalChannel = original.space.channels.firstWhereOrNull(
-      outputChannel.isAnalogous,
-    );
-    if (originalChannel == null) return false;
-
-    return original.isChannelMissing(originalChannel.name);
   }
 
   /// Returns a hue partway between [hue1] and [hue2] according to [method].

--- a/lib/src/value/color.dart
+++ b/lib/src/value/color.dart
@@ -2,7 +2,6 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
 
@@ -944,21 +943,12 @@ class SassColor._forSpace(
       throw RangeError.range(weight, 0, 1, 'weight');
     }
 
-    // If either color is missing a channel _and_ that channel is analogous with
-    // one in the output space, then the output channel should take on the other
-    // color's value.
-    var missing1_0 = _isAnalogousChannelMissing(this, color1, 0);
-    var missing1_1 = _isAnalogousChannelMissing(this, color1, 1);
-    var missing1_2 = _isAnalogousChannelMissing(this, color1, 2);
-    var missing2_0 = _isAnalogousChannelMissing(other, color2, 0);
-    var missing2_1 = _isAnalogousChannelMissing(other, color2, 1);
-    var missing2_2 = _isAnalogousChannelMissing(other, color2, 2);
-    var channel1_0 = (missing1_0 ? color2 : color1).channel0;
-    var channel1_1 = (missing1_1 ? color2 : color1).channel1;
-    var channel1_2 = (missing1_2 ? color2 : color1).channel2;
-    var channel2_0 = (missing2_0 ? color1 : color2).channel0;
-    var channel2_1 = (missing2_1 ? color1 : color2).channel1;
-    var channel2_2 = (missing2_2 ? color1 : color2).channel2;
+    var channel1_0 = color1.channel0OrNull ?? color2.channel0OrNull;
+    var channel1_1 = color1.channel1OrNull ?? color2.channel1OrNull;
+    var channel1_2 = color1.channel2OrNull ?? color2.channel2OrNull;
+    var channel2_0 = color2.channel0OrNull ?? color1.channel0OrNull;
+    var channel2_1 = color2.channel1OrNull ?? color1.channel1OrNull;
+    var channel2_2 = color2.channel2OrNull ?? color1.channel2OrNull;
     var alpha1 = alphaOrNull ?? other.alpha;
     var alpha2 = other.alphaOrNull ?? alpha;
 
@@ -967,25 +957,25 @@ class SassColor._forSpace(
     var mixedAlpha = isAlphaMissing && other.isAlphaMissing
         ? null
         : alpha1 * weight + alpha2 * (1 - weight);
-    var mixed0 = missing1_0 && missing2_0
+    var mixed0 = channel1_0 == null
         ? null
-        : (channel1_0 * thisMultiplier + channel2_0 * otherMultiplier) /
+        : (channel1_0 * thisMultiplier + channel2_0! * otherMultiplier) /
               (mixedAlpha ?? 1);
-    var mixed1 = missing1_1 && missing2_1
+    var mixed1 = channel1_1 == null
         ? null
-        : (channel1_1 * thisMultiplier + channel2_1 * otherMultiplier) /
+        : (channel1_1 * thisMultiplier + channel2_1! * otherMultiplier) /
               (mixedAlpha ?? 1);
-    var mixed2 = missing1_2 && missing2_2
+    var mixed2 = channel1_2 == null
         ? null
-        : (channel1_2 * thisMultiplier + channel2_2 * otherMultiplier) /
+        : (channel1_2 * thisMultiplier + channel2_2! * otherMultiplier) /
               (mixedAlpha ?? 1);
 
     return switch (method.space) {
       ColorSpace.hsl || ColorSpace.hwb => SassColor.forSpaceInternal(
         method.space,
-        missing1_0 && missing2_0
+        channel1_0 == null
             ? null
-            : _interpolateHues(channel1_0, channel2_0, method.hue!, weight),
+            : _interpolateHues(channel1_0, channel2_0!, method.hue!, weight),
         mixed1,
         mixed2,
         mixedAlpha,
@@ -994,9 +984,9 @@ class SassColor._forSpace(
         method.space,
         mixed0,
         mixed1,
-        missing1_2 && missing2_2
+        channel1_2 == null
             ? null
-            : _interpolateHues(channel1_2, channel2_2, method.hue!, weight),
+            : _interpolateHues(channel1_2, channel2_2!, method.hue!, weight),
         mixedAlpha,
       ),
       _ => SassColor.forSpaceInternal(
@@ -1007,29 +997,6 @@ class SassColor._forSpace(
         mixedAlpha,
       ),
     }.toSpace(space, legacyMissing: legacyMissing);
-  }
-
-  /// Returns whether [output], which was converted to its color space from
-  /// [original], should be considered to have a missing channel at
-  /// [outputChannelIndex].
-  ///
-  /// This includes channels that are analogous to missing channels in
-  /// [original].
-  bool _isAnalogousChannelMissing(
-    SassColor original,
-    SassColor output,
-    int outputChannelIndex,
-  ) {
-    if (output.channelsOrNull[outputChannelIndex] == null) return true;
-    if (identical(original, output)) return false;
-
-    var outputChannel = output.space.channels[outputChannelIndex];
-    var originalChannel = original.space.channels.firstWhereOrNull(
-      outputChannel.isAnalogous,
-    );
-    if (originalChannel == null) return false;
-
-    return original.isChannelMissing(originalChannel.name);
   }
 
   /// Returns a hue partway between [hue1] and [hue2] according to [method].

--- a/lib/src/value/color/space.dart
+++ b/lib/src/value/color/space.dart
@@ -211,6 +211,26 @@ abstract base class ColorSpace {
     bool missingA = false,
     bool missingB = false,
   }) {
+    // Normalize analogous sets of channels so that the destination color for
+    // any space has its analogous channels set to missing when the source
+    // color's channels are missing. See
+    // https://github.com/w3c/csswg-drafts/issues/10210#issuecomment-4290447477
+    // for some discussion of whether it's appropriate to handle analogous
+    // components as part of color conversion in general rather than just for
+    // interpolation.
+    if (missingA && missingB) {
+      missingChroma = true;
+      missingHue = true;
+    } else if (missingChroma && missingHue) {
+      missingA = true;
+      missingB = true;
+    }
+
+    if ((missingLightness && missingChroma && missingHue) ||
+        (red == null && green == null && blue == null)) {
+      return SassColor.forSpaceInternal(dest, null, null, null, alpha);
+    }
+
     var linearDest = switch (dest) {
       ColorSpace.hsl || ColorSpace.hwb => const SrgbColorSpace(),
       ColorSpace.lab || ColorSpace.lch => const XyzD50ColorSpace(),

--- a/lib/src/value/color/space.dart
+++ b/lib/src/value/color/space.dart
@@ -209,6 +209,26 @@ abstract base class const ColorSpace(
     bool missingA = false,
     bool missingB = false,
   }) {
+    // Normalize analogous sets of channels so that the destination color for
+    // any space has its analogous channels set to missing when the source
+    // color's channels are missing. See
+    // https://github.com/w3c/csswg-drafts/issues/10210#issuecomment-4290447477
+    // for some discussion of whether it's appropriate to handle analogous
+    // components as part of color conversion in general rather than just for
+    // interpolation.
+    if (missingA && missingB) {
+      missingChroma = true;
+      missingHue = true;
+    } else if (missingChroma && missingHue) {
+      missingA = true;
+      missingB = true;
+    }
+
+    if ((missingLightness && missingChroma && missingHue) ||
+        (red == null && green == null && blue == null)) {
+      return SassColor.forSpaceInternal(dest, null, null, null, alpha);
+    }
+
     var linearDest = switch (dest) {
       ColorSpace.hsl || ColorSpace.hwb => const SrgbColorSpace(),
       ColorSpace.lab || ColorSpace.lch => const XyzD50ColorSpace(),

--- a/lib/src/value/color/space/hwb.dart
+++ b/lib/src/value/color/space/hwb.dart
@@ -39,6 +39,24 @@ final class HwbColorSpace extends ColorSpace {
     double? blackness,
     double? alpha,
   ) {
+    if (whiteness == null && blackness == null) {
+      if (hue == null) {
+        return SassColor.forSpaceInternal(dest, null, null, null, alpha);
+      }
+
+      // Handle this manually to avoid having to pipe `missingWhiteness` and
+      // `missingBlackness` everywhere even though they're not analogous to any
+      // channels.
+      var converted = convert(dest, hue, 0, 0, alpha);
+      return switch (dest) {
+        ColorSpace.hsl => SassColor.forSpaceInternal(
+            dest, converted.channel0, null, null, converted.alpha),
+        ColorSpace.lch || ColorSpace.oklch => SassColor.forSpaceInternal(
+            dest, null, null, converted.channel2, converted.alpha),
+        _ => converted
+      };
+    }
+
     // From https://www.w3.org/TR/css-color-4/#hwb-to-rgb
     var scaledHue = (hue ?? 0) % 360 / 360;
     var scaledWhiteness = (whiteness ?? 0) / 100;

--- a/lib/src/value/color/space/hwb.dart
+++ b/lib/src/value/color/space/hwb.dart
@@ -39,6 +39,34 @@ final class const HwbColorSpace() extends ColorSpace {
     double? blackness,
     double? alpha,
   ) {
+    if (whiteness == null && blackness == null) {
+      if (hue == null) {
+        return SassColor.forSpaceInternal(dest, null, null, null, alpha);
+      }
+
+      // Handle this manually to avoid having to pipe `missingWhiteness` and
+      // `missingBlackness` everywhere even though they're not analogous to any
+      // channels.
+      var converted = convert(dest, hue, 0, 0, alpha);
+      return switch (dest) {
+        ColorSpace.hsl => SassColor.forSpaceInternal(
+          dest,
+          converted.channel0,
+          null,
+          null,
+          converted.alpha,
+        ),
+        ColorSpace.lch || ColorSpace.oklch => SassColor.forSpaceInternal(
+          dest,
+          null,
+          null,
+          converted.channel2,
+          converted.alpha,
+        ),
+        _ => converted,
+      };
+    }
+
     // From https://www.w3.org/TR/css-color-4/#hwb-to-rgb
     var scaledHue = (hue ?? 0) % 360 / 360;
     var scaledWhiteness = (whiteness ?? 0) / 100;

--- a/lib/src/value/color/space/lab.dart
+++ b/lib/src/value/color/space/lab.dart
@@ -47,6 +47,14 @@ final class LabColorSpace extends ColorSpace {
     bool missingChroma = false,
     bool missingHue = false,
   }) {
+    if (missingChroma && missingHue) {
+      a = null;
+      b = null;
+    } else if (a == null && b == null) {
+      missingChroma = true;
+      missingHue = true;
+    }
+
     switch (dest) {
       case ColorSpace.lab:
         var powerlessAB = lightness == null || fuzzyEquals(lightness, 0);

--- a/lib/src/value/color/space/lab.dart
+++ b/lib/src/value/color/space/lab.dart
@@ -47,6 +47,14 @@ final class const LabColorSpace() extends ColorSpace {
     bool missingChroma = false,
     bool missingHue = false,
   }) {
+    if (missingChroma && missingHue) {
+      a = null;
+      b = null;
+    } else if (a == null && b == null) {
+      missingChroma = true;
+      missingHue = true;
+    }
+
     switch (dest) {
       case ColorSpace.lab:
         var powerlessAB = lightness == null || fuzzyEquals(lightness, 0);

--- a/lib/src/value/color/space/lms.dart
+++ b/lib/src/value/color/space/lms.dart
@@ -45,6 +45,19 @@ final class LmsColorSpace extends ColorSpace {
     bool missingA = false,
     bool missingB = false,
   }) {
+    if (missingA && missingB) {
+      missingChroma = true;
+      missingHue = true;
+    } else if (missingChroma && missingHue) {
+      missingA = true;
+      missingB = true;
+    }
+
+    if ((missingLightness && missingChroma && missingHue) ||
+        (long == null && medium == null && short == null)) {
+      return SassColor.forSpaceInternal(dest, null, null, null, alpha);
+    }
+
     switch (dest) {
       case ColorSpace.oklab:
         // Algorithm from https://drafts.csswg.org/css-color-4/#color-conversion-code

--- a/lib/src/value/color/space/lms.dart
+++ b/lib/src/value/color/space/lms.dart
@@ -45,6 +45,19 @@ final class const LmsColorSpace() extends ColorSpace {
     bool missingA = false,
     bool missingB = false,
   }) {
+    if (missingA && missingB) {
+      missingChroma = true;
+      missingHue = true;
+    } else if (missingChroma && missingHue) {
+      missingA = true;
+      missingB = true;
+    }
+
+    if ((missingLightness && missingChroma && missingHue) ||
+        (long == null && medium == null && short == null)) {
+      return SassColor.forSpaceInternal(dest, null, null, null, alpha);
+    }
+
     switch (dest) {
       case ColorSpace.oklab:
         // Algorithm from https://drafts.csswg.org/css-color-4/#color-conversion-code

--- a/lib/src/value/color/space/oklab.dart
+++ b/lib/src/value/color/space/oklab.dart
@@ -59,6 +59,14 @@ final class OklabColorSpace extends ColorSpace {
       );
     }
 
+    if (a == null && b == null) {
+      missingChroma = true;
+      missingHue = true;
+    } else if (missingChroma && missingHue) {
+      a = null;
+      b = null;
+    }
+
     var missingLightness = lightness == null;
     var missingA = a == null;
     var missingB = b == null;

--- a/lib/src/value/color/space/oklab.dart
+++ b/lib/src/value/color/space/oklab.dart
@@ -59,6 +59,14 @@ final class const OklabColorSpace() extends ColorSpace {
       );
     }
 
+    if (a == null && b == null) {
+      missingChroma = true;
+      missingHue = true;
+    } else if (missingChroma && missingHue) {
+      a = null;
+      b = null;
+    }
+
     var missingLightness = lightness == null;
     var missingA = a == null;
     var missingB = b == null;

--- a/lib/src/value/color/space/srgb.dart
+++ b/lib/src/value/color/space/srgb.dart
@@ -39,6 +39,11 @@ final class SrgbColorSpace extends ColorSpace {
     bool missingChroma = false,
     bool missingHue = false,
   }) {
+    if ((red == null && green == null && blue == null) ||
+        (missingLightness && missingChroma && missingHue)) {
+      return SassColor.forSpaceInternal(dest, null, null, null, alpha);
+    }
+
     switch (dest) {
       case ColorSpace.hsl || ColorSpace.hwb:
         red ??= 0;

--- a/lib/src/value/color/space/srgb.dart
+++ b/lib/src/value/color/space/srgb.dart
@@ -39,6 +39,11 @@ final class const SrgbColorSpace() extends ColorSpace {
     bool missingChroma = false,
     bool missingHue = false,
   }) {
+    if ((red == null && green == null && blue == null) ||
+        (missingLightness && missingChroma && missingHue)) {
+      return SassColor.forSpaceInternal(dest, null, null, null, alpha);
+    }
+
     switch (dest) {
       case ColorSpace.hsl || ColorSpace.hwb:
         red ??= 0;
@@ -88,8 +93,8 @@ final class const SrgbColorSpace() extends ColorSpace {
             missingHue || fuzzyGreaterThanOrEquals(whiteness + blackness, 100)
                 ? null
                 : hue % 360,
-            whiteness,
-            blackness,
+            missingChroma && missingLightness ? null : whiteness,
+            missingChroma && missingLightness ? null : blackness,
             alpha,
           );
         }

--- a/lib/src/value/color/space/utils.dart
+++ b/lib/src/value/color/space/utils.dart
@@ -83,6 +83,9 @@ SassColor labToLch(
   bool missingChroma = false,
   bool missingHue = false,
 }) {
+  missingChroma = missingChroma || (a == null && b == null);
+  missingHue = missingHue || (a == null && b == null);
+
   // Algorithm from https://www.w3.org/TR/css-color-4/#color-conversion-code
   var chroma = math.sqrt(math.pow(a ?? 0, 2) + math.pow(b ?? 0, 2));
   var hue = missingHue || fuzzyEquals(chroma, 0)

--- a/lib/src/value/color/space/xyz_d50.dart
+++ b/lib/src/value/color/space/xyz_d50.dart
@@ -38,6 +38,19 @@ final class XyzD50ColorSpace extends ColorSpace {
     bool missingA = false,
     bool missingB = false,
   }) {
+    if (missingA && missingB) {
+      missingChroma = true;
+      missingHue = true;
+    } else if (missingChroma && missingHue) {
+      missingA = true;
+      missingB = true;
+    }
+
+    if ((missingLightness && missingChroma && missingHue) ||
+        (x == null && y == null && z == null)) {
+      return SassColor.forSpaceInternal(dest, null, null, null, alpha);
+    }
+
     switch (dest) {
       case ColorSpace.lab || ColorSpace.lch:
         // Algorithm from https://www.w3.org/TR/css-color-4/#color-conversion-code

--- a/lib/src/value/color/space/xyz_d50.dart
+++ b/lib/src/value/color/space/xyz_d50.dart
@@ -38,6 +38,19 @@ final class const XyzD50ColorSpace() extends ColorSpace {
     bool missingA = false,
     bool missingB = false,
   }) {
+    if (missingA && missingB) {
+      missingChroma = true;
+      missingHue = true;
+    } else if (missingChroma && missingHue) {
+      missingA = true;
+      missingB = true;
+    }
+
+    if ((missingLightness && missingChroma && missingHue) ||
+        (x == null && y == null && z == null)) {
+      return SassColor.forSpaceInternal(dest, null, null, null, alpha);
+    }
+
     switch (dest) {
       case ColorSpace.lab || ColorSpace.lch:
         // Algorithm from https://www.w3.org/TR/css-color-4/#color-conversion-code

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,11 +1,3 @@
-## 0.4.54
-
-* No user-visible changes.
-
-## 0.4.53
-
-* No user-visible changes.
-
 ## 0.4.52
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.54",
+  "version": "0.4.52",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/dart-sass",
   "author": "Google Inc.",
@@ -39,7 +39,6 @@
     "@eslint/js": "^9.39.2",
     "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^8.53.0",
-    "@typescript/native": "npm:typescript@^7.0.2",
     "copyfiles": "^2.4.1",
     "eslint": "^10.0.1",
     "expect": "^30.0.5",
@@ -51,7 +50,7 @@
     "ts-jest": "^29.4.11",
     "ts-node": "^10.2.1",
     "typedoc": "^0.28.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.53.0"
   }
 }

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,16 +1,8 @@
+## 17.9.0
+
+* No user-visible changes.
+
 ## 17.8.0
-
-* No user-visible changes.
-
-## 17.7.7
-
-* No user-visible changes.
-
-## 17.7.6
-
-* No user-visible changes.
-
-## 17.7.5
 
 * No user-visible changes.
 

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 17.8.0
+version: 17.9.0
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.13.0 <4.0.0"
 
 dependencies:
-  sass: 1.102.0
+  sass: 1.103.0
 
 dev_dependencies:
   dartdoc: ">=8.0.14 <10.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.102.0
+version: 1.103.0
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
This brings us back in line with the CSS spec, with the caveat that while spec authors have informally expressed the intention for analogous components to be applied widely, the spec text doesn't consistently indicate that they should be used for general color conversions.

See https://github.com/sass/sass-spec/pull/2159