### PR TITLE
Use TypeScript 7 without breaking Eslint

### DIFF
--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.54
+
+* No user-visible changes.
+
 ## 0.4.53
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.53",
+  "version": "0.4.54",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/dart-sass",
   "author": "Google Inc.",
@@ -39,6 +39,7 @@
     "@eslint/js": "^9.39.2",
     "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^8.53.0",
+    "@typescript/native": "npm:typescript@^7.0.2",
     "copyfiles": "^2.4.1",
     "eslint": "^10.0.1",
     "expect": "^30.0.5",
@@ -50,7 +51,7 @@
     "ts-jest": "^29.4.11",
     "ts-node": "^10.2.1",
     "typedoc": "^0.28.0",
-    "typescript": "^6.0.3",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8.53.0"
   }
 }


### PR DESCRIPTION
Closes #2842

This was originally landed in https://github.com/sass/dart-sass/pull/2803, but was accidentally reverted in #2810.