### PR TITLE
Automatically merge dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,26 @@ jobs:
       actions: read # Forwarded
     uses: ./.github/workflows/test.yml
 
+  dependabot_merge:
+    name: Auto-merge Dependabot PR
+    permissions:
+      contents: write # Needed to merge PR
+      pull-requests: write # Needed to merge PR
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'sass/dart-sass'
+
+    steps:
+      - id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   double_check:
     name: Double-check
     runs-on: ubuntu-latest


### PR DESCRIPTION
This automatically merges PRs whose tests pass which don't update major dependency versions.