### PR TITLE
Prevent `--watch` from compiling generated CSS files to themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.104.1-dev
+
+### Command Line Interface
+
+* Many-to-many compilations no longer compile any files that appear in the
+  output directory if the output directory is also within the source directory.
+  This fixes a bug where `--watch` mode could enter an infinite loop recompiling
+  the same CSS file over and over.
+
 ## 1.104.0
 
 * **Potentially breaking compatibility fix:** Colors now convert the special

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -464,8 +464,10 @@ final class ExecutableOptions._(
     return {
       for (var path in listDir(source, recursive: true))
         if (_isEntrypoint(path) &&
-            // Don't compile a CSS file that is already in destination.
-            !(p.extension(path) == '.css' && p.isWithin(destination, path)))
+            // Don't compile a CSS file to its own location.
+            !(source == destination && p.extension(path) == '.css') &&
+            // Ignore files already in the destination if it is inside the source.
+            !(p.isWithin(source, destination) && p.isWithin(destination, path)))
           path: p.join(
             destination,
             p.setExtension(p.relative(path, from: source), '.css'),

--- a/lib/src/executable/options.dart
+++ b/lib/src/executable/options.dart
@@ -464,8 +464,8 @@ final class ExecutableOptions._(
     return {
       for (var path in listDir(source, recursive: true))
         if (_isEntrypoint(path) &&
-            // Don't compile a CSS file to its own location.
-            !(source == destination && p.extension(path) == '.css'))
+            // Don't compile a CSS file that is already in destination.
+            !(p.extension(path) == '.css' && p.isWithin(destination, path)))
           path: p.join(
             destination,
             p.setExtension(p.relative(path, from: source), '.css'),

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -250,8 +250,14 @@ final class _Watcher(
         p.setExtension(p.relative(source, from: sourceDir), '.css'),
       );
 
-      // Don't compile ".css" files to their own locations.
-      if (!p.equals(destination, source)) return destination;
+      // Don't compile ".css" files to their own relative locations.
+      // Prevents ./x.scss -> ./out/x.css -> ./out/out/x.css -> ...
+      if (!p.equals(
+        p.relative(destination, from: destinationDir),
+        p.relative(source, from: sourceDir),
+      )) {
+        return destination;
+      }
     }
 
     return null;

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -250,12 +250,8 @@ final class _Watcher(
         p.setExtension(p.relative(source, from: sourceDir), '.css'),
       );
 
-      // Don't compile ".css" files to their own relative locations.
-      // Prevents ./x.scss -> ./out/x.css -> ./out/out/x.css -> ...
-      if (!p.equals(
-        p.relative(destination, from: destinationDir),
-        p.relative(source, from: sourceDir),
-      )) {
+      if (!(p.extension(source) == '.css' &&
+          p.isWithin(destinationDir, source))) {
         return destination;
       }
     }

--- a/lib/src/executable/watch.dart
+++ b/lib/src/executable/watch.dart
@@ -250,8 +250,11 @@ final class _Watcher(
         p.setExtension(p.relative(source, from: sourceDir), '.css'),
       );
 
-      if (!(p.extension(source) == '.css' &&
-          p.isWithin(destinationDir, source))) {
+      // Don't compile ".css" files to their own locations.
+      if (!p.equals(destination, source) &&
+          // Ignore files already in the destination if it is inside the source.
+          !(p.isWithin(sourceDir, destinationDir) &&
+              p.isWithin(destinationDir, source))) {
         return destination;
       }
     }

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.55-dev
+
+* No user-visible changes.
+
 ## 0.4.54
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.54",
+  "version": "0.4.55-dev",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/dart-sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.10.1-dev
+
+* No user-visible changes.
+
 ## 17.10.0
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 17.10.0
+version: 17.10.1-dev
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.13.0 <4.0.0"
 
 dependencies:
-  sass: 1.104.0
+  sass: 1.104.1
 
 dev_dependencies:
   dartdoc: ">=8.0.14 <10.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.104.0
+version: 1.104.1-dev
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/test/cli/shared/colon_args.dart
+++ b/test/cli/shared/colon_args.dart
@@ -211,23 +211,22 @@ void sharedTests(
       await d.file("dir/test.css", "a {b: c}").validate();
     });
 
-    test(
-      "ignores a CSS file that is already in the output directory",
-      () async {
-        var desc = d.dir("dir", [
-          d.dir("out", [d.file("test.css", "a {b: c}")]),
-        ]);
-        await desc.create();
+    test("ignores files already in the output directory", () async {
+      await d.dir("dir", [
+        d.dir("out", [
+          d.file("test.css", "a {b: c}"),
+          d.file("test2.scss", "x {y: z}"),
+        ]),
+      ]).create();
 
-        var sass = await runSass(["dir:dir/out"]);
-        expect(sass.stdout, emitsDone);
-        await sass.shouldExit(0);
+      var sass = await runSass(["dir:dir/out"]);
+      expect(sass.stdout, emitsDone);
+      await sass.shouldExit(0);
 
-        await desc.validate();
-        await d.nothing('dir/out/out/test.css').validate();
-        await d.nothing('dir/out/out').validate();
-      },
-    );
+      await d.nothing('dir/out/out/test.css').validate();
+      await d.nothing('dir/out/out/test2.css').validate();
+      await d.nothing('dir/out/out').validate();
+    });
   });
 
   group("reports all", () {

--- a/test/cli/shared/colon_args.dart
+++ b/test/cli/shared/colon_args.dart
@@ -210,6 +210,24 @@ void sharedTests(
 
       await d.file("dir/test.css", "a {b: c}").validate();
     });
+
+    test(
+      "ignores a CSS file that is already in the output directory",
+      () async {
+        var desc = d.dir("dir", [
+          d.dir("out", [d.file("test.css", "a {b: c}")]),
+        ]);
+        await desc.create();
+
+        var sass = await runSass(["dir:dir/out"]);
+        expect(sass.stdout, emitsDone);
+        await sass.shouldExit(0);
+
+        await desc.validate();
+        await d.nothing('dir/out/out/test.css').validate();
+        await d.nothing('dir/out/out').validate();
+      },
+    );
   });
 
   group("reports all", () {

--- a/test/cli/shared/watch.dart
+++ b/test/cli/shared/watch.dart
@@ -1168,7 +1168,7 @@ void sharedTests(
       });
 
       // Regression test for #2846.
-      test("doesn't try to place an output directory inside the output directory", () async {
+      test("should ignore files in the output directory if it is inside the source directory", () async {
         await d.dir("dir", [d.dir("out")]).create();
 
         var sass = await watch(["dir:dir/out"]);
@@ -1176,20 +1176,21 @@ void sharedTests(
         await tickIfPoll();
 
         await d.file("dir/out/test.css", "a {b: c}").create();
+        await d.file("dir/out/test2.scss", "p {q: r}").create();
         await tick;
 
         // Create a new file that *will* be compiled so that if the first change
         // did incorrectly trigger a compilation, it would emit a message
         // before the message for this change.
-        await d.file("dir/test2.scss", "x {y: z}").create();
+        await d.file("dir/test3.scss", "x {y: z}").create();
         await expectLater(
           sass.stdout,
-          emits(endsWith(_compiled('dir/test2.scss', 'dir/out/test2.css'))),
+          emits(endsWith(_compiled('dir/test3.scss', 'dir/out/test3.css'))),
         );
 
         await sass.kill();
 
-        await d.file("dir/out/test.css", "a {b: c}").validate();
+        await d.nothing("dir/out/out").validate();
       });
 
       group("doesn't allow", () {

--- a/test/cli/shared/watch.dart
+++ b/test/cli/shared/watch.dart
@@ -1168,15 +1168,18 @@ void sharedTests(
       });
 
       // Regression test for #2846.
-      test("should ignore files in the output directory if it is inside the source directory", () async {
+      test("should ignore files in the output directory if it is inside the "
+          "source directory", () async {
         await d.dir("dir", [d.dir("out")]).create();
 
         var sass = await watch(["dir:dir/out"]);
         await expectLater(sass.stdout, _watchingForChanges);
         await tickIfPoll();
 
-        await d.file("dir/out/test.css", "a {b: c}").create();
-        await d.file("dir/out/test2.scss", "p {q: r}").create();
+        await d.dir("dir/out", [
+          d.file("test.css", "a {b: c}"),
+          d.file("test2.scss", "p {q: r}"),
+        ]).create();
         await tick;
 
         // Create a new file that *will* be compiled so that if the first change

--- a/test/cli/shared/watch.dart
+++ b/test/cli/shared/watch.dart
@@ -1167,6 +1167,31 @@ void sharedTests(
         await d.file("dir/test.css", "a {b: c}").validate();
       });
 
+      // Regression test for #2846.
+      test("doesn't try to place an output directory inside the output directory", () async {
+        await d.dir("dir", [d.dir("out")]).create();
+
+        var sass = await watch(["dir:dir/out"]);
+        await expectLater(sass.stdout, _watchingForChanges);
+        await tickIfPoll();
+
+        await d.file("dir/out/test.css", "a {b: c}").create();
+        await tick;
+
+        // Create a new file that *will* be compiled so that if the first change
+        // did incorrectly trigger a compilation, it would emit a message
+        // before the message for this change.
+        await d.file("dir/test2.scss", "x {y: z}").create();
+        await expectLater(
+          sass.stdout,
+          emits(endsWith(_compiled('dir/test2.scss', 'dir/out/test2.css'))),
+        );
+
+        await sass.kill();
+
+        await d.file("dir/out/test.css", "a {b: c}").validate();
+      });
+
       group("doesn't allow", () {
         test("--stdin", () async {
           var sass = await watch(["--stdin", "test.scss"]);


### PR DESCRIPTION
Fix an edge case where
```bash
touch style.scss
sass -w .:out
```
causes in an infinite loop.

* Loop occurred because Sass tries to compile `style.scss` → `out/style.css` → `out/out/style.css` → …
* The extant fix for [#853] misses this since `destination == "out/out/style.css" != "out/style.css" == source`
* Fixed by ignoring all source files that are inside the destination directory, except when the source and destination directories are the same
* Added regression tests

Closes #2846

[#853]: <https://github.com/sass/dart-sass/issues/853>