### PR TITLE
Bump PostCSS in sass-parser

### DIFF
--- a/pkg/sass-parser/lib/src/statement/container.test.ts
+++ b/pkg/sass-parser/lib/src/statement/container.test.ts
@@ -35,14 +35,11 @@ describe('a container node', () => {
         const rule2 = new Rule({selector: '.bar'});
         const otherRoot = new Root({nodes: [rule1, rule2]});
         root.append(otherRoot);
-        expect(root.nodes[0]).toBeInstanceOf(Rule);
-        expect(root.nodes[0]).toHaveNode('parsedSelector', '.foo');
-        expect(root.nodes[1]).toBeInstanceOf(Rule);
-        expect(root.nodes[1]).toHaveNode('parsedSelector', '.bar');
-        expect(root.nodes[0].parent).toBe(root);
-        expect(root.nodes[1].parent).toBe(root);
-        expect(rule1.parent).toBeUndefined();
-        expect(rule2.parent).toBeUndefined();
+        expect(root.nodes[0]).toBe(rule1);
+        expect(root.nodes[1]).toBe(rule2);
+        expect(rule1.parent).toBe(root);
+        expect(rule2.parent).toBe(root);
+        expect(otherRoot.nodes).toHaveLength(0);
       });
 
       it('a PostCSS rule node', () => {

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "postcss": "8.5.15",
+    "postcss": "8.5.23",
     "sass": "file:../../build/npm"
   },
   "devDependencies": {


### PR DESCRIPTION
This changes a test to align with PostCSS's new semantics (adding one container to another moves nodes rather than copying them).

Closes #2814
Closes #2804 