### PR TITLE
Don't add quotes to the sass-parser version number during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Get Sass parser version
         id: sass-parser-version
         run: |
-          echo "version=$(jq .version pkg/sass-parser/package.json)" | tee --append "$GITHUB_OUTPUT"
+          echo "version=$(jq -r .version pkg/sass-parser/package.json)" | tee --append "$GITHUB_OUTPUT"
       - run: git tag "sass-parser/$VERSION"
         env:
           VERSION: ${{ steps.sass-parser-version.outputs.version }}


### PR DESCRIPTION
This was causing these versions to be tagged as `sass-parser/"x.y.z"` rather than `sass-parser/x.y.z`.