### PR TITLE
Fix `--watch` not recompiling sources modified during a compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.104.1-dev
+## 1.104.1
 
 * Fix a bug where loud comments before `@use` rules could be emitted multiple
   times under certain circumstances.
@@ -13,6 +13,11 @@
   output directory if the output directory is also within the source directory.
   This fixes a bug where `--watch` mode could enter an infinite loop recompiling
   the same CSS file over and over.
+
+* Sass now sets the modification time of output files to the time compilation
+  *started* rather than the time it *ended*. This ensures that, if a source file
+  is modified during compilation, `--watch` and `--update` mode will recompile
+  the outputs to include the new source file contents.
 
 ## 1.104.0
 

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -85,6 +85,7 @@ Future<void> _compileStylesheetWithoutErrorHandling(
   String? destination, {
   bool ifModified = false,
 }) async {
+  var compilationStarted = DateTime.now();
   var importer = FilesystemImporter.cwd;
   if (ifModified) {
     try {
@@ -192,18 +193,25 @@ Future<void> _compileStylesheetWithoutErrorHandling(
       } else {
         ensureDir(p.dirname(destination));
         writeFile(destination, "${error.toCssString()}\n");
+        _trySetModificationTime(destination, compilationStarted);
       }
     }
     rethrow;
   }
 
   var css = result.css;
-  css += _writeSourceMap(options, result.sourceMap, destination);
+  css += _writeSourceMap(
+    options,
+    result.sourceMap,
+    destination,
+    compilationStarted,
+  );
   if (destination == null) {
     if (css.isNotEmpty) print(css);
   } else {
     ensureDir(p.dirname(destination));
     writeFile(destination, "$css\n");
+    _trySetModificationTime(destination, compilationStarted);
   }
 
   if (options.quiet || (!options.update && !options.watch)) return;
@@ -238,6 +246,7 @@ String _writeSourceMap(
   ExecutableOptions options,
   SingleMapping? sourceMap,
   String? destination,
+  DateTime compilationStarted,
 ) {
   if (sourceMap == null) return "";
 
@@ -268,6 +277,7 @@ String _writeSourceMap(
     var sourceMapPath = '${destination!}.map';
     ensureDir(p.dirname(sourceMapPath));
     writeFile(sourceMapPath, sourceMapText);
+    _trySetModificationTime(sourceMapPath, compilationStarted);
 
     url = p.toUri(p.relative(sourceMapPath, from: p.dirname(destination)));
   }
@@ -286,6 +296,19 @@ void _tryDelete(String path) {
     deleteFile(path);
   } on FileSystemException {
     // If the file doesn't exist, that's fine.
+  }
+}
+
+/// Backdate [path] to [time], ignoring failures.
+///
+/// Outputs keep the time compilation started so that sources modified during
+/// compilation compare as newer. Best effort on filesystems with coarse
+/// granularity.
+void _trySetModificationTime(String path, DateTime time) {
+  try {
+    setModificationTime(path, time);
+  } on FileSystemException {
+    // The output is still usable with its actual modification time.
   }
 }
 

--- a/lib/src/executable/compile_stylesheet.dart
+++ b/lib/src/executable/compile_stylesheet.dart
@@ -301,9 +301,10 @@ void _tryDelete(String path) {
 
 /// Backdate [path] to [time], ignoring failures.
 ///
-/// Outputs keep the time compilation started so that sources modified during
-/// compilation compare as newer. Best effort on filesystems with coarse
-/// granularity.
+/// We use the time that a compilation started as the modification time for
+/// output files so that if a source file is modified during compilation, it
+/// will be considered newer than the output and compilation will run again
+/// (immediately for `--watch` or on the next invocation for `--update`).
 void _trySetModificationTime(String path, DateTime time) {
   try {
     setModificationTime(path, time);

--- a/lib/src/io/interface.dart
+++ b/lib/src/io/interface.dart
@@ -81,6 +81,9 @@ String realpath(String path) => throw '';
 /// Returns the modification time of the file at [path].
 DateTime modificationTime(String path) => throw '';
 
+/// Sets the modification time of the file at [path] to [time].
+void setModificationTime(String path, DateTime time) => throw '';
+
 /// Returns the value of the environment variable with the given [name], or
 /// `null` if it's not set.
 String? getEnvironmentVariable(String name) => throw '';

--- a/lib/src/io/js.dart
+++ b/lib/src/io/js.dart
@@ -248,6 +248,18 @@ DateTime modificationTime(String path) {
   );
 }
 
+void setModificationTime(String path, DateTime time) {
+  if (!isNodeJs) {
+    throw UnsupportedError(
+      "setModificationTime() is only supported on Node.js",
+    );
+  }
+  return _systemErrorToFileSystemException(() {
+    var seconds = time.millisecondsSinceEpoch / 1000;
+    fs.utimesSync(path, seconds, seconds);
+  });
+}
+
 String? getEnvironmentVariable(String name) {
   var env = _process?.env;
   return env == null ? null : getProperty(env as Object, name) as String?;

--- a/lib/src/io/vm.dart
+++ b/lib/src/io/vm.dart
@@ -101,6 +101,9 @@ DateTime modificationTime(String path) {
   return stat.modified;
 }
 
+void setModificationTime(String path, DateTime time) =>
+    io.File(path).setLastModifiedSync(time);
+
 String? getEnvironmentVariable(String name) => io.Platform.environment[name];
 
 Future<Stream<WatchEvent>> watchDir(String path, {bool poll = false}) async {

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.55-dev
+## 0.4.55
 
 * Omit an extra newline that was being added to the end of `Rule.selector` in
   the indented syntax.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.55-dev",
+  "version": "0.4.55",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/dart-sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 17.10.1-dev
+## 17.10.1
 
 * Omit an extra newline that was being added to the end of `StyleRule.selector`
   in the indented syntax.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 17.10.1-dev
+version: 17.10.1
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.104.1-dev
+version: 1.104.1
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 

--- a/test/cli/shared/update.dart
+++ b/test/cli/shared/update.dart
@@ -63,6 +63,52 @@ void sharedTests(
           .validate();
     });
 
+    // Regression test for #2849.
+    test("a source modified during a compilation", () async {
+      await d.file("_slow.scss", _slowSource).create();
+      await d.file("_other.scss", "a {b: c}").create();
+      await d.file("test.scss", "@use 'slow'; @use 'other'").create();
+
+      var watcher = await runSass([
+        "--no-source-map",
+        "--watch",
+        "test.scss:out.css",
+      ]);
+      await expectLater(
+        watcher.stdout,
+        emits(endsWith('Compiled test.scss to out.css.')),
+      );
+      await expectLater(
+        watcher.stdout,
+        emitsInOrder([
+          "Sass is watching for changes. Press Ctrl-C to stop.",
+          "",
+        ]),
+      );
+
+      // Modifying the slow stylesheet starts a compilation that runs for
+      // several seconds. The delay is short enough to land while that
+      // compilation is still in progress.
+      await d.file("_slow.scss", "$_slowSource\n// modified").create();
+      await Future<void>.delayed(Duration(seconds: 3));
+      await d.file("_other.scss", "x {y: z}").create();
+
+      // Stop once the compilation that missed the second modification is
+      // written, leaving the CSS on disk one generation behind.
+      await expectLater(
+        watcher.stdout,
+        emits(endsWith('Compiled test.scss to out.css.')),
+      );
+      await watcher.kill();
+
+      // A later `--update` must pick up the missed generation.
+      var sass = await update(["test.scss:out.css"]);
+      expect(sass.stdout, emits(endsWith('Compiled test.scss to out.css.')));
+      await sass.shouldExit(0);
+
+      await d.file("out.css", contains("y: z")).validate();
+    }, timeout: Timeout.factor(4));
+
     test("files that share a modified import", () async {
       await d.file("other.scss", r"a {b: $var}").create();
       await d.file("test1.scss", r"$var: 1; @import 'other'").create();
@@ -311,3 +357,15 @@ void sharedTests(
     });
   });
 }
+
+/// A stylesheet that takes multiple seconds to compile, so that another file
+/// can be modified while a compilation that includes it is in progress.
+const _slowSource = r"""
+@use "sass:math";
+@for $i from 1 through 80 {
+  .a-#{$i} { %ph-#{$i} { color: red; } }
+  @for $j from 1 through 80 {
+    .b-#{$i}-#{$j} { @extend %ph-#{$i}; width: math.div($i * 100%, $j); }
+  }
+}
+""";

--- a/test/cli/shared/update.dart
+++ b/test/cli/shared/update.dart
@@ -361,11 +361,17 @@ void sharedTests(
 /// A stylesheet that takes multiple seconds to compile, so that another file
 /// can be modified while a compilation that includes it is in progress.
 const _slowSource = r"""
-@use "sass:math";
-@for $i from 1 through 80 {
-  .a-#{$i} { %ph-#{$i} { color: red; } }
-  @for $j from 1 through 80 {
-    .b-#{$i}-#{$j} { @extend %ph-#{$i}; width: math.div($i * 100%, $j); }
+  @use "sass:math";
+  @for $i from 1 through 80 {
+    .a-#{$i} {
+      %ph-#{$i} {color: red}
+    }
+
+    @for $j from 1 through 80 {
+      .b-#{$i}-#{$j} {
+        @extend %ph-#{$i};
+        width: math.div($i * 100%, $j);
+      }
+    }
   }
-}
 """;

--- a/test/cli/shared/watch.dart
+++ b/test/cli/shared/watch.dart
@@ -208,6 +208,41 @@ void sharedTests(
               .validate();
         });
 
+        // Regression test for #2849.
+        test("when a dependency is modified during a compilation", () async {
+          await d.file("_slow.scss", _slowSource).create();
+          await d.file("_other.scss", "a {b: c}").create();
+          await d.file("test.scss", "@use 'slow'; @use 'other'").create();
+
+          var sass = await watch(["test.scss:out.css"]);
+          await expectLater(
+            sass.stdout,
+            emits(endsWith('Compiled test.scss to out.css.')),
+          );
+          await expectLater(sass.stdout, _watchingForChanges);
+          await tickIfPoll();
+
+          // Modifying the slow stylesheet starts a compilation that runs for
+          // several seconds. The delay is longer than the polling interval so
+          // that the modification below is seen as a separate change, but short
+          // enough that it lands while that compilation is still in progress.
+          await d.file("_slow.scss", "$_slowSource\n// modified").create();
+          await Future<void>.delayed(Duration(seconds: 3));
+          await d.file("_other.scss", "x {y: z}").create();
+
+          await expectLater(
+            sass.stdout,
+            emits(endsWith('Compiled test.scss to out.css.')),
+          );
+          await expectLater(
+            sass.stdout,
+            emits(endsWith('Compiled test.scss to out.css.')),
+          );
+          await sass.kill();
+
+          await d.file("out.css", contains("y: z")).validate();
+        }, timeout: Timeout.factor(4));
+
         test("when it's modified when watched from a directory", () async {
           await d.dir("dir", [d.file("test.scss", "a {b: c}")]).create();
 
@@ -1215,6 +1250,18 @@ void sharedTests(
     });
   }
 }
+
+/// A stylesheet that takes multiple seconds to compile, so that another file
+/// can be modified while a compilation that includes it is in progress.
+const _slowSource = r"""
+@use "sass:math";
+@for $i from 1 through 80 {
+  .a-#{$i} { %ph-#{$i} { color: red; } }
+  @for $j from 1 through 80 {
+    .b-#{$i}-#{$j} { @extend %ph-#{$i}; width: math.div($i * 100%, $j); }
+  }
+}
+""";
 
 /// Writes [contents] to [path] atomically.
 ///

--- a/test/cli/shared/watch.dart
+++ b/test/cli/shared/watch.dart
@@ -1254,13 +1254,19 @@ void sharedTests(
 /// A stylesheet that takes multiple seconds to compile, so that another file
 /// can be modified while a compilation that includes it is in progress.
 const _slowSource = r"""
-@use "sass:math";
-@for $i from 1 through 80 {
-  .a-#{$i} { %ph-#{$i} { color: red; } }
-  @for $j from 1 through 80 {
-    .b-#{$i}-#{$j} { @extend %ph-#{$i}; width: math.div($i * 100%, $j); }
+  @use "sass:math";
+  @for $i from 1 through 80 {
+    .a-#{$i} {
+      %ph-#{$i} {color: red}
+    }
+
+    @for $j from 1 through 80 {
+      .b-#{$i}-#{$j} {
+        @extend %ph-#{$i};
+        width: math.div($i * 100%, $j);
+      }
+    }
   }
-}
 """;
 
 /// Writes [contents] to [path] atomically.


### PR DESCRIPTION
Fixes #2849.

`--watch` decides whether a stylesheet needs recompiling by comparing the modification time of the source and its dependencies against that of the CSS file it produced (`compileStylesheet`'s `ifModified`). When a source is modified while a compilation is already in progress that comparison is wrong: the CSS file is written when the compilation finishes, so it is newer than the modification that arrived in the meantime. The source looks up to date, no recompilation happens, and the CSS on disk stays one generation behind, silently. It also survives a restart, since `--update` makes the same comparison.

This threads the time at which the previous compilation started through to `compileStylesheet` and uses it in place of the destination's modification time when it is earlier. A source that changed during a compilation is newer than that timestamp, so it is recompiled. The bound is always the earlier of the two, so this can only ever cause more compilations than before, never fewer, and only for sources whose modification time falls between the start of the last compilation and the output it wrote. Startup, one-shot compilations and `--update` are unaffected, since they pass no timestamp.

The regression test is in the existing `recompiles a watched file` group. It needs a stylesheet that takes several seconds to compile, since the bug only exists while a compilation is in flight; the delay between the two writes is longer than the polling interval so that the two modifications aren't batched into a single recompilation under `--poll`. It fails on `main` in both the `--poll` and non-`--poll` variants and passes with this change; the rest of `test/cli/dart/watch_test.dart` and `update_test.dart` (114 tests) pass with no retries.

One related problem this doesn't address: modifications that land during the initial compilation are dropped outright rather than skipped, because `MultiDirWatcher`'s `StreamGroup` has no subscriber until `watch()` starts iterating it, which happens after that compilation finishes.
I wanted to provide a minimal fix to the more common issue we face, and fixing that means attaching the subscription earlier, which changes startup behaviour, so it seemed better as a separate change. But if you want I can include that one as well.

