### PR TITLE
Only emit pre-module comments once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.103.2
+
+* Only emit comments that appear before a stylesheet's first `@use` rule once,
+  rather than once for each module that the stylesheet and its dependencies load
+  in common.
+
 ## 1.103.1
 
 * No user-visible changes.

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -946,6 +946,10 @@ final class _EvaluateVisitor({
       _parent = root;
       _endOfImports = 0;
       _outOfOrderImports = null;
+      // Each module tracks only the comments that appear in its own source. If
+      // this isn't cleared, a nested load inherits its parent's comments and
+      // emits them again for every module it uses in common with the parent.
+      _preModuleComments = null;
       _extensionStore = extensionStore;
       _styleRuleIgnoringAtRoot = null;
       _mediaQueries = null;

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: ebcdfe290310c02ee3510dde85176aebe3b006bb
+// Checksum: c10096030022088cfc5958cbadd6e07321b4d465
 //
 // ignore_for_file: unused_import
 
@@ -939,6 +939,10 @@ final class _EvaluateVisitor({
       _parent = root;
       _endOfImports = 0;
       _outOfOrderImports = null;
+      // Each module tracks only the comments that appear in its own source. If
+      // this isn't cleared, a nested load inherits its parent's comments and
+      // emits them again for every module it uses in common with the parent.
+      _preModuleComments = null;
       _extensionStore = extensionStore;
       _styleRuleIgnoringAtRoot = null;
       _mediaQueries = null;

--- a/pkg/sass-parser/CHANGELOG.md
+++ b/pkg/sass-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.54
+
+* No user-visible changes.
+
 ## 0.4.53
 
 * No user-visible changes.

--- a/pkg/sass-parser/package.json
+++ b/pkg/sass-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-parser",
-  "version": "0.4.53",
+  "version": "0.4.54",
   "description": "A PostCSS-compatible wrapper of the official Sass parser",
   "repository": "sass/dart-sass",
   "author": "Google Inc.",

--- a/pkg/sass_api/CHANGELOG.md
+++ b/pkg/sass_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.9.2
+
+* No user-visible changes.
+
 ## 17.9.1
 
 * No user-visible changes.

--- a/pkg/sass_api/pubspec.yaml
+++ b/pkg/sass_api/pubspec.yaml
@@ -2,7 +2,7 @@ name: sass_api
 # Note: Every time we add a new Sass AST node, we need to bump the *major*
 # version because it's a breaking change for anyone who's implementing the
 # visitor interface(s).
-version: 17.9.1
+version: 17.9.2
 description: Additional APIs for Dart Sass.
 homepage: https://github.com/sass/dart-sass
 
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.13.0 <4.0.0"
 
 dependencies:
-  sass: 1.103.1
+  sass: 1.103.2
 
 dev_dependencies:
   dartdoc: ">=8.0.14 <10.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass
-version: 1.103.1
+version: 1.103.2
 description: A Sass implementation in Dart.
 homepage: https://github.com/sass/dart-sass
 


### PR DESCRIPTION
Fixes #2851.

Comments before a stylesheet's first `@use` rule are collected into `_preModuleComments` so `_combineCss` can emit them ahead of the CSS of the module they precede. In `_loadModule`, that field is saved and restored around a nested load, but unlike the other per-module state (`__root`, `_endOfImports`, `_outOfOrderImports`, `_extensionStore`) it is never reset. A nested stylesheet therefore inherits its parent's comments and records them as its own module's `preModuleComments`, and `_combineCss` re-emits them once for every module the parent and the nested stylesheet load in common.

Before, for an entrypoint whose leading comment precedes a `@use` that two of its other dependencies also load:

```css
/* header */
a { file: shared; }

/* header */
b { file: left; }

/* header */
c { file: right; }
```

After, the comment is emitted once, with the rules and their order unchanged.

The fix resets `_preModuleComments` alongside the other per-module state in `async_evaluate.dart`; `evaluate.dart` is regenerated with `dart run grinder synchronize`.

## Testing

Regression tests are not included here because language tests live in sass-spec. I have a candidate covering three cases (a module used both directly and transitively, two dependents of one shared module, and multiple leading comments); each fails before this change and passes after. Happy to open that as a separate sass-spec PR.

Checks run locally:

- Full sass-spec suite: 0 failures, 14210 passing, unchanged from `main`.
- `dart test -x node`: no new failures. The CLI-test and `double_check` failures I see are identical on `main` and come from build artifacts missing in my environment.
- `dart analyze lib test`: identical output to `main`, with nothing reported in `evaluate.dart`.
- `dart format`: clean.
