### PR TITLE
Avoid duplicating loud comments that appear before `@use`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.104.1-dev
 
+* Fix a bug where loud comments before `@use` rules could be emitted multiple
+  times under certain circumstances.
+
 ### Command Line Interface
 
 * Many-to-many compilations no longer compile any files that appear in the

--- a/lib/src/visitor/async_evaluate.dart
+++ b/lib/src/visitor/async_evaluate.dart
@@ -943,6 +943,7 @@ final class _EvaluateVisitor({
       _importer = importer;
       _stylesheet = stylesheet;
       var root = __root = ModifiableCssStylesheet(stylesheet.span);
+      _preModuleComments = {};
       _parent = root;
       _endOfImports = 0;
       _outOfOrderImports = null;
@@ -1031,27 +1032,32 @@ final class _EvaluateVisitor({
     // The CSS statements in the final document.
     var css = <CssNode>[];
 
-    /// The modules in reverse topological order.
+    // The modules in reverse topological order.
     var sorted = Queue<Module>();
 
-    /// The modules that have been visited so far. Note that if [cloneCss] is
-    /// true, this contains the original modules, not the copies.
+    // The modules that have been visited so far. Note that if [cloneCss] is
+    // true, this contains the original modules, not the copies.
     var seen = <Module>{};
 
     void visitModule(Module module) {
       if (!seen.add(module)) return;
       if (clone) module = module.cloneCss();
 
+      var seenUpstream = <Module>{};
       for (var upstream in module.upstream) {
-        if (upstream.transitivelyContainsCss) {
-          if (module.preModuleComments[upstream] case var comments?) {
-            // Intermix the top-level comments with plain CSS `@import`s until we
-            // start to have actual CSS defined, at which point start treating it as
-            // normal CSS.
-            (css.isEmpty ? imports : css).addAll(comments);
-          }
-          visitModule(upstream);
+        if (!upstream.transitivelyContainsCss) continue;
+
+        // A downstream module can load the same upstream module multiple times,
+        // but we only track pre-module comments for the first load.
+        if (!seenUpstream.add(upstream)) continue;
+
+        if (module.preModuleComments[upstream] case var comments?) {
+          // Intermix the top-level comments with plain CSS `@import`s until we
+          // start to have actual CSS defined, at which point start treating it as
+          // normal CSS.
+          (css.isEmpty ? imports : css).addAll(comments);
         }
+        visitModule(upstream);
       }
 
       sorted.addFirst(module);

--- a/lib/src/visitor/evaluate.dart
+++ b/lib/src/visitor/evaluate.dart
@@ -5,7 +5,7 @@
 // DO NOT EDIT. This file was generated from async_evaluate.dart.
 // See tool/grind/synchronize.dart for details.
 //
-// Checksum: ebcdfe290310c02ee3510dde85176aebe3b006bb
+// Checksum: df69c482a73d1ce15448bd3cf9acd3277886d1b6
 //
 // ignore_for_file: unused_import
 
@@ -936,6 +936,7 @@ final class _EvaluateVisitor({
       _importer = importer;
       _stylesheet = stylesheet;
       var root = __root = ModifiableCssStylesheet(stylesheet.span);
+      _preModuleComments = {};
       _parent = root;
       _endOfImports = 0;
       _outOfOrderImports = null;
@@ -1024,27 +1025,32 @@ final class _EvaluateVisitor({
     // The CSS statements in the final document.
     var css = <CssNode>[];
 
-    /// The modules in reverse topological order.
+    // The modules in reverse topological order.
     var sorted = Queue<Module<Callable>>();
 
-    /// The modules that have been visited so far. Note that if [cloneCss] is
-    /// true, this contains the original modules, not the copies.
+    // The modules that have been visited so far. Note that if [cloneCss] is
+    // true, this contains the original modules, not the copies.
     var seen = <Module<Callable>>{};
 
     void visitModule(Module<Callable> module) {
       if (!seen.add(module)) return;
       if (clone) module = module.cloneCss();
 
+      var seenUpstream = <Module<Callable>>{};
       for (var upstream in module.upstream) {
-        if (upstream.transitivelyContainsCss) {
-          if (module.preModuleComments[upstream] case var comments?) {
-            // Intermix the top-level comments with plain CSS `@import`s until we
-            // start to have actual CSS defined, at which point start treating it as
-            // normal CSS.
-            (css.isEmpty ? imports : css).addAll(comments);
-          }
-          visitModule(upstream);
+        if (!upstream.transitivelyContainsCss) continue;
+
+        // A downstream module can load the same upstream module multiple times,
+        // but we only track pre-module comments for the first load.
+        if (!seenUpstream.add(upstream)) continue;
+
+        if (module.preModuleComments[upstream] case var comments?) {
+          // Intermix the top-level comments with plain CSS `@import`s until we
+          // start to have actual CSS defined, at which point start treating it as
+          // normal CSS.
+          (css.isEmpty ? imports : css).addAll(comments);
         }
+        visitModule(upstream);
       }
 
       sorted.addFirst(module);


### PR DESCRIPTION
See https://github.com/sass/sass-spec/pull/2166

Closes #2851
Closes #2852